### PR TITLE
fixed container mass

### DIFF
--- a/data/recipes.json
+++ b/data/recipes.json
@@ -5446,7 +5446,7 @@
   "Container S":{ 
     "tier": 1,
     "type": "Container",
-    "mass": 1280,
+    "mass": 1281.31,
     "volume": 342,
     "outputQuantity": 1,
     "time": 1440,
@@ -5462,7 +5462,7 @@
   "Container M":{ 
     "tier": 1,
     "type": "Container",
-    "mass": 7420,
+    "mass": 7421.35,
     "volume": 1873,
     "outputQuantity": 1,
     "time": 5760,
@@ -5478,7 +5478,7 @@
   "Container L":{ 
     "tier": 1,
     "type": "Container",
-    "mass": 14840,
+    "mass": 14842.7,
     "volume": 3746,
     "outputQuantity": 1,
     "time": 5760,


### PR DESCRIPTION
it seems a lot of items does not really have the exact mass written in the item description. (near all items above 1 ton)
the updated mass of containers come from the result of the `getSelfMass()` method