### PR TITLE
Fixed incorrect recipe

### DIFF
--- a/data/recipes.json
+++ b/data/recipes.json
@@ -2917,8 +2917,7 @@
     "industries": ["Metalwork Industry M"],
     "input": {
       "Steel": 343,
-      "Basic Pipe": 125,
-      "Basic Burner": 125
+      "Basic Pipe": 125
     }
   },
   {


### PR DESCRIPTION
Basic Combustion Chamber L incorrectly contained basic burners in the input array.