### PR TITLE
Speedup crafiting calculation

### DIFF
--- a/js/Crafting_Calc r016.js
+++ b/js/Crafting_Calc r016.js
@@ -51,11 +51,14 @@ function itemRecipe(name,data){
 	};
 }
 
+
+
+
 // holds recipe database and performs crafting calculations
 function recipeCalc(data){
 	
 	//parse db from JSON
-	this.types=[];
+	this.types={};
 	
 	
 	this.lang={"english":{}};
@@ -79,19 +82,10 @@ function recipeCalc(data){
 		this.db={};
 		
 		var db=JSON.parse(db);
+		var id = 1;
 		Object.keys(db).forEach(function(name,i){
-			var fnd=false;
-			for (var j=0;j<this.types.length;j++)
-			{
-				if(this.types[j]==db[name].type)
-				{
-					fnd=true;
-					break;
-				}
-			}
-			if(!fnd){
-				this.types.push(db[name].type);
-			}
+			this.types[db[name].type] = id++;
+
 			this.db[name]=new itemRecipe(name,db[name]);
 			this.lang.english[name]=name;
 			this.langr.english[name]=name;
@@ -126,61 +120,7 @@ function recipeCalc(data){
 	this.debug=[];
 	//console.log(JSON.stringify(this.db,null,2));
 	
-	// eliminate 0 quantity list items and combine repeated ones
-	this.reduceItems=function(list)
-	{
-		//console.log("reduce items");
-		//console.log(JSON.stringify(list));
-		var newList=[];
-		for (var i=0;i<list.length;i++)
-		{
-			if (typeof list[i].bpquantity ==="undefined"){
-				list[i].bpquantity=0;
-			}
-			if (typeof list[i].quantity ==="undefined"){
-				list[i].quantity=0;
-			}
-			var fnd=false;
-			for (var j=0;j<newList.length;j++)
-			{
-				if (list[i].name===newList[j].name)
-				{
-					newList[j].quantity+=list[i].quantity;
-					newList[j].bpquantity+=list[i].bpquantity;
-					
-					Object.keys(list[i]).forEach(function(item,index){
-						if(item=="quantity" || item=="bpquantity"){return;}
-						newList[j][item]=list[i][item];
-					});
-					
-					fnd=true;
-					break;
-				}
-			}
-			if (!fnd && (list[i].quantity+list[i].bpquantity)>0)
-			{
-				var obj={};
-				Object.keys(list[i]).forEach(function(item,index){
-					obj[item]=list[i][item];
-				});
-				newList[newList.length]=obj;
-			}
-		}
-		//console.log("reduced list: "+JSON.stringify(newList));
-		var t=this;
-		newList.sort(function(l,r){ 
-			//console.log("reduceItems sort");
-			//console.log("L: "+l.name);
-			//console.log("R: "+r.name);
-			//console.log("L: "+JSON.stringify(t.db[l.name]));
-			//console.log("R: "+JSON.stringify(t.db[r.name]));
-			var typeL=t.db[l.name].type;
-			var typeR=t.db[r.name].type;
-			return t.types.indexOf(typeL)>t.types.indexOf(typeR);
-		});
-		//console.log("reduced list: "+JSON.stringify(newList));
-		return newList;
-	};
+	
 	
 	this.modifyItemStat=function(name,type,amount,relative){
 		if (type=="Time"){
@@ -297,182 +237,4 @@ function recipeCalc(data){
 			}
 		}
 	}
-	
-	
-	
-	//crafting simulation calculation
-	// returns list of required crafting queue for a given input of crafted items
-	this.simulate=function(input,inventory,skills){
-		
-		//console.log("SIMULATING "+JSON.stringify(input));
-		var itemSequence=[];
-		
-		for (var jj=0;jj<input.length;jj++){
-			var iqPair=input[jj];
-			
-			this.debug.push("number of "+iqPair.name+" required "+iqPair.quantity);
-			this.debug.push("checking inventory "+JSON.stringify(inventory[iqPair.name]));
-			if (iqPair.quantity<=(inventory[iqPair.name].quantity+inventory[iqPair.name].bpquantity)){
-				
-				this.debug.push("inventory has enough of input, moving on to next input");
-				continue;
-			}
-			
-			//console.log(JSON.stringify(this.db[iqPair.name],null,2));
-			var ingredients=this.db[iqPair.name].getIngredients();
-			var byproducts=this.db[iqPair.name].getByproducts();
-			var oq=this.db[iqPair.name].actualOQ;
-			
-			
-			this.debug.push("----checking ingredients of input");
-			this.debug.push(JSON.stringify(ingredients));
-			this.debug.push("----checking inventory for ingredients");
-			if(ingredients.length!=0){
-				this.debug.push(iqPair.name+": "+inventory[iqPair.name].quantity+" of "+iqPair.quantity);
-				while(inventory[iqPair.name].quantity+inventory[iqPair.name].bpquantity<iqPair.quantity)
-				{
-					this.debug.push("crafting ingredients for "+iqPair.name);
-					ingredients.forEach(function(ingPair,i){
-						this.debug.push("");
-						var subSeq=this.simulate([ingPair],inventory,skills)
-						
-						if(inventory[ingPair.name].bpquantity>ingPair.quantity){
-							inventory[ingPair.name].bpquantity-=ingPair.quantity;
-						}else if (inventory[ingPair.name].bpquantity>0){
-							var diff=ingPair.quantity-inventory[ingPair.name].bpquantity;
-							inventory[ingPair.name].bpquantity=0;
-							inventory[ingPair.name].quantity-=diff;
-						}else{
-							inventory[ingPair.name].quantity-=ingPair.quantity
-						}
-						itemSequence=itemSequence.concat(subSeq);
-					},this);
-					inventory[iqPair.name].quantity+=oq;
-					
-					this.debug.push(iqPair.name+" now has: "+inventory[iqPair.name].quantity+" of "+iqPair.quantity);
-					
-					itemSequence=itemSequence.concat([{name:iqPair.name,quantity:oq,effectivenessQ:0,skillQ:0}]);
-					
-					
-					
-					
-					byproducts.forEach(function(bPair,i){
-						inventory[bPair.name].bpquantity+=bPair.quantity;
-						itemSequence=itemSequence.concat([{name:bPair.name,bpquantity:bPair.quantity}]);
-					},this);
-					
-				}
-			}
-			else{
-				this.debug.push("this is a base recipe, inserting desired amount to inventory");
-				itemSequence=itemSequence.concat([iqPair]);
-				
-				inventory[iqPair.name].quantity+=iqPair.quantity;
-				this.debug.push("have "+inventory[iqPair.name].quantity+" of "+iqPair.quantity);
-				
-				byproducts.forEach(function(bPair,i){
-					inventory[bPair.name].bpquantity+=iqPair.quantity*bPair.quantity;
-					itemSequence=itemSequence.concat([{name:bPair.name,bpquantity:bPair.quantity*iqPair.quantity}]);
-				},this);
-			}
-			//console.log("adding "+JSON.stringify(dict)+" to sequence");
-			//console.log("sequence: "+JSON.stringify(itemSequence));
-					
-			//console.log("adding "+iqPair.quantity);
-			//console.log(iqPair.name+" now "+inventory[iqPair.name]);
-		}
-		
-		//console.log("returning "+JSON.stringify(itemSequence));
-		//console.log("");
-		//console.log("inventory: "+JSON.stringify(removeInvZeros(inventory)));
-		return itemSequence;
-	};
-	
-	
-	// wrapper for the simulate func
-	this.calcList=function(input,inv,skills)
-	{
-		//console.log("Craft.calcList start");
-		var inputRed=this.reduceItems(input);
-		var invRed=this.reduceItems(inv);
-		
-		for (var i=inputRed.length-1;i>=0;i--){
-			if (this.db[inputRed[i].name]===undefined) {
-				//console.log(JSON.stringify(inputRed[i]));
-				inputRed.splice(i,1);
-				continue;
-				}
-		}
-		for (var i=invRed.length-1;i>=0;i--){
-			if (this.db[invRed[i].name]===undefined) {
-				invRed.splice(i,1);
-				continue;
-				}
-		}
-		
-		var sortFunc=function(l,r){
-			return (l.typeid+l.tier/10)-(r.typeid+r.tier/10);
-		}
-		
-		inputRed.forEach(function(k,i){
-			k.type=this.db[k.name].type;
-			k.typeid=this.types.indexOf(this.db[k.name].type);
-			k.tier=this.db[k.name].tier;
-		},this);
-		
-		inputRed.sort(sortFunc);
-		inputRed.reverse();
-		
-		
-		var inventory={};
-		Object.keys(this.db).forEach(function(k,i){
-			inventory[k]={name:k,quantity:0,bpquantity:0};
-		});
-		invRed.forEach(function(e,i){
-			//console.log(JSON.stringify(e));
-			inventory[e.name].quantity=e.quantity;
-			//console.log(e.name+" "+inventory[e.name]);
-		},this);
-		
-		//console.log("input");
-		//console.log(JSON.stringify(inputRed));
-		
-		//console.log("inv before");
-		//console.log(JSON.stringify(removeInvZeros(inventory)));
-		this.debug=[];
-		var craftList=this.simulate(inputRed,inventory,skills);
-		//console.log("inv after");
-		//console.log(JSON.stringify(removeInvZeros(inventory)));
-		
-		//console.log("raw craft list "+JSON.stringify(craftList));
-		
-		var compressedList=this.reduceItems(JSON.parse(JSON.stringify(craftList)));
-		//console.log("compressed craft list "+JSON.stringify(compressedList,null,2));
-		
-		function populate(k,i){
-			k.time=k.quantity/this.db[k.name].outputQuantity*this.db[k.name].actualTime;
-			k.tier=this.db[k.name].tier;
-			k.type=this.db[k.name].type;
-			k.typeid=this.types.indexOf(k.type);
-			k.industries=this.db[k.name].industries;
-			k.skillT=0;
-			k.effectivenessT=1;
-		}
-		/*
-		for (var i=compressedList.length-1;i>=0;i--){
-			if (compressedList[i].quantity<=compressedList[i].bpquantity){
-				compressedList.splice(i,1);
-			}
-		}
-		*/
-		compressedList.forEach(populate,this);
-		compressedList.sort(sortFunc);
-		
-		
-		
-		//console.log("calcLists normal");
-		//console.log(JSON.stringify(compressedList,null,2));
-		return {normal:compressedList,expanded:craftList,inventory:inventory}
-	};
-	
 }

--- a/js/Crafting_Calc_interface.js
+++ b/js/Crafting_Calc_interface.js
@@ -276,10 +276,16 @@ Skills have already been applied to recipes
 	})
 	list = []
 	Object.keys(craftQueue).forEach(function(name){
-		bpqty = 0
+		var bpqty = 0
 		if(byproducts[name] != undefined) {
 			bpqty = byproducts[name].quantity
 			// console.log("Byproduct: " + name + "x" + bpqty)
+		}
+		var type = cc.db[name].type
+		var typeid = cc.types[cc.db[name].type]
+		if (craftQueue[name].quantity < 1) {
+			type = "Byproduct"
+			typeid = 999
 		}
 		if (bpqty < 1 && craftQueue[name].quantity < 1) { return }
 		list.push({
@@ -289,15 +295,17 @@ Skills have already been applied to recipes
 			name:name,
 			time:(craftQueue[name].quantity/cc.db[name].actualOQ)*cc.db[name].actualTime,
 			tier:cc.db[name].tier,
-			type:cc.db[name].type,
-			typeid:cc.types[cc.db[name].type],
+			type:type,
+			typeid:typeid,
 			industries:cc.db[name].industries,
 			skillT:0,
 			effectivenessT:1
 		})
 	})
 	list.sort(function(l,r){
-		return (l.stage+l.typeid/100+l.tier/1000)-(r.stage+r.typeid/100+r.tier/1000);
+		var lAlpha = l.name.charCodeAt(0)
+		var rAlpha = r.name.charCodeAt(0)
+		return (l.stage + (l.typeid / 1000) + (l.tier / 100000) + (lAlpha / 10000000)) - (r.stage + (r.typeid / 1000) + (r.tier / 100000) + (rAlpha / 10000000));
 	})
 	//console.log("calculating the craft");
 	//itemLists=cc.calcList(craft,inv,skills);
@@ -322,14 +330,14 @@ Skills have already been applied to recipes
 	
 	for (var i=0;i<list.length;i++)
 	{
-		var typeIndex=cc.types[ cc.db[list[i].name].type ];
+		var typeIndex=list[i].typeid;
 		if(i>0 && typeIndex!=0){
-			var typeIndexLast=cc.types[ cc.db[list[i-1].name].type ];
+			var typeIndexLast=list[i-1].typeid;
 			if(typeIndex!=typeIndexLast){
 			var line1=[];
 			
 			var gapdet1=document.createElement("div");
-			gapdet1.innerHTML=cc.db[list[i].name].type;
+			gapdet1.innerHTML=list[i].type;
 			line1.push(gapdet1);
 			
 			var gapdet2=document.createElement("div");
@@ -359,7 +367,7 @@ Skills have already been applied to recipes
 			
 			line2=[];
 			var gap4=document.createElement("div");
-			gap4.innerHTML=cc.db[list[i].name].type;
+			gap4.innerHTML=list[i].type;
 			gap4.style.padding="0 0 0 5px";
 			line2.push(gap4);
 				

--- a/js/Crafting_Calc_interface.js
+++ b/js/Crafting_Calc_interface.js
@@ -55,7 +55,7 @@ var tierNames=["Basic","Uncommon","Advanced","Rare","Exotic"];
 
 var itemsAccordion,skillsAccordion,industryPrices,prices,recipes,german,french;
 
-var ver = "2020-10-09"
+var ver = "2020-10-17"
 document.getElementById("version").innerHTML = ver;
 console.log("Crafing Calculator Version: " + ver)
 
@@ -114,7 +114,7 @@ String.prototype.toHHMMSS = function () {
 
 //-----------------------------------------------------------------------------------
 // crafting calculator variables and calculation
-var inv=[];
+var inv={};
 var craft=[];
 var industrySelection={};
 var itemLists=[];
@@ -191,11 +191,94 @@ function calculate()
 		return;
 	}
 	
+
+/* Assumptions:
+The addition of craft/inventory items prevents duplicates
+Skills have already been applied to recipes
+*/
+	craftQueue = {}
+	function addInputs(name,qty) {
+		if (craftQueue[name] == undefined ) { 
+			craftQueue[name] = {quantity:qty,stage:0}
+		} else { 
+			craftQueue[name].quantity+=qty
+		}
+		var ingredients = cc.db[name].getIngredients()
+		// Add each ingredient, we allow for fractional additions as we are assumed all ingredients are in
+		// a giant pool for the crafting of all products.
+		ingredients.forEach(function (ingredient) { 
+			// console.log("requires: "+ingredient.quantity+" " +ingredient.name)
+			addInputs(ingredient.name, ingredient.quantity * qty/cc.db[name].actualOQ); 
+			if (craftQueue[ingredient.name].stage >= craftQueue[name].stage) {
+				craftQueue[name].stage = craftQueue[ingredient.name].stage + 1; 
+			}
+		})
+		// Subtract byproducts from required list, this will cause them to not show up if they are less than 0
+		// This might not be great for catalysts?
+		var byproducts = cc.db[name].getByproducts()
+		byproducts.forEach(function (byproduct) { 
+			// console.log("byproducts: "+byproduct.quantity+" " +byproduct.name)
+			addInputs(byproduct.name, -byproduct.quantity * qty/cc.db[name].actualOQ); 
+		})
+		// console.log("adding "+qty+" "+name+" at stage "+craftQueue[name].stage)
+	}
+	craft.forEach(function(item){addInputs(item.name,item.quantity)})
+	craftA = Object.entries(craftQueue)
+	craftA.sort(function(l,r){return r[1].stage - l[1].stage})
+	// Reduce by items in inventory
+
+	waste={}
+	craftA.forEach(function (item) {
+		// console.log("item[0]: "+item[0]+" at stage "+craftQueue[item[0]].stage)
+		var adjustment = 0
+		if (inv[item[0]] != undefined) {
+			// console.log("found Inventory for "+item[0]+ " X "+inv[item[0]].quantity)
+			if (inv[item[0]].quantity > 0) {
+				adjustment -=inv[item[0]].quantity
+			}
+		}
+		if (craftQueue[item[0]].quantity + adjustment >= 1) {
+			var batchSize = cc.db[item[0]].actualOQ
+			var mq = Math.ceil(craftQueue[item[0]].quantity / batchSize) * batchSize
+			if (mq > craftQueue[item[0]].quantity) {
+				var w = mq - craftQueue[item[0]].quantity
+				waste[item[0]] = w
+				adjustment += w
+			}
+		}
+		if (adjustment != 0) {
+			addInputs(item[0], adjustment)
+		}
+		if (craftQueue[item[0]].quantity < 1) {
+			// console.log("Removing " + item[0])
+			delete craftQueue[item[0]]
+		}
+	})
+
+
+	list = []
+	Object.keys(craftQueue).forEach(function(name){
+		list.push({
+			quantity:craftQueue[name].quantity,
+			stage:craftQueue[name].stage,
+			name:name,
+			time:(craftQueue[name].quantity/cc.db[name].actualOQ)*cc.db[name].actualTime,
+			tier:cc.db[name].tier,
+			type:cc.db[name].type,
+			typeid:cc.types[cc.db[name].type],
+			industries:cc.db[name].industries,
+			skillT:0,
+			effectivenessT:1
+		})
+	})
+	list.sort(function(l,r){
+		return (l.stage+l.typeid/100+l.tier/1000)-(r.stage+r.typeid/100+r.tier/1000);
+	})
 	//console.log("calculating the craft");
-	itemLists=cc.calcList(craft,inv,skills);
+	//itemLists=cc.calcList(craft,inv,skills);
 	//console.log(JSON.stringify(cc.debug,null,2));
 	//console.log("got the craft list");
-	var list=itemLists.normal;
+	//var list=itemLists.normal;
 	
 	//console.log("result of craftcalc is");
 	//console.log(JSON.stringify(list,null,2));
@@ -214,9 +297,9 @@ function calculate()
 	
 	for (var i=0;i<list.length;i++)
 	{
-		var typeIndex=cc.types.indexOf( cc.db[list[i].name].type );
+		var typeIndex=cc.types[ cc.db[list[i].name].type ];
 		if(i>0 && typeIndex!=0){
-			var typeIndexLast=cc.types.indexOf( cc.db[list[i-1].name].type );
+			var typeIndexLast=cc.types[ cc.db[list[i-1].name].type ];
 			if(typeIndex!=typeIndexLast){
 			var line1=[];
 			
@@ -871,7 +954,7 @@ skillsButton.onclick=displaySkillsModal;
 clearButton.onclick=clearLists;
 
 invClearBut.onclick=function(){
-	inv=[];
+	inv={};
 	updateInvList();
 	calculate();
 }
@@ -931,14 +1014,7 @@ function updateInv(event)
 {
 	var name=event.target.previousSibling.innerHTML
 	name=cc.transr(language,name)
-	for(var i=0;i<inv.length;i++)
-	{
-		if (inv[i].name==name)
-		{
-			inv[i].quantity=newParse(event.target.value);
-			break;
-		}
-	}
+	inv[name].quantity=newParse(event.target.value);
 	//console.log(JSON.stringify(inv));
 	calculate();
 }
@@ -965,18 +1041,13 @@ function updateCft(event)
 function addInvItem(name,quantity)
 {
 	if (quantity==null) {quantity=1;}
-	
-	for (var i=0;i<inv.length;i++)
-	{
-		if (inv[i].name==name)
-		{
-			inv[i].quantity+=quantity;
-			updateInvList();
-			calculate();
-			return;
-		}
+	console.log("Adding "+name+"x"+quantity+" to inventory")
+	if(inv[name] == undefined) {
+		inv[name]={quantity:quantity}
 	}
-	inv.push({name:name,quantity:quantity});
+	else {
+		inv[name].quantity += quantity
+	}
 	updateInvList();
 	calculate();
 }
@@ -984,10 +1055,11 @@ function updateInvList(){
 	while(invList.children.length>invListCols){
 		invList.removeChild(invList.children[invListCols]);
 	}
-	for(var i=0;i<inv.length;i++){
-		var name=inv[i].name;
+	// for(var i=0;i<inv.length;i++){
+		Object.keys(inv).forEach(function(name){
+		//var name=inv[i].name;
 		var tp=cc.db[name].type;
-		var quantity=inv[i].quantity.toString()
+		var quantity=inv[name].quantity.toString()
 		//if (quantity<=0){continue;}
 		
 		//console.log(i+" "+name+", "+tp);
@@ -1016,7 +1088,7 @@ function updateInvList(){
 		invList.appendChild(minus)
 		invList.appendChild(item);
 		invList.appendChild(qty);
-	}
+	})
 }
 
 function addCraftItem(name, quantity) {
@@ -1095,13 +1167,14 @@ function removeItem(event)
 		invList.removeChild(minus);
 		invList.removeChild(item);
 		invList.removeChild(qty);
-		for(var i=0;i<inv.length;i++)
-		{
-			if(inv[i].name==cc.transr(language,item.innerHTML))
-			{
-				inv.splice(i,1);
-			}
-		}
+		delete inv[cc.transr(language,item.innerHTML)]
+		// for(var i=0;i<inv.length;i++)
+		// {
+		// 	if(inv[i].name==cc.transr(language,item.innerHTML))
+		// 	{
+		// 		inv.splice(i,1);
+		// 	}
+		// }
 	}else{
 		cftList.removeChild(minus);
 		cftList.removeChild(item);
@@ -1276,7 +1349,7 @@ function updateIndSelections(){
 function clearLists(){
 	craft=[];
 	updateCraftList();
-	inv=[];
+	inv={};
 	updateInvList();
 	
 	window.localStorage.setItem("profiles","[]");


### PR DESCRIPTION
Eliminate need for simulation by tallying ingredients as a pool.
Prevents slowdown seen when several items were added to the crafting queue.

using objects as maps to avoid search loops

Fixes #112 