### PR TITLE
Update items and recipes

### DIFF
--- a/data/itemsAccordion.json
+++ b/data/itemsAccordion.json
@@ -3,13 +3,13 @@
 		"name": "Consumables",
 		"data": [
 			{
-				"name": "Ammo",
+				"name": "Ammunition",
 				"data": [
 					{
 						"name": "Cannon Ammo",
 						"data": [
 							{
-								"name": "Extra-Small Cannon Ammo",
+								"name": "Cannon Ammo XS",
 								"data": [
 									{
 										"name": "Kinetic Ammo",
@@ -27,14 +27,14 @@
 											"Cannon Agile Thermic Ammo XS",
 											"Cannon Defense Thermic Ammo XS",
 											"Cannon Heavy Thermic Ammo XS",
-											"Cannon Thermic Ammo XS",
-											"Cannon Precision Thermic Ammo XS"
+											"Cannon Precision Thermic Ammo XS",
+											"Cannon Thermic Ammo XS"
 										]
 									}
 								]
 							},
 							{
-								"name": "Small Cannon Ammo",
+								"name": "Cannon Ammo S",
 								"data": [
 									{
 										"name": "Kinetic Ammo",
@@ -52,14 +52,14 @@
 											"Cannon Agile Thermic Ammo S",
 											"Cannon Defense Thermic Ammo S",
 											"Cannon Heavy Thermic Ammo S",
-											"Cannon Thermic Ammo S",
-											"Cannon Precision Thermic Ammo S"
+											"Cannon Precision Thermic Ammo S",
+											"Cannon Thermic Ammo S"
 										]
 									}
 								]
 							},
 							{
-								"name": "Medium Cannon Ammo",
+								"name": "Cannon Ammo M",
 								"data": [
 									{
 										"name": "Kinetic Ammo",
@@ -77,14 +77,14 @@
 											"Cannon Agile Thermic Ammo M",
 											"Cannon Defense Thermic Ammo M",
 											"Cannon Heavy Thermic Ammo M",
-											"Cannon Thermic Ammo M",
-											"Cannon Precision Thermic Ammo M"
+											"Cannon Precision Thermic Ammo M",
+											"Cannon Thermic Ammo M"
 										]
 									}
 								]
 							},
 							{
-								"name": "Large Cannon Ammo",
+								"name": "Cannon Ammo L",
 								"data": [
 									{
 										"name": "Kinetic Ammo",
@@ -102,8 +102,8 @@
 											"Cannon Agile Thermic Ammo L",
 											"Cannon Defense Thermic Ammo L",
 											"Cannon Heavy Thermic Ammo L",
-											"Cannon Thermic Ammo L",
-											"Cannon Precision Thermic Ammo L"
+											"Cannon Precision Thermic Ammo L",
+											"Cannon Thermic Ammo L"
 										]
 									}
 								]
@@ -114,15 +114,15 @@
 						"name": "Laser Ammo",
 						"data": [
 							{
-								"name": "Extra-Small Laser Ammo",
+								"name": "Laser Ammo XS",
 								"data": [
 									{
 										"name": "Electromagnetic Ammo",
 										"data": [
 											"Laser Agile Electromagnetic Ammo XS",
 											"Laser Defense Electromagnetic Ammo XS",
-											"Laser Heavy Electromagnetic Ammo XS",
 											"Laser Electromagnetic Ammo XS",
+											"Laser Heavy Electromagnetic Ammo XS",
 											"Laser Precision Electromagnetic Ammo XS"
 										]
 									},
@@ -132,22 +132,22 @@
 											"Laser Agile Thermic Ammo XS",
 											"Laser Defense Thermic Ammo XS",
 											"Laser Heavy Thermic Ammo XS",
-											"Laser Thermic Ammo XS",
-											"Laser Precision Thermic Ammo XS"
+											"Laser Precision Thermic Ammo XS",
+											"Laser Thermic Ammo XS"
 										]
 									}
 								]
 							},
 							{
-								"name": "Small Laser Ammo",
+								"name": "Laser Ammo S",
 								"data": [
 									{
 										"name": "Electromagnetic Ammo",
 										"data": [
 											"Laser Agile Electromagnetic Ammo S",
 											"Laser Defense Electromagnetic Ammo S",
-											"Laser Heavy Electromagnetic Ammo S",
 											"Laser Electromagnetic Ammo S",
+											"Laser Heavy Electromagnetic Ammo S",
 											"Laser Precision Electromagnetic Ammo S"
 										]
 									},
@@ -157,22 +157,22 @@
 											"Laser Agile Thermic Ammo S",
 											"Laser Defense Thermic Ammo S",
 											"Laser Heavy Thermic Ammo S",
-											"Laser Thermic Ammo S",
-											"Laser Precision Thermic Ammo S"
+											"Laser Precision Thermic Ammo S",
+											"Laser Thermic Ammo S"
 										]
 									}
 								]
 							},
 							{
-								"name": "Medium Laser Ammo",
+								"name": "Laser Ammo M",
 								"data": [
 									{
 										"name": "Electromagnetic Ammo",
 										"data": [
 											"Laser Agile Electromagnetic Ammo M",
 											"Laser Defense Electromagnetic Ammo M",
-											"Laser Heavy Electromagnetic Ammo M",
 											"Laser Electromagnetic Ammo M",
+											"Laser Heavy Electromagnetic Ammo M",
 											"Laser Precision Electromagnetic Ammo M"
 										]
 									},
@@ -182,22 +182,22 @@
 											"Laser Agile Thermic Ammo M",
 											"Laser Defense Thermic Ammo M",
 											"Laser Heavy Thermic Ammo M",
-											"Laser Thermic Ammo M",
-											"Laser Precision Thermic Ammo M"
+											"Laser Precision Thermic Ammo M",
+											"Laser Thermic Ammo M"
 										]
 									}
 								]
 							},
 							{
-								"name": "Large Laser Ammo",
+								"name": "Laser Ammo L",
 								"data": [
 									{
 										"name": "Electromagnetic Ammo",
 										"data": [
 											"Laser Agile Electromagnetic Ammo L",
 											"Laser Defense Electromagnetic Ammo L",
-											"Laser Heavy Electromagnetic Ammo L",
 											"Laser Electromagnetic Ammo L",
+											"Laser Heavy Electromagnetic Ammo L",
 											"Laser Precision Electromagnetic Ammo L"
 										]
 									},
@@ -207,8 +207,8 @@
 											"Laser Agile Thermic Ammo L",
 											"Laser Defense Thermic Ammo L",
 											"Laser Heavy Thermic Ammo L",
-											"Laser Thermic Ammo L",
-											"Laser Precision Thermic Ammo L"
+											"Laser Precision Thermic Ammo L",
+											"Laser Thermic Ammo L"
 										]
 									}
 								]
@@ -216,18 +216,18 @@
 						]
 					},
 					{
-						"name": "Missile Pod Ammo",
+						"name": "Missile Ammo",
 						"data": [
 							{
-								"name": "Extra-Small Missile Ammo",
+								"name": "Missile Ammo XS",
 								"data": [
 									{
 										"name": "Antimatter Ammo",
 										"data": [
 											"Missile Agile Antimatter Ammo XS",
+											"Missile Antimatter Ammo XS",
 											"Missile Defense Antimatter Ammo XS",
 											"Missile Heavy Antimatter Ammo XS",
-											"Missile Antimatter Ammo XS",
 											"Missile Precision Antimatter Ammo XS"
 										]
 									},
@@ -244,15 +244,15 @@
 								]
 							},
 							{
-								"name": "Small Missile Ammo",
+								"name": "Missile Ammo S",
 								"data": [
 									{
 										"name": "Antimatter Ammo",
 										"data": [
 											"Missile Agile Antimatter Ammo S",
+											"Missile Antimatter Ammo S",
 											"Missile Defense Antimatter Ammo S",
 											"Missile Heavy Antimatter Ammo S",
-											"Missile Antimatter Ammo S",
 											"Missile Precision Antimatter Ammo S"
 										]
 									},
@@ -269,15 +269,15 @@
 								]
 							},
 							{
-								"name": "Medium Missile Ammo",
+								"name": "Missile Ammo M",
 								"data": [
 									{
 										"name": "Antimatter Ammo",
 										"data": [
 											"Missile Agile Antimatter Ammo M",
+											"Missile Antimatter Ammo M",
 											"Missile Defense Antimatter Ammo M",
 											"Missile Heavy Antimatter Ammo M",
-											"Missile Antimatter Ammo M",
 											"Missile Precision Antimatter Ammo M"
 										]
 									},
@@ -294,15 +294,15 @@
 								]
 							},
 							{
-								"name": "Large Missile Ammo",
+								"name": "Missile Ammo L",
 								"data": [
 									{
 										"name": "Antimatter Ammo",
 										"data": [
 											"Missile Agile Antimatter Ammo L",
+											"Missile Antimatter Ammo L",
 											"Missile Defense Antimatter Ammo L",
 											"Missile Heavy Antimatter Ammo L",
-											"Missile Antimatter Ammo L",
 											"Missile Precision Antimatter Ammo L"
 										]
 									},
@@ -321,18 +321,18 @@
 						]
 					},
 					{
-						"name": "Railgun Pod Ammo",
+						"name": "Railgun Ammo",
 						"data": [
 							{
-								"name": "Extra-Small Railgun Ammo",
+								"name": "Railgun Ammo XS",
 								"data": [
 									{
 										"name": "Antimatter Ammo",
 										"data": [
 											"Railgun Agile Antimatter Ammo XS",
+											"Railgun Antimatter Ammo XS",
 											"Railgun Defense Antimatter Ammo XS",
 											"Railgun Heavy Antimatter Ammo XS",
-											"Railgun Antimatter Ammo XS",
 											"Railgun Precision Antimatter Ammo XS"
 										]
 									},
@@ -340,24 +340,24 @@
 										"name": "Electromagnetic Ammo",
 										"data": [
 											"Railgun Agile Electromagnetic Ammo XS",
+											"Railgun Electromagnetic Ammo XS",
 											"Railgun Defense Electromagnetic Ammo XS",
 											"Railgun Heavy Electromagnetic Ammo XS",
-											"Railgun Electromagnetic Ammo XS",
 											"Railgun Precision Electromagnetic Ammo XS"
 										]
 									}
 								]
 							},
 							{
-								"name": "Small Railgun Ammo",
+								"name": "Railgun Ammo S",
 								"data": [
 									{
 										"name": "Antimatter Ammo",
 										"data": [
 											"Railgun Agile Antimatter Ammo S",
+											"Railgun Antimatter Ammo S",
 											"Railgun Defense Antimatter Ammo S",
 											"Railgun Heavy Antimatter Ammo S",
-											"Railgun Antimatter Ammo S",
 											"Railgun Precision Antimatter Ammo S"
 										]
 									},
@@ -366,23 +366,23 @@
 										"data": [
 											"Railgun Agile Electromagnetic Ammo S",
 											"Railgun Defense Electromagnetic Ammo S",
-											"Railgun Heavy Electromagnetic Ammo S",
 											"Railgun Electromagnetic Ammo S",
+											"Railgun Heavy Electromagnetic Ammo S",
 											"Railgun Precision Electromagnetic Ammo S"
 										]
 									}
 								]
 							},
 							{
-								"name": "Medium Railgun Ammo",
+								"name": "Railgun Ammo M",
 								"data": [
 									{
 										"name": "Antimatter Ammo",
 										"data": [
 											"Railgun Agile Antimatter Ammo M",
+											"Railgun Antimatter Ammo M",
 											"Railgun Defense Antimatter Ammo M",
 											"Railgun Heavy Antimatter Ammo M",
-											"Railgun Antimatter Ammo M",
 											"Railgun Precision Antimatter Ammo M"
 										]
 									},
@@ -391,23 +391,23 @@
 										"data": [
 											"Railgun Agile Electromagnetic Ammo M",
 											"Railgun Defense Electromagnetic Ammo M",
-											"Railgun Heavy Electromagnetic Ammo M",
 											"Railgun Electromagnetic Ammo M",
+											"Railgun Heavy Electromagnetic Ammo M",
 											"Railgun Precision Electromagnetic Ammo M"
 										]
 									}
 								]
 							},
 							{
-								"name": "Large Railgun Ammo",
+								"name": "Railgun Ammo L",
 								"data": [
 									{
 										"name": "Antimatter Ammo",
 										"data": [
 											"Railgun Agile Antimatter Ammo L",
+											"Railgun Antimatter Ammo L",
 											"Railgun Defense Antimatter Ammo L",
 											"Railgun Heavy Antimatter Ammo L",
-											"Railgun Antimatter Ammo L",
 											"Railgun Precision Antimatter Ammo L"
 										]
 									},
@@ -416,8 +416,8 @@
 										"data": [
 											"Railgun Agile Electromagnetic Ammo L",
 											"Railgun Defense Electromagnetic Ammo L",
-											"Railgun Heavy Electromagnetic Ammo L",
 											"Railgun Electromagnetic Ammo L",
+											"Railgun Heavy Electromagnetic Ammo L",
 											"Railgun Precision Electromagnetic Ammo L"
 										]
 									}
@@ -428,297 +428,701 @@
 				]
 			},
 			{
-				"name": "Elements",
+				"name": "Scraps",
 				"data": [
 					{
-						"name": "Construct Elements",
+						"name": "Basic Scraps",
+						"data": [
+							"Aluminium Scrap",
+							"Carbon Scrap",
+							"Iron Scrap",
+							"Silicon Scrap"
+						]
+					},
+					{
+						"name": "Uncommon Scraps",
+						"data": [
+							"Calcium Scrap",
+							"Chromium Scrap",
+							"Copper Scrap",
+							"Sodium Scrap"
+						]
+					},
+					{
+						"name": "Advanced Scraps",
+						"data": [
+							"Lithium Scrap",
+							"Nickel Scrap",
+							"Silver Scrap",
+							"Sulfur Scrap"
+						]
+					},
+					{
+						"name": "Rare Scraps",
+						"data": [
+							"Cobalt Scrap",
+							"Fluorine Scrap",
+							"Gold Scrap",
+							"Scandium Scrap"
+						]
+					},
+					{
+						"name": "Exotic Scraps",
+						"data": [
+							"Manganese Scrap",
+							"Niobium Scrap",
+							"Titanium Scrap",
+							"Vanadium Scrap"
+						]
+					}
+				]
+			},
+			{
+				"name": "Warp Cell",
+				"data": [
+					"Warp Cell"
+				]
+			}
+		]
+	},
+	{
+		"name": "Elements",
+		"data": [
+			{
+				"name": "Combat & Defense Elements",
+				"data": [
+					{
+						"name": "Radar",
 						"data": [
 							{
-								"name": "Decorative Element",
+								"name": "Atmospheric Radar",
 								"data": [
-									{
-										"name": "Adjuncts",
-										"data": [
-											"Vertical Wing",
-											"Wing Tip S",
-											"Wing Tip M",
-											"Wing Tip L"
-										]
-									},
-									{
-										"name": "Antennas",
-										"data": [
-											"Antenna S",
-											"Antenna M",
-											"Antenna L"
-										]
-									},
-									{
-										"name": "Barriers",
-										"data": [
-											"Barrier Corner",
-											"Barrier S",
-											"Barrier M"
-										]
-									},
-									{
-										"name": "Bathroom Elements",
-										"data": [
-											"Shower Unit",
-											"Sink Unit",
-											"Toilet Unit A",
-											"Toilet Unit B",
-											"Urinal Unit"
-										]
-									},
-									{
-										"name": "Decorative Cables",
-										"data": [
-											"Cable Model-A S",
-											"Cable Model-A M",
-											"Cable Model-B S",
-											"Cable Model-B M",
-											"Cable Model-C S",
-											"Cable Model-C M",
-											"Corner Cable Model-A",
-											"Corner Cable Model-B",
-											"Corner Cable Model-C"
-										]
-									},
-									{
-										"name": "Furnitures",
-										"data": [
-											"\"Eye Doll's Workshop\" - Artist Unknown",
-											"\"HMS Ajax33\" - Artist Unknown",
-											"\"Parrotos Sanctuary\" - Artist Unknown",
-											"Bed",
-											"Bench",
-											"Dresser",
-											"Nightstand",
-											"Round Carpet",
-											"Shelf Empty",
-											"Shelf Full",
-											"Shelf Half Full",
-											"Sofa",
-											"Square Carpet",
-											"Table",
-											"Trash",
-											"Wardrobe",
-											"Wooden Armchair",
-											"Wooden Chair",
-											"Wooden Dresser",
-											"Wooden Low Table",
-											"Wooden Sofa",
-											"Wooden Table L",
-											"Wooden Table M",
-											"Wooden Wardrobe",
-											"Navigator Chair",
-											"Office Chair",
-											"Encampment Chair"
-										]
-									},
-									{
-										"name": "Holograms",
-										"data": [
-											"Planet Hologram",
-											"Planet Hologram L",
-											"Spaceship Hologram S",
-											"Spaceship Hologram M",
-											"Spaceship Hologram L"
-										]
-									},
-									{
-										"name": "Hull Decoration",
-										"data": [
-											"Hull Decorative Element A",
-											"Hull Decorative Element B",
-											"Hull Decorative Element C",
-											"Steel Column",
-											"Steel Panel"
-										]
-									},
-									{
-										"name": "Pipes",
-										"data": [
-											"Pipe A M",
-											"Pipe B M",
-											"Pipe C M",
-											"Pipe D M",
-											"Pipe Connector M",
-											"Pipe Corner M"
-										]
-									},
-									{
-										"name": "Plants",
-										"data": [
-											"Suspended Plant A",
-											"Bagged Plant A",
-											"Bagged Plant B",
-											"Bonsai",
-											"Eggplant Plant Case",
-											"Ficus Plant A",
-											"Ficus Plant B",
-											"Foliage Plant Case A",
-											"Foliage Plant Case B",
-											"Plant",
-											"Plant Case A",
-											"Plant Case B",
-											"Plant Case C",
-											"Plant Case D",
-											"Plant Case E",
-											"Plant Case S",
-											"Plant Case M"
-										]
-									},
-									{
-										"name": "Windows",
-										"data": [
-											"Armored Window XS",
-											"Armored Window S",
-											"Armored Window M",
-											"Armored Window L",
-											"Bay Window XL",
-											"Glass Panel S",
-											"Glass Panel M",
-											"Glass Panel L",
-											"Window XS",
-											"Window S",
-											"Window M",
-											"Window L"
-										]
-									},
-									"Keyboard Unit"
+									"Atmospheric Radar S",
+									"Atmospheric Radar M",
+									"Atmospheric Radar L"
 								]
 							},
 							{
-								"name": "Industry",
-								"data": [
-									"Assembly Line XS",
-									"Assembly Line S",
-									"Assembly Line M",
-									"Assembly Line L",
-									"Assembly Line XL",
-									"3D Printer M",
-									"Chemical Industry M",
-									"Electronics Industry M",
-									"Glass Furnace M",
-									"Honeycomb Refinery M",
-									"Metalwork Industry M",
-									"Recycler M",
-									"Refiner M",
-									"Smelter M",
-									"Transfer Unit"
-								]
-							},
-							{
-								"name": "Anti-Gravity Generator",
-								"data": [
-									"Anti-Gravity Generator S",
-									"Anti-Gravity Generator M",
-									"Anti-Gravity Generator L"
-								]
-							},
-							{
-								"name": "Anti-Gravity Pulsors",
-								"data": [
-									"Anti-Gravity Pulsor"
-								]
-							},
-							{
-								"name": "Containers",
+								"name": "Space Radars",
 								"data": [
 									{
-										"name": "Dispensers",
+										"name": "Space Radar S",
 										"data": [
-											"Dispenser",
-											"Medium Dispenser",
-											"Heavy Dispenser"
+											"Space Radar S",
+											"Advanced Phased-Array Space Radar S",
+											"Advanced Protected Space Radar S",
+											"Advanced Quick-Wired Space Radar S",
+											"Rare Phased-Array Space Radar S",
+											"Rare Protected Space Radar S",
+											"Rare Quick-Wired Space Radar S",
+											"Exotic Phased-Array Space Radar S",
+											"Exotic Protected Space Radar S",
+											"Exotic Quick-Wired Space Radar S"
 										]
 									},
 									{
-										"name": "Fuel Tanks",
+										"name": "Space Radar M",
 										"data": [
-											{
-												"name": "Atmospheric Fuel Containers",
-												"data": [
-													"Atmospheric Fuel-Tank XS",
-													"Atmospheric Fuel-Tank S",
-													"Atmospheric Fuel-Tank M",
-													"Atmospheric Fuel-Tank L"
-												]
-											},
-											{
-												"name": "Rocket Fuel Containers",
-												"data": [
-													"Rocket Fuel-Tank XS",
-													"Rocket Fuel-Tank S",
-													"Rocket Fuel-Tank M",
-													"Rocket Fuel-Tank L"
-												]
-											},
-											{
-												"name": "Space Fuel Containers",
-												"data": [
-													"Space Fuel-Tank S",
-													"Space Fuel-Tank M",
-													"Space Fuel-Tank L"
-												]
-											}
+											"Space Radar M",
+											"Advanced Phased-Array Space Radar M",
+											"Advanced Protected Space Radar M",
+											"Advanced Quick-Wired Space Radar M",
+											"Rare Phased-Array Space Radar M",
+											"Rare Protected Space Radar M",
+											"Rare Quick-Wired Space Radar M",
+											"Exotic Phased-Array Space Radar M",
+											"Exotic Protected Space Radar M",
+											"Exotic Quick-Wired Space Radar M"
 										]
 									},
 									{
-										"name": "Item Containers",
+										"name": "Space Radars L",
 										"data": [
-											"Container Hub",
-											"Container XS",
-											"Container S",
-											"Container M",
-											"Container L"
+											"Space Radar L",
+											"Advanced Phased-Array Space Radar L",
+											"Advanced Protected Space Radar L",
+											"Advanced Quick-Wired Space Radar L",
+											"Rare Phased-Array Space Radar L",
+											"Rare Protected Space Radar L",
+											"Rare Quick-Wired Space Radar L",
+											"Exotic Phased-Array Space Radar L",
+											"Exotic Protected Space Radar L",
+											"Exotic Quick-Wired Space Radar L"
+										]
+									}
+								]
+							}
+						]
+					},
+					"Repair Unit",
+					"Transponder",
+					{
+						"name": "Weapon Unit",
+						"data": [
+							{
+								"name": "Cannons",
+								"data": [
+									{
+										"name": "Cannons XS",
+										"data": [
+											"Cannon XS",
+											"Advanced Agile Cannon XS",
+											"Advanced Defense Cannon XS",
+											"Advanced Heavy Cannon XS",
+											"Advanced Precision Cannon XS",
+											"Rare Agile Cannon XS",
+											"Rare Defense Cannon XS",
+											"Rare Heavy Cannon XS",
+											"Rare Precision Cannon XS",
+											"Exotic Agile Cannon XS",
+											"Exotic Defense Cannon XS",
+											"Exotic Heavy Cannon XS",
+											"Exotic Precision Cannon XS"
 										]
 									},
 									{
-										"name": "Ammo Containers",
+										"name": "Cannons S",
 										"data": [
-											"Ammo Container XS",
-											"Ammo Container S",
-											"Ammo Container M",
-											"Ammo Container L"
+											"Cannon S",
+											"Advanced Agile Cannon S",
+											"Advanced Defense Cannon S",
+											"Advanced Heavy Cannon S",
+											"Advanced Precision Cannon S",
+											"Rare Agile Cannon S",
+											"Rare Defense Cannon S",
+											"Rare Heavy Cannon S",
+											"Rare Precision Cannon S",
+											"Exotic Agile Cannon S",
+											"Exotic Defense Cannon S",
+											"Exotic Heavy Cannon S",
+											"Exotic Precision Cannon S"
+										]
+									},
+									{
+										"name": "Cannons M",
+										"data": [
+											"Cannon M",
+											"Advanced Agile Cannon M",
+											"Advanced Defense Cannon M",
+											"Advanced Heavy Cannon M",
+											"Advanced Precision Cannon M",
+											"Rare Agile Cannon M",
+											"Rare Defense Cannon M",
+											"Rare Heavy Cannon M",
+											"Rare Precision Cannon M",
+											"Exotic Agile Cannon M",
+											"Exotic Defense Cannon M",
+											"Exotic Heavy Cannon M",
+											"Exotic Precision Cannon M"
+										]
+									},
+									{
+										"name": "Cannons L",
+										"data": [
+											"Cannon L",
+											"Advanced Agile Cannon L",
+											"Advanced Defense Cannon L",
+											"Advanced Heavy Cannon L",
+											"Advanced Precision Cannon L",
+											"Rare Agile Cannon L",
+											"Rare Defense Cannon L",
+											"Rare Heavy Cannon L",
+											"Rare Precision Cannon L",
+											"Exotic Agile Cannon L",
+											"Exotic Defense Cannon L",
+											"Exotic Heavy Cannon L",
+											"Exotic Precision Cannon L"
 										]
 									}
 								]
 							},
 							{
-								"name": "Control Units",
+								"name": "Lasers",
 								"data": [
-									"Emergency Controller",
-									"Hovercraft Seat Controller",
-									"Cockpit Controller",
-									"Command Seat Controller",
-									"Programming Board",
-									"Remote Controller"
+									{
+										"name": "Lasers XS",
+										"data": [
+											"Laser XS",
+											"Advanced Agile Laser XS",
+											"Advanced Defense Laser XS",
+											"Advanced Heavy Laser XS",
+											"Advanced Precision Laser XS",
+											"Rare Agile Laser XS",
+											"Rare Defense Laser XS",
+											"Rare Heavy Laser XS",
+											"Rare Precision Laser XS",
+											"Exotic Agile Laser XS",
+											"Exotic Defense Laser XS",
+											"Exotic Heavy Laser XS",
+											"Exotic Precision Laser XS"
+										]
+									},
+									{
+										"name": "Lasers S",
+										"data": [
+											"Laser S",
+											"Advanced Agile Laser S",
+											"Advanced Defense Laser S",
+											"Advanced Heavy Laser S",
+											"Advanced Precision Laser S",
+											"Rare Agile Laser S",
+											"Rare Defense Laser S",
+											"Rare Heavy Laser S",
+											"Rare Precision Laser S",
+											"Exotic Agile Laser S",
+											"Exotic Defense Laser S",
+											"Exotic Heavy Laser S",
+											"Exotic Precision Laser S"
+										]
+									},
+									{
+										"name": "Lasers M",
+										"data": [
+											"Laser M",
+											"Advanced Agile Laser M",
+											"Advanced Defense Laser M",
+											"Advanced Heavy Laser M",
+											"Advanced Precision Laser M",
+											"Rare Agile Laser M",
+											"Rare Defense Laser M",
+											"Rare Heavy Laser M",
+											"Rare Precision Laser M",
+											"Exotic Agile Laser M",
+											"Exotic Defense Laser M",
+											"Exotic Heavy Laser M",
+											"Exotic Precision Laser M"
+										]
+									},
+									{
+										"name": "Lasers L",
+										"data": [
+											"Laser L",
+											"Advanced Agile Laser L",
+											"Advanced Defense Laser L",
+											"Advanced Heavy Laser L",
+											"Advanced Precision Laser L",
+											"Rare Agile Laser L",
+											"Rare Defense Laser L",
+											"Rare Heavy Laser L",
+											"Rare Precision Laser L",
+											"Exotic Agile Laser L",
+											"Exotic Defense Laser L",
+											"Exotic Heavy Laser L",
+											"Exotic Precision Laser L"
+										]
+									}
 								]
 							},
 							{
-								"name": "Electronics",
+								"name": "Missiles",
 								"data": [
 									{
-										"name": "AND Operators",
+										"name": "Missiles XS",
 										"data": [
-											"AND Operator"
+											"Missile XS",
+											"Advanced Agile Missile XS",
+											"Advanced Defense Missile XS",
+											"Advanced Heavy Missile XS",
+											"Advanced Precision Missile XS",
+											"Rare Agile Missile XS",
+											"Rare Defense Missile XS",
+											"Rare Heavy Missile XS",
+											"Rare Precision Missile XS",
+											"Exotic Agile Missile XS",
+											"Exotic Defense Missile XS",
+											"Exotic Heavy Missile XS",
+											"Exotic Precision Missile XS"
 										]
 									},
 									{
-										"name": "NOT Operators",
+										"name": "Missiles S",
 										"data": [
-											"NOT Operator"
+											"Missile S",
+											"Advanced Agile Missile S",
+											"Advanced Defense Missile S",
+											"Advanced Heavy Missile S",
+											"Advanced Precision Missile S",
+											"Rare Agile Missile S",
+											"Rare Defense Missile S",
+											"Rare Heavy Missile S",
+											"Rare Precision Missile S",
+											"Exotic Agile Missile S",
+											"Exotic Defense Missile S",
+											"Exotic Heavy Missile S",
+											"Exotic Precision Missile S"
 										]
 									},
 									{
-										"name": "OR Operators",
+										"name": "Missiles M",
 										"data": [
-											"OR Operator"
+											"Missile M",
+											"Advanced Agile Missile M",
+											"Advanced Defense Missile M",
+											"Advanced Heavy Missile M",
+											"Advanced Precision Missile M",
+											"Rare Agile Missile M",
+											"Rare Defense Missile M",
+											"Rare Heavy Missile M",
+											"Rare Precision Missile M",
+											"Exotic Agile Missile M",
+											"Exotic Defense Missile M",
+											"Exotic Heavy Missile M",
+											"Exotic Precision Missile M"
 										]
 									},
+									{
+										"name": "Missiles L",
+										"data": [
+											"Missile L",
+											"Advanced Agile Missile L",
+											"Advanced Defense Missile L",
+											"Advanced Heavy Missile L",
+											"Advanced Precision Missile L",
+											"Rare Agile Missile L",
+											"Rare Defense Missile L",
+											"Rare Heavy Missile L",
+											"Rare Precision Missile L",
+											"Exotic Agile Missile L",
+											"Exotic Defense Missile L",
+											"Exotic Heavy Missile L",
+											"Exotic Precision Missile L"
+										]
+									}
+								]
+							},
+							{
+								"name": "Railguns",
+								"data": [
+									{
+										"name": "Railguns XS",
+										"data": [
+											"Railgun XS",
+											"Advanced Agile Railgun XS",
+											"Advanced Defense Railgun XS",
+											"Advanced Heavy Railgun XS",
+											"Advanced Precision Railgun XS",
+											"Rare Agile Railgun XS",
+											"Rare Defense Railgun XS",
+											"Rare Heavy Railgun XS",
+											"Rare Precision Railgun XS",
+											"Exotic Agile Railgun XS",
+											"Exotic Defense Railgun XS",
+											"Exotic Heavy Railgun XS",
+											"Exotic Precision Railgun XS"
+										]
+									},
+									{
+										"name": "Railguns S",
+										"data": [
+											"Railgun S",
+											"Advanced Agile Railgun S",
+											"Advanced Defense Railgun S",
+											"Advanced Heavy Railgun S",
+											"Advanced Precision Railgun S",
+											"Rare Agile Railgun S",
+											"Rare Defense Railgun S",
+											"Rare Heavy Railgun S",
+											"Rare Precision Railgun S",
+											"Exotic Agile Railgun S",
+											"Exotic Defense Railgun S",
+											"Exotic Heavy Railgun S",
+											"Exotic Precision Railgun S"
+										]
+									},
+									{
+										"name": "Railguns M",
+										"data": [
+											"Railgun M",
+											"Advanced Agile Railgun M",
+											"Advanced Defense Railgun M",
+											"Advanced Heavy Railgun M",
+											"Advanced Precision Railgun M",
+											"Rare Agile Railgun M",
+											"Rare Defense Railgun M",
+											"Rare Heavy Railgun M",
+											"Rare Precision Railgun M",
+											"Exotic Agile Railgun M",
+											"Exotic Defense Railgun M",
+											"Exotic Heavy Railgun M",
+											"Exotic Precision Railgun M"
+										]
+									},
+									{
+										"name": "Railguns L",
+										"data": [
+											"Railgun L",
+											"Advanced Agile Railgun L",
+											"Advanced Defense Railgun L",
+											"Advanced Heavy Railgun L",
+											"Advanced Precision Railgun L",
+											"Rare Agile Railgun L",
+											"Rare Defense Railgun L",
+											"Rare Heavy Railgun L",
+											"Rare Precision Railgun L",
+											"Exotic Agile Railgun L",
+											"Exotic Defense Railgun L",
+											"Exotic Heavy Railgun L",
+											"Exotic Precision Railgun L"
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			{
+				"name": "Furniture & Appliances",
+				"data": [
+					{
+						"name": "Chairs",
+						"data": [
+							"Bed",
+							"Bench",
+							"Encampment Chair",
+							"Navigator Chair",
+							"Office Chair",
+							"Shower Unit",
+							"Sofa",
+							"Toilet Unit A",
+							"Toilet Unit B",
+							"Urinal Unit",
+							"Wooden Armchair",
+							"Wooden Chair",
+							"Wooden Sofa"
+						]
+					},
+					{
+						"name": "Decorative Element",
+						"data": [
+							{
+								"name": "Adjuncts",
+								"data": [
+									"Vertical Wing",
+									"Wingtip S",
+									"Wingtip M",
+									"Wingtip L"
+								]
+							},
+							{
+								"name": "Antennas",
+								"data": [
+									"Antenna S",
+									"Antenna M",
+									"Antenna L"
+								]
+							},
+							{
+								"name": "Barriers",
+								"data": [
+									"Barrier Corner",
+									"Barrier S",
+									"Barrier M"
+								]
+							},
+							{
+								"name": "Bathroom Elements",
+								"data": [
+									"Sink Unit"
+								]
+							},
+							{
+								"name": "Board",
+								"data": [
+									"Keyboard Unit"
+								]
+							},
+							{
+								"name": "Decorative Cables",
+								"data": [
+									"Cable Model A S",
+									"Cable Model A M",
+									"Cable Model B S",
+									"Cable Model B M",
+									"Cable Model C S",
+									"Cable Model C M",
+									"Corner Cable Model A",
+									"Corner Cable Model B",
+									"Corner Cable Model C"
+								]
+							},
+							{
+								"name": "Furniture",
+								"data": [
+									"\"Eye Doll's Workshop\" - Artist Unknown",
+									"\"HMS Ajax33\" - Artist Unknown",
+									"\"Parrotos Sanctuary\" - Artist Unknown",
+									"Dresser",
+									"Nightstand",
+									"Round Carpet",
+									"Shelf Empty",
+									"Shelf Full",
+									"Shelf Half Full",
+									"Square Carpet",
+									"Table",
+									"Trash Can",
+									"Wardrobe",
+									"Wooden Dresser",
+									"Wooden Low Table",
+									"Wooden Table M",
+									"Wooden Table L",
+									"Wooden Wardrobe"
+								]
+							},
+							{
+								"name": "Holograms",
+								"data": [
+									"Planet Hologram",
+									"Planet Hologram L",
+									"Spaceship Hologram S",
+									"Spaceship Hologram M",
+									"Spaceship Hologram L"
+								]
+							},
+							{
+								"name": "Hull Decoration",
+								"data": [
+									"Canopy Metal Corner S",
+									"Canopy Metal Corner M",
+									"Canopy Metal Corner L",
+									"Canopy Metal Flat S",
+									"Canopy Metal Flat M",
+									"Canopy Metal Flat L",
+									"Canopy Metal Tilted S",
+									"Canopy Metal Tilted M",
+									"Canopy Metal Tilted L",
+									"Canopy Metal Triangle S",
+									"Canopy Metal Triangle M",
+									"Canopy Metal Triangle L",
+									"Hull Decorative Element A",
+									"Hull Decorative Element B",
+									"Hull Decorative Element C",
+									"Steel Column",
+									"Steel Panel"
+								]
+							},
+							{
+								"name": "Pipes",
+								"data": [
+									"Pipe A M",
+									"Pipe B M",
+									"Pipe C M",
+									"Pipe Connector M",
+									"Pipe Corner M",
+									"Pipe D M"
+								]
+							},
+							{
+								"name": "Plants",
+								"data": [
+									"Bagged Plant A",
+									"Bagged Plant B",
+									"Bonsai",
+									"Eggplant Plant Case",
+									"Ficus Plant A",
+									"Ficus Plant B",
+									"Foliage Plant Case A",
+									"Foliage Plant Case B",
+									"Plant",
+									"Plant Case S",
+									"Plant Case M",
+									"Plant Case A",
+									"Plant Case B",
+									"Plant Case C",
+									"Plant Case D",
+									"Plant Case E",
+									"Salad Plant Case",
+									"Squash Plant Case",
+									"Suspended Fruit Plant",
+									"Suspended Plant A",
+									"Suspended Plant B"
+								]
+							},
+							{
+								"name": "Windows",
+								"data": [
+									"Armored Window XS",
+									"Armored Window S",
+									"Armored Window M",
+									"Armored Window L",
+									"Bay Window XL",
+									"Canopy Windshield Corner S",
+									"Canopy Windshield Corner M",
+									"Canopy Windshield Corner L",
+									"Canopy Windshield Flat S",
+									"Canopy Windshield Flat M",
+									"Canopy Windshield Flat L",
+									"Canopy Windshield Tilted S",
+									"Canopy Windshield Tilted M",
+									"Canopy Windshield Tilted L",
+									"Canopy Windshield Triangle S",
+									"Canopy Windshield Triangle M",
+									"Canopy Windshield Triangle L",
+									"Glass Panel S",
+									"Glass Panel M",
+									"Glass Panel L",
+									"Window XS",
+									"Window S",
+									"Window M",
+									"Window L"
+								]
+							},
+							{
+								"name": "Displays",
+								"data": [
+									{
+										"name": "Info Buttons",
+										"data": [
+											"Info Button S"
+										]
+									},
+									{
+										"name": "Screens",
+										"data": [
+											"Screen XS",
+											"Screen S",
+											"Screen M",
+											"Screen XL",
+											{
+												"name": "Signs",
+												"data": [
+													"Sign XS",
+													"Sign S",
+													"Sign M",
+													"Sign L",
+													"Vertical Sign XS",
+													"Vertical Sign M",
+													"Vertical Sign L"
+												]
+											},
+											"Transparent Screen XS",
+											"Transparent Screen S",
+											"Transparent Screen M",
+											"Transparent Screen L"
+										]
+									}
+								]
+							},
+							{
+								"name": "Doors",
+								"data": [
+									"Airlock",
+									"Expanded Gate S",
+									"Expanded Gate L",
+									"Fuel Intake XS",
+									"Gate XS",
+									"Gate M",
+									"Gate XL",
+									"Hatch S",
+									"Interior door",
+									"Reinforced Sliding Door",
+									"Sliding Door S",
+									"Sliding Door M"
+								]
+							},
+							{
+								"name": "Electronic Elements",
+								"data": [
 									{
 										"name": "Counters",
 										"data": [
@@ -730,17 +1134,17 @@
 										]
 									},
 									{
-										"name": "Data Banks",
-										"data": [
-											"Databank"
-										]
-									},
-									{
 										"name": "Data Emitters",
 										"data": [
 											"Emitter XS",
 											"Emitter S",
 											"Emitter M"
+										]
+									},
+									{
+										"name": "Databanks",
+										"data": [
+											"Databank"
 										]
 									},
 									{
@@ -752,8 +1156,49 @@
 									{
 										"name": "Laser Emitters",
 										"data": [
-											"Infra-Red Laser Emitter",
+											"Infrared Laser Emitter",
 											"Laser Emitter"
+										]
+									},
+									{
+										"name": "Logic Operators",
+										"data": [
+											{
+												"name": "AND Operators",
+												"data": [
+													"AND Operator"
+												]
+											},
+											{
+												"name": "NAND Operators",
+												"data": [
+													"NAND Operator"
+												]
+											},
+											{
+												"name": "NOR Operators",
+												"data": [
+													"NOR Operator"
+												]
+											},
+											{
+												"name": "NOT Operators",
+												"data": [
+													"NOT Operator"
+												]
+											},
+											{
+												"name": "OR Operators",
+												"data": [
+													"OR Operator"
+												]
+											},
+											{
+												"name": "XOR Operators",
+												"data": [
+													"XOR Operator"
+												]
+											}
 										]
 									},
 									{
@@ -769,233 +1214,69 @@
 										"data": [
 											"Relay"
 										]
-									}
-								]
-							},
-							{
-								"name": "Engines",
-								"data": [
-									{
-										"name": "Adjustors",
-										"data": [
-											"Adjustor XS",
-											"Adjustor S",
-											"Adjustor M",
-											"Adjustor L"
-										]
 									},
 									{
-										"name": "Airbrakes",
-										"data": [
-											"Atmospheric Airbrake S",
-											"Atmospheric Airbrake M",
-											"Atmospheric Airbrake L"
-										]
-									},
-									{
-										"name": "Airfoil",
+										"name": "Sensors",
 										"data": [
 											{
-												"name": "Aileron",
+												"name": "Laser Detectors",
 												"data": [
-													"Aileron XS",
-													"Aileron S",
-													"Aileron M",
-													"Compact Aileron XS",
-													"Compact Aileron S",
-													"Compact Aileron M"
+													"Infrared Laser Receiver",
+													"Laser Receiver"
 												]
 											},
 											{
-												"name": "Stabilizer",
+												"name": "Telemeters",
 												"data": [
-													"Stabilizer XS",
-													"Stabilizer S",
-													"Stabilizer M",
-													"Stabilizer L"
+													"Telemeter"
 												]
 											},
 											{
-												"name": "Wing",
+												"name": "Zone Detectors",
 												"data": [
-													"Wing XS",
-													"Wing S",
-													"Wing M",
-													"Wing Variant M"
+													"Detection Zone XS",
+													"Detection Zone S",
+													"Detection Zone M",
+													"Detection Zone L"
 												]
 											}
 										]
 									},
 									{
-										"name": "Atmospheric Engines",
+										"name": "Triggers",
 										"data": [
 											{
-												"name": "Atmospheric Engines XS",
+												"name": "Manual Buttons",
 												"data": [
-													"Atmospheric Engine XS",
-													"Freight Atmospheric Engine XS",
-													"Maneuver Atmospheric Engine XS",
-													"Military Atmospheric Engine XS",
-													"Safe Atmospheric Engine XS"
+													"Manual Button XS",
+													"Manual Button S"
 												]
 											},
 											{
-												"name": "Atmospheric Engines S",
+												"name": "Manual Switches",
 												"data": [
-													"Atmospheric Engine S",
-													"Freight Atmospheric Engine S",
-													"Maneuver Atmospheric Engine S",
-													"Military Atmospheric Engine S",
-													"Safe Atmospheric Engine S"
+													"Manual Switch"
 												]
 											},
 											{
-												"name": "Atmospheric Engines M",
+												"name": "Pressure Tiles",
 												"data": [
-													"Atmospheric Engine M",
-													"Freight Atmospheric Engine M",
-													"Maneuver Atmospheric Engine M",
-													"Military Atmospheric Engine M",
-													"Safe Atmospheric Engine M"
-												]
-											},
-											{
-												"name": "Atmospheric Engines L",
-												"data": [
-													"Atmospheric Engine L",
-													"Freight Atmospheric Engine L",
-													"Maneuver Atmospheric Engine L",
-													"Military Atmospheric Engine L",
-													"Safe Atmospheric Engine L"
+													"Pressure Tile"
 												]
 											}
-										]
-									},
-									{
-										"name": "Hovercraft Engines",
-										"data": [
-											"Hover Engine S",
-											"Hover Engine M",
-											"Hover Engine L",
-											"Flat Hover Engine L"
-										]
-									},
-									{
-										"name": "Rocket Engines",
-										"data": [
-											"Rocket Engine S",
-											"Rocket Engine M",
-											"Rocket Engine L"
-										]
-									},
-									{
-										"name": "Space Brakes",
-										"data": [
-											"Retro-Rocket Brake S",
-											"Retro-Rocket Brake M",
-											"Retro-Rocket Brake L"
-										]
-									},
-									{
-										"name": "Space Engines",
-										"data": [
-											{
-												"name": "Space Engines XS",
-												"data": [
-													"Space Engine XS",
-													"Freight Space Engine XS",
-													"Maneuver Space Engine XS",
-													"Military Space Engine XS",
-													"Safe Space Engine XS"
-												]
-											},
-											{
-												"name": "Space Engines S",
-												"data": [
-													"Space Engine S",
-													"Freight Space Engine S",
-													"Maneuver Space Engine S",
-													"Military Space Engine S",
-													"Safe Space Engine S"
-												]
-											},
-											{
-												"name": "Space Engines M",
-												"data": [
-													"Space Engine M",
-													"Freight Space Engine M",
-													"Maneuver Space Engine M",
-													"Military Space Engine M",
-													"Safe Space Engine M"
-												]
-											},
-											{
-												"name": "Space Engines L",
-												"data": [
-													"Space Engine L",
-													"Freight Space Engine L",
-													"Maneuver Space Engine L",
-													"Military Space Engine L",
-													"Safe Space Engine L"
-												]
-											},
-											{
-												"name": "Space Engines XL",
-												"data": [
-													"Space Engine XL",
-													"Freight Space Engine XL",
-													"Maneuver Space Engine XL",
-													"Military Space Engine XL",
-													"Safe Space Engine XL"
-												]
-											}
-										]
-									},
-									{
-										"name": "Vertical Boosters",
-										"data": [
-											"Vertical Booster XS",
-											"Vertical Booster S",
-											"Vertical Booster M",
-											"Vertical Booster L"
 										]
 									}
 								]
 							},
 							{
-								"name": "Instruments",
+								"name": "Elevators",
 								"data": [
-									"Gyroscope",
-									"Telemeter",
-									"Territory Scanner"
+									"Elevator XS"
 								]
 							},
 							{
-								"name": "Interactive Elements",
+								"name": "High-Tech Furniture",
 								"data": [
-									{
-										"name": "Doors",
-										"data": [
-											"Airlock",
-											"Interior Door",
-											"Reinforced Sliding Door",
-											"Sliding Door S",
-											"Sliding Door M",
-											"Gate XS",
-											"Expanded Gate S",
-											"Gate M",
-											"Expanded Gate L",
-											"Gate XL",
-											"Hatch S",
-											"Fuel Intake XS"
-										]
-									},
-									{
-										"name": "Elevators",
-										"data": [
-											"Elevator XS"
-										]
-									},
 									{
 										"name": "Force Fields",
 										"data": [
@@ -1006,33 +1287,9 @@
 										]
 									},
 									{
-										"name": "Landing Gears",
+										"name": "Virtual Projectors",
 										"data": [
-											"Landing Gear XS",
-											"Landing Gear S",
-											"Landing Gear M",
-											"Landing Gear L"
-										]
-									},
-									{
-										"name": "Screens/Signs",
-										"data": [
-											"Screen XS",
-											"Screen S",
-											"Screen M",
-											"Screen XL",
-											"Transparent Screen XS",
-											"Transparent Screen S",
-											"Transparent Screen M",
-											"Transparent Screen L",
-											"Sign XS",
-											"Sign S",
-											"Sign M",
-											"Sign L",
-											"Sign Vertical XS",
-											"Sign Vertical M",
-											"Sign Vertical L",
-											"Sensors S"
+											"Virtual Scaffolding Projector"
 										]
 									}
 								]
@@ -1054,192 +1311,765 @@
 									"Vertical Light M",
 									"Vertical Light L"
 								]
-							},
+							}
+						]
+					}
+				]
+			},
+			{
+				"name": "Industry & Infrastructure Elements",
+				"data": [
+					{
+						"name": "Containers",
+						"data": [
 							{
-								"name": "Resurrection Nodes",
+								"name": "Ammo Container",
 								"data": [
-									"Resurrection Node"
+									"Ammo Container XS",
+									"Ammo Container S",
+									"Ammo Container M",
+									"Ammo Container L"
 								]
 							},
 							{
-								"name": "Sensors",
+								"name": "Dispensers",
+								"data": [
+									"Deprecated Dispenser",
+									"Dispenser"
+								]
+							},
+							{
+								"name": "Fuel Tanks",
 								"data": [
 									{
-										"name": "Laser Detectors",
+										"name": "Atmospheric Fuel Containers",
 										"data": [
-											"Infra-Red Laser Receiver",
-											"Laser Receiver"
+											"Atmospheric Fuel Tank XS",
+											"Atmospheric Fuel Tank S",
+											"Atmospheric Fuel Tank M",
+											"Atmospheric Fuel Tank L"
 										]
 									},
 									{
-										"name": "Manual Buttons",
+										"name": "Rocket Fuel Containers",
 										"data": [
-											"Manual Button S",
-											"Manual Button XS"
+											"Rocket Fuel Tank XS",
+											"Rocket Fuel Tank S",
+											"Rocket Fuel Tank M",
+											"Rocket Fuel Tank L"
 										]
 									},
 									{
-										"name": "Manual Switches",
+										"name": "Space Fuel Containers",
 										"data": [
-											"Manual Switch"
-										]
-									},
-									{
-										"name": "Pressure Tiles",
-										"data": [
-											"Pressure Tile"
-										]
-									},
-									{
-										"name": "Radars",
-										"data": [
-											"Small Atmospheric Radar PvP S",
-											"Medium Atmospheric Radar PvP M",
-											"Large Atmospheric Radar PvP L",
-											"Space Radar S",
-											"Space Radar M",
-											"Space Radar L",
-											"Transponder"
-										]
-									},
-									{
-										"name": "Zone Detectors",
-										"data": [
-											"Detection Zone XS",
-											"Detection Zone S",
-											"Detection Zone M",
-											"Detection Zone L"
+											"Space Fuel Tank S",
+											"Space Fuel Tank M",
+											"Space Fuel Tank L"
 										]
 									}
 								]
 							},
 							{
-								"name": "Virtual Projectors",
+								"name": "Item Containers",
 								"data": [
-									"Virtual Scaffolding Projector"
+									"Container Hub",
+									"Container XS",
+									"Container S",
+									"Container M",
+									"Container L",
+									"Container XL",
+									"Expanded Container XL"
 								]
 							},
 							{
-								"name": "Combat Elements",
+								"name": "Parcel Container",
 								"data": [
-									{
-										"name": "Weapon Units",
-										"data": [
-											{
-												"name": "Cannons",
-												"data": [
-													"Cannon XS",
-													"Cannon S",
-													"Cannon M",
-													"Cannon L"
-												]
-											},
-											{
-												"name": "Lasers",
-												"data": [
-													"Laser XS",
-													"Laser S",
-													"Laser M",
-													"Laser L"
-												]
-											},
-											{
-												"name": "Missile Pods",
-												"data": [
-													"Missile XS",
-													"Missile S",
-													"Missile M",
-													"Missile L"
-												]
-											},
-											{
-												"name": "Railguns",
-												"data": [
-													"Railgun XS",
-													"Railgun S",
-													"Railgun M",
-													"Railgun L"
-												]
-											}
-										]
-									},
-									{
-										"name": "Gunner Seats",
-										"data": [
-											"Gunner Module S",
-											"Gunner Module M",
-											"Gunner Module L"
-										]
-									},
-									"Repair Unit"
-								]
-							},
-							{
-								"name": "Surrogate VR Elements",
-								"data": [
-									"Surrogate Pod Station",
-									"Surrogate VR Station"
-								]
-							},
-							{
-								"name": "Warp Drives",
-								"data": [
-									"Warp Drive L"
-								]
-							},
-							{
-								"name": "Warp Beacons",
-								"data": [
-									"Warp Beacon XL"
+									"Parcel Container XS",
+									"Parcel Container S",
+									"Parcel Container M",
+									"Parcel Container L",
+									"Parcel Container XL",
+									"Expanded Parcel Container XL"
 								]
 							}
 						]
 					},
 					{
-						"name": "Planet Elements",
+						"name": "Industry",
 						"data": [
 							{
-								"name": "Core Units",
+								"name": "Basic Industry",
 								"data": [
-									{
-										"name": "Dynamic Core Units",
-										"data": [
-											"Dynamic Core XS",
-											"Dynamic Core S",
-											"Dynamic Core M",
-											"Dynamic Core L"
-										]
-									},
-									{
-										"name": "Static Core Units",
-										"data": [
-											"Static Core XS",
-											"Static Core S",
-											"Static Core M",
-											"Static Core L"
-										]
-									},
-									{
-										"name": "Space Core Units",
-										"data": [
-											"Space Core XS",
-											"Space Core S",
-											"Space Core M",
-											"Space Core L"
-										]
-									}
+									"Basic 3D Printer M",
+									"Basic Assembly Line XS",
+									"Basic Assembly Line S",
+									"Basic Assembly Line M",
+									"Basic Assembly Line L",
+									"Basic Assembly Line XL",
+									"Basic Chemical Industry M",
+									"Basic Electronics Industry M",
+									"Basic Glass Furnace M",
+									"Basic Honeycomb Refinery M",
+									"Basic Metalwork Industry M",
+									"Basic Recycler M",
+									"Basic Refiner M",
+									"Basic Smelter M"
 								]
 							},
+							{
+								"name": "Uncommon Industry",
+								"data": [
+									"Uncommon 3D Printer M",
+									"Uncommon Assembly Line XS",
+									"Uncommon Assembly Line S",
+									"Uncommon Assembly Line M",
+									"Uncommon Assembly Line L",
+									"Uncommon Assembly Line XL",
+									"Uncommon Chemical Industry M",
+									"Uncommon Electronics Industry M",
+									"Uncommon Glass Furnace M",
+									"Uncommon Honeycomb Refinery M",
+									"Uncommon Metalwork Industry M",
+									"Uncommon Recycler M",
+									"Uncommon Refiner M",
+									"Uncommon Smelter M"
+								]
+							},
+							{
+								"name": "Advanced Industry",
+								"data": [
+									"Advanced 3D Printer M",
+									"Advanced Assembly Line XS",
+									"Advanced Assembly Line S",
+									"Advanced Assembly Line M",
+									"Advanced Assembly Line L",
+									"Advanced Assembly Line XL",
+									"Advanced Chemical Industry M",
+									"Advanced Electronics Industry M",
+									"Advanced Glass Furnace M",
+									"Advanced Honeycomb Refinery M",
+									"Advanced Metalwork Industry M",
+									"Advanced Recycler M",
+									"Advanced Refiner M",
+									"Advanced Smelter M"
+								]
+							},
+							{
+								"name": "Rare Industry",
+								"data": [
+									"Rare 3D Printer M",
+									"Rare Assembly Line XS",
+									"Rare Assembly Line S",
+									"Rare Assembly Line M",
+									"Rare Assembly Line L",
+									"Rare Assembly Line XL",
+									"Rare Chemical Industry M",
+									"Rare Electronics Industry M",
+									"Rare Glass Furnace M",
+									"Rare Honeycomb Refinery M",
+									"Rare Metalwork Industry M",
+									"Rare Recycler M",
+									"Rare Refiner M",
+									"Rare Smelter M"
+								]
+							},
+							"Transfer Unit"
+						]
+					}
+				]
+			},
+			{
+				"name": "Planet Elements",
+				"data": [
+					{
+						"name": "Core Units",
+						"data": [
+							{
+								"name": "Dynamic Core Units",
+								"data": [
+									"Dynamic Core Unit XS",
+									"Dynamic Core Unit S",
+									"Dynamic Core Unit M",
+									"Dynamic Core Unit L"
+								]
+							},
+							{
+								"name": "Space Core Units",
+								"data": [
+									"Space Core Unit XS",
+									"Space Core Unit S",
+									"Space Core Unit M",
+									"Space Core Unit L"
+								]
+							},
+							{
+								"name": "Static Core Units",
+								"data": [
+									"Static Core Unit XS",
+									"Static Core Unit S",
+									"Static Core Unit M",
+									"Static Core Unit L"
+								]
+							}
+						]
+					},
+					{
+						"name": "Territory Units",
+						"data": [
 							"Territory Unit"
 						]
 					}
 				]
 			},
 			{
-				"name": "Materials",
+				"name": "Systems",
 				"data": [
 					{
-						"name": "Catalysts",
+						"name": "Control Units",
+						"data": [
+							{
+								"name": "Emergency Controllers",
+								"data": [
+									"Emergency Controller"
+								]
+							},
+							{
+								"name": "Generic Control Units",
+								"data": [
+									"Programming Board"
+								]
+							},
+							{
+								"name": "Gunner Module",
+								"data": [
+									"Gunner Module S",
+									"Gunner Module M",
+									"Gunner Module L"
+								]
+							},
+							{
+								"name": "Piloting Control Units",
+								"data": [
+									{
+										"name": "Closed Cockpits",
+										"data": [
+											"Cockpit Controller"
+										]
+									},
+									{
+										"name": "Command Seat",
+										"data": [
+											"Command Seat Controller"
+										]
+									},
+									{
+										"name": "Hovercraft Cockpits",
+										"data": [
+											"Hovercraft Seat Controller"
+										]
+									},
+									{
+										"name": "Remote Controllers",
+										"data": [
+											"Remote Controller"
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						"name": "Resurrection Nodes",
+						"data": [
+							"Resurrection Node"
+						]
+					},
+					{
+						"name": "Surrogate Station Equipment",
+						"data": [
+							"Surrogate Pod Station",
+							"Surrogate VR Station"
+						]
+					},
+					{
+						"name": "Territory Scanners",
+						"data": [
+							"Territory Scanner"
+						]
+					}
+				]
+			},
+			{
+				"name": "Transportation Elements",
+				"data": [
+					{
+						"name": "Airfoil",
+						"data": [
+							{
+								"name": "Aileron",
+								"data": [
+									"Aileron XS",
+									"Aileron S",
+									"Aileron M",
+									"Compact Aileron XS",
+									"Compact Aileron S",
+									"Compact Aileron M"
+								]
+							},
+							{
+								"name": "Stabilizer",
+								"data": [
+									"Stabilizer XS",
+									"Stabilizer S",
+									"Stabilizer M",
+									"Stabilizer L"
+								]
+							},
+							{
+								"name": "Wing",
+								"data": [
+									"Wing XS",
+									"Wing S",
+									"Wing M",
+									"Wing Variant M"
+								]
+							}
+						]
+					},
+					{
+						"name": "Atmospheric Brakes",
+						"data": [
+							{
+								"name": "Airbrakes",
+								"data": [
+									"Atmospheric Airbrake S",
+									"Atmospheric Airbrake M",
+									"Atmospheric Airbrake L"
+								]
+							},
+							{
+								"name": "Space Brakes",
+								"data": [
+									"Retro-Rocket Brake S",
+									"Retro-Rocket Brake M",
+									"Retro-Rocket Brake L"
+								]
+							}
+						]
+					},
+					{
+						"name": "Engines",
+						"data": [
+							{
+								"name": "Adjustors",
+								"data": [
+									"Adjustor XS",
+									"Adjustor S",
+									"Adjustor M",
+									"Adjustor L"
+								]
+							},
+							{
+								"name": "Atmospheric Engines",
+								"data": [
+									{
+										"name": "Atmospheric Engines XS",
+										"data": [
+											"Basic Atmospheric Engine XS",
+											"Uncommon Freight Atmospheric Engine XS",
+											"Uncommon Maneuver Atmospheric Engine XS",
+											"Uncommon Military Atmospheric Engine XS",
+											"Uncommon Safe Atmospheric Engine XS",
+											"Advanced Freight Atmospheric Engine XS",
+											"Advanced Maneuver Atmospheric Engine XS",
+											"Advanced Military Atmospheric Engine XS",
+											"Advanced Safe Atmospheric Engine XS",
+											"Rare Freight Atmospheric Engine XS",
+											"Rare Maneuver Atmospheric Engine XS",
+											"Rare Military Atmospheric Engine XS",
+											"Rare Safe Atmospheric Engine XS"
+										]
+									},
+									{
+										"name": "Atmospheric Engines S",
+										"data": [
+											"Basic Atmospheric Engine S",
+											"Uncommon Freight Atmospheric Engine S",
+											"Uncommon Maneuver Atmospheric Engine S",
+											"Uncommon Military Atmospheric Engine S",
+											"Uncommon Safe Atmospheric Engine S",
+											"Advanced Freight Atmospheric Engine S",
+											"Advanced Maneuver Atmospheric Engine S",
+											"Advanced Military Atmospheric Engine S",
+											"Advanced Safe Atmospheric Engine S",
+											"Rare Freight Atmospheric Engine S",
+											"Rare Maneuver Atmospheric Engine S",
+											"Rare Military Atmospheric Engine S",
+											"Rare Safe Atmospheric Engine S"
+										]
+									},
+									{
+										"name": "Atmospheric Engines M",
+										"data": [
+											"Basic Atmospheric Engine M",
+											"Uncommon Freight Atmospheric Engine M",
+											"Uncommon Maneuver Atmospheric Engine M",
+											"Uncommon Military Atmospheric Engine M",
+											"Uncommon Safe Atmospheric Engine M",
+											"Advanced Freight Atmospheric Engine M",
+											"Advanced Maneuver Atmospheric Engine M",
+											"Advanced Military Atmospheric Engine M",
+											"Advanced Safe Atmospheric Engine M",
+											"Rare Freight Atmospheric Engine M",
+											"Rare Maneuver Atmospheric Engine M",
+											"Rare Military Atmospheric Engine M",
+											"Rare Safe Atmospheric Engine M"
+										]
+									},
+									{
+										"name": "Atmospheric Engines L",
+										"data": [
+											"Basic Atmospheric Engine L",
+											"Uncommon Freight Atmospheric Engine L",
+											"Uncommon Maneuver Atmospheric Engine L",
+											"Uncommon Military Atmospheric Engine L",
+											"Uncommon Safe Atmospheric Engine L",
+											"Advanced Freight Atmospheric Engine L",
+											"Advanced Maneuver Atmospheric Engine L",
+											"Advanced Military Atmospheric Engine L",
+											"Advanced Safe Atmospheric Engine L",
+											"Rare Freight Atmospheric Engine L",
+											"Rare Maneuver Atmospheric Engine L",
+											"Rare Military Atmospheric Engine L",
+											"Rare Safe Atmospheric Engine L"
+										]
+									}
+								]
+							},
+							{
+								"name": "Ground Engines",
+								"data": [
+									{
+										"name": "Hovercraft Engines",
+										"data": [
+											"Flat Hover Engine L",
+											"Hover Engine S",
+											"Hover Engine M",
+											"Hover Engine L"
+										]
+									},
+									{
+										"name": "Vertical Boosters",
+										"data": [
+											"Vertical Booster XS",
+											"Vertical Booster S",
+											"Vertical Booster M",
+											"Vertical Booster L"
+										]
+									}
+								]
+							},
+							{
+								"name": "Rocket Engines",
+								"data": [
+									"Rocket Engine S",
+									"Rocket Engine M",
+									"Rocket Engine L"
+								]
+							},
+							{
+								"name": "Space Engines",
+								"data": [
+									{
+										"name": "Space Engines XS",
+										"data": [
+											"Basic Space Engine XS",
+											"Uncommon Freight Space Engine XS",
+											"Uncommon Maneuver Space Engine XS",
+											"Uncommon Military Space Engine XS",
+											"Uncommon Safe Space Engine XS",
+											"Advanced Freight Space Engine XS",
+											"Advanced Maneuver Space Engine XS",
+											"Advanced Military Space Engine XS",
+											"Advanced Safe Space Engine XS",
+											"Rare Freight Space Engine XS",
+											"Rare Maneuver Space Engine XS",
+											"Rare Military Space Engine XS",
+											"Rare Safe Space Engine XS"
+										]
+									},
+									{
+										"name": "Space Engines S",
+										"data": [
+											"Basic Space Engine S",
+											"Uncommon Freight Space Engine S",
+											"Uncommon Maneuver Space Engine S",
+											"Uncommon Military Space Engine S",
+											"Uncommon Safe Space Engine S",
+											"Advanced Freight Space Engine S",
+											"Advanced Maneuver Space Engine S",
+											"Advanced Military Space Engine S",
+											"Advanced Safe Space Engine S",
+											"Rare Freight Space Engine S",
+											"Rare Maneuver Space Engine S",
+											"Rare Military Space Engine S",
+											"Rare Safe Space Engine S"
+										]
+									},
+									{
+										"name": "Space Engines M",
+										"data": [
+											"Basic Space Engine M",
+											"Uncommon Freight Space Engine M",
+											"Uncommon Maneuver Space Engine M",
+											"Uncommon Military Space Engine M",
+											"Uncommon Safe Space Engine M",
+											"Advanced Freight Space Engine M",
+											"Advanced Maneuver Space Engine M",
+											"Advanced Military Space Engine M",
+											"Advanced Safe Space Engine M",
+											"Rare Freight Space Engine M",
+											"Rare Maneuver Space Engine M",
+											"Rare Military Space Engine M",
+											"Rare Safe Space Engine M"
+										]
+									},
+									{
+										"name": "Space Engines L",
+										"data": [
+											"Basic Space Engine L",
+											"Uncommon Freight Space Engine L",
+											"Uncommon Maneuver Space Engine L",
+											"Uncommon Military Space Engine L",
+											"Uncommon Safe Space Engine L",
+											"Advanced Freight Space Engine L",
+											"Advanced Maneuver Space Engine L",
+											"Advanced Military Space Engine L",
+											"Advanced Safe Space Engine L",
+											"Rare Freight Space Engine L",
+											"Rare Maneuver Space Engine L",
+											"Rare Military Space Engine L",
+											"Rare Safe Space Engine L"
+										]
+									},
+									{
+										"name": "Space Engines XL",
+										"data": [
+											"Basic Space Engine XL",
+											"Uncommon Freight Space Engine XL",
+											"Uncommon Maneuver Space Engine XL",
+											"Uncommon Military Space Engine XL",
+											"Uncommon Safe Space Engine XL",
+											"Advanced Freight Space Engine XL",
+											"Advanced Maneuver Space Engine XL",
+											"Advanced Military Space Engine XL",
+											"Advanced Safe Space Engine XL",
+											"Rare Freight Space Engine XL",
+											"Rare Maneuver Space Engine XL",
+											"Rare Military Space Engine XL",
+											"Rare Safe Space Engine XL"
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						"name": "High-Tech Transportation",
+						"data": [
+							{
+								"name": "Anti-Gravity Generator",
+								"data": [
+									"Anti-Gravity Generator S",
+									"Anti-Gravity Generator M",
+									"Anti-Gravity Generator L"
+								]
+							},
+							{
+								"name": "Anti-Gravity Pulsor",
+								"data": [
+									"Anti-Gravity Pulsor"
+								]
+							},
+							{
+								"name": "Warp Beacon Units",
+								"data": [
+									"Warp Beacon XL"
+								]
+							},
+							{
+								"name": "Warp Drive Units",
+								"data": [
+									"Warp Drive L"
+								]
+							}
+						]
+					},
+					{
+						"name": "Support Tech",
+						"data": [
+							{
+								"name": "Gyroscopes",
+								"data": [
+									"Gyroscope"
+								]
+							},
+							{
+								"name": "Landing Gears",
+								"data": [
+									"Landing Gear XS",
+									"Landing Gear S",
+									"Landing Gear M",
+									"Landing Gear L"
+								]
+							}
+						]
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Materials",
+		"data": [
+			{
+				"name": "Fuels",
+				"data": [
+					{
+						"name": "Atmospheric Fuels",
+						"data": [
+							"Nitron Fuel"
+						]
+					},
+					{
+						"name": "Rocket Fuels",
+						"data": [
+							"Xeron Fuel"
+						]
+					},
+					{
+						"name": "Space Fuels",
+						"data": [
+							"Kergon-X1 Fuel",
+							"Kergon-X2 Fuel",
+							"Kergon-X3 Fuel",
+							"Kergon-X4 Fuel"
+						]
+					}
+				]
+			},
+			{
+				"name": "Honeycomb Materials",
+				"data": [
+					{
+						"name": "Product Honeycomb Materials",
+						"data": [
+							"Al-Li Honeycomb",
+							"Brick Honeycomb",
+							"Carbon Fiber Honeycomb",
+							"Concrete Honeycomb",
+							"Duralumin Honeycomb",
+							"Grade 5 Titanium Honeycomb",
+							"Inconel Honeycomb",
+							"Luminescent White Glass",
+							"Mangalloy Honeycomb",
+							"Maraging Steel Honeycomb",
+							"Marble Honeycomb",
+							"Plastic Honeycomb",
+							"Sc-Al Honeycomb",
+							"Silumin Honeycomb",
+							"Stainless Steel Honeycomb",
+							"Steel Honeycomb",
+							"Wood Honeycomb"
+						]
+					},
+					{
+						"name": "Pure Honeycomb Materials",
+						"data": [
+							"Aluminium Honeycomb",
+							"Calcium Honeycomb",
+							"Chromium Honeycomb",
+							"Cobalt Honeycomb",
+							"Copper Honeycomb",
+							"Fluorine Honeycomb",
+							"Gold Honeycomb",
+							"Iron Honeycomb",
+							"Lithium Honeycomb",
+							"Manganese Honeycomb",
+							"Nickel Honeycomb",
+							"Niobium Honeycomb",
+							"Scandium Honeycomb",
+							"Silicon Honeycomb",
+							"Silver Honeycomb",
+							"Sodium Honeycomb",
+							"Sulfur Honeycomb",
+							"Titanium Honeycomb",
+							"Vanadium Honeycomb"
+						]
+					}
+				]
+			},
+			{
+				"name": "Minable Materials",
+				"data": [
+					{
+						"name": "Ores",
+						"data": [
+							{
+								"name": "Tier 1 Ores",
+								"data": [
+									"Bauxite",
+									"Coal",
+									"Hematite",
+									"Quartz"
+								]
+							},
+							{
+								"name": "Tier 2 Ores",
+								"data": [
+									"Chromite",
+									"Limestone",
+									"Malachite",
+									"Natron"
+								]
+							},
+							{
+								"name": "Tier 3 Ores",
+								"data": [
+									"Acanthite",
+									"Garnierite",
+									"Petalite",
+									"Pyrite"
+								]
+							},
+							{
+								"name": "Tier 4 Ores",
+								"data": [
+									"Cobaltite",
+									"Cryolite",
+									"Gold Nuggets",
+									"Kolbeckite"
+								]
+							},
+							{
+								"name": "Tier 5 Ores",
+								"data": [
+									"Columbite",
+									"Illmenite",
+									"Rhodonite",
+									"Thoramine",
+									"Vanadinite"
+								]
+							}
+						]
+					}
+				]
+			},
+			{
+				"name": "Refined Materials",
+				"data": [
+					{
+						"name": "Catalyst",
 						"data": [
 							"Catalyst 3",
 							"Catalyst 4",
@@ -1247,187 +2077,118 @@
 						]
 					},
 					{
-						"name": "Fuels",
+						"name": "Products",
 						"data": [
-							{
-								"name": "Atmospheric Fuels",
-								"data": [
-									"Nitron Fuel"
-								]
-							},
-							{
-								"name": "Rocket Fuels",
-								"data": [
-									"Xeron Fuel"
-								]
-							},
-							{
-								"name": "Space Fuels",
-								"data": [
-									"Kergon-X1 Fuel",
-									"Kergon-X2 Fuel",
-									"Kergon-X3 Fuel",
-									"Kergon-X4 Fuel"
-								]
-							}
-						]
-					},
-					{
-						"name": "Honeycomb Materials",
-						"data": [
-							{
-								"name": "Product Honeycomb",
-								"data": [
-									"Brick Honeycomb",
-									"Carbonfiber Honeycomb",
-									"Concrete Honeycomb",
-									"Marble Honeycomb",
-									"Plastic Honeycomb",
-									"Steel Honeycomb",
-									"Wood Honeycomb",
-									"Luminescent White Glass"
-								]
-							},
-							{
-								"name": "Pure Honeycomb",
-								"data": [
-									"Aluminium Honeycomb",
-									"Carbon Honeycomb",
-									"Iron Honeycomb",
-									"Silicon Honeycomb",
-									"Calcium Honeycomb",
-									"Chromium Honeycomb",
-									"Copper Honeycomb",
-									"Sodium Honeycomb",
-									"Lithium Honeycomb",
-									"Nickel Honeycomb",
-									"Silver Honeycomb",
-									"Sulfur Honeycomb",
-									"Cobalt Honeycomb",
-									"Fluorine Honeycomb",
-									"Gold Honeycomb",
-									"Scandium Honeycomb",
-									"Manganese Honeycomb",
-									"Niobium Honeycomb",
-									"Titanium Honeycomb",
-									"Vanadium Honeycomb"
-								]
-							}
-						]
-					},
-					{
-						"name": "Product",
-						"data": [
-							"Advanced Glass",
-							"Ag-Li Reinforced Glass",
-							"Al-Fe Alloy",
-							"Al-Li Alloy",
 							"Biological Matter",
 							"Brick",
-							"Calcium Reinforced Copper",
 							"Carbon Fiber",
-							"Cu-Ag Alloy",
 							"Concrete",
-							"Duralumin",
-							"Fluoropolymer",
-							"Glass",
-							"Gold Coated Glass",
-							"Grade 5 Titanium Alloy",
-							"Inconel",
-							"Mangalloy",
-							"Manganese Reinforced Glass",
-							"Maraging Steel",
+							{
+								"name": "Conductor Metals",
+								"data": [
+									"Al-Fe Alloy",
+									"Calcium Reinforced Copper",
+									"Cu-Ag Alloy",
+									"Red Gold",
+									"Ti-Nb Supraconductor"
+								]
+							},
+							{
+								"name": "Glass Materials",
+								"data": [
+									"Glass",
+									"Advanced Glass",
+									"Ag-Li Reinforced Glass",
+									"Gold-Coated Glass",
+									"Manganese Reinforced Glass"
+								]
+							},
+							{
+								"name": "Heavy Metals",
+								"data": [
+									"Steel",
+									"Stainless Steel",
+									"Inconel",
+									"Maraging Steel",
+									"Mangalloy"
+								]
+							},
+							{
+								"name": "Light Metals",
+								"data": [
+									"Silumin",
+									"Duralumin",
+									"Al-Li Alloy",
+									"Sc-Al Alloy",
+									"Grade 5 Titanium Alloy"
+								]
+							},
 							"Marble",
-							"Polycalcite Plastic",
-							"Polycarbonate Plastic",
-							"Polysulfide Plastic",
-							"Red Gold",
-							"Sc-Al Alloy",
-							"Silumin",
-							"Stainless Steel",
-							"Steel",
-							"Ti-Nb Supraconductor",
-							"Vanamer",
+							{
+								"name": "Polymers",
+								"data": [
+									"Polycarbonate Plastic",
+									"Polycalcite Plastic",
+									"Polysulfide Plastic",
+									"Fluoropolymer",
+									"Vanamer"
+								]
+							},
 							"Wood"
 						]
 					},
 					{
-						"name": "Pure",
+						"name": "Pures",
 						"data": [
-							"Aluminium Pure",
-							"Calcium Pure",
-							"Carbon Pure",
-							"Chromium Pure",
-							"Cobalt Pure",
-							"Copper Pure",
-							"Gold Pure",
-							"Iron Pure",
-							"Fluorine Pure",
-							"Lithium Pure",
-							"Manganese Pure",
-							"Nickel Pure",
-							"Niobium Pure",
-							"Scandium Pure",
-							"Silicon Pure",
-							"Silver Pure",
-							"Sodium Pure",
-							"Sulfur Pure",
-							"Titanium Pure",
-							"Vanadium Pure"
-						]
-					},
-					{
-						"name": "Ore",
-						"data": [
-							"Acanthite",
-							"Bauxite",
-							"Chromite",
-							"Coal",
-							"Cobaltite",
-							"Columbite",
-							"Cryolite",
-							"Garnierite",
-							"Gold Nuggets",
-							"Hematite",
-							"Illmenite",
-							"Kolbeckite",
-							"Limestone",
-							"Malachite",
-							"Natron",
-							"Petalite",
-							"Pyrite",
-							"Quartz",
-							"Rhodonite",
-							"Vanadinite"
+							{
+								"name": "Basic Pure Materials",
+								"data": [
+									"Pure Aluminium",
+									"Pure Carbon",
+									"Pure Iron",
+									"Pure Silicon"
+								]
+							},
+							{
+								"name": "Uncommon Pure Materials",
+								"data": [
+									"Pure Calcium",
+									"Pure Chromium",
+									"Pure Copper",
+									"Pure Sodium"
+								]
+							},
+							{
+								"name": "Advanced Pure Materials",
+								"data": [
+									"Pure Lithium",
+									"Pure Nickel",
+									"Pure Silver",
+									"Pure Sulfur"
+								]
+							},
+							{
+								"name": "Rare Pure Materials",
+								"data": [
+									"Pure Cobalt",
+									"Pure Fluorine",
+									"Pure Gold",
+									"Pure Scandium"
+								]
+							},
+							{
+								"name": "Exotic Pure Materials",
+								"data": [
+									"Pure Manganese",
+									"Pure Niobium",
+									"Pure Titanium",
+									"Pure Vanadium"
+								]
+							},
+							"Pure Hydrogen",
+							"Pure Oxygen"
 						]
 					}
-				]
-			},
-			{
-				"name": "Scraps",
-				"data": [
-					"Aluminium Scrap",
-					"Calcium Scrap",
-					"Carbon Scrap",
-					"Chromium Scrap",
-					"Cobalt Scrap",
-					"Copper Scrap",
-					"Gold Scrap",
-					"Iron Scrap",
-					"Fluorine Scrap",
-					"Lithium Scrap",
-					"Nickel Scrap",
-					"Scandium Scrap",
-					"Silicon Scrap",
-					"Silver Scrap",
-					"Sodium Scrap",
-					"Sulfur Scrap"
-				]
-			},
-			{
-				"name": "Warp Cells",
-				"data": [
-					"Warp Cell"
 				]
 			}
 		]
@@ -1436,16 +2197,14 @@
 		"name": "Parts",
 		"data": [
 			{
-				"name": "Complex Parts",
+				"name": "Complex parts",
 				"data": [
 					{
-						"name": "Anti-Matter Capsules",
+						"name": "Antimatter Capsules",
 						"data": [
-							"Basic Anti-Matter Capsule",
-							"Uncommon Anti-Matter Capsule",
-							"Advanced Anti-Matter Capsule",
-							"Rare Anti-Matter Capsule",
-							"Exotic Anti-Matter Capsule"
+							"Basic Antimatter Capsule",
+							"Uncommon Antimatter Capsule",
+							"Advanced Antimatter Capsule"
 						]
 					},
 					{
@@ -1453,7 +2212,9 @@
 						"data": [
 							"Basic Burner",
 							"Uncommon Burner",
-							"Advanced Burner"
+							"Advanced Burner",
+							"Rare Burner",
+							"Exotic Burner"
 						]
 					},
 					{
@@ -1479,14 +2240,18 @@
 						"data": [
 							"Basic Hydraulics",
 							"Uncommon Hydraulics",
-							"Advanced Hydraulics"
+							"Advanced Hydraulics",
+							"Rare Hydraulics",
+							"Exotic Hydraulics"
 						]
 					},
 					{
 						"name": "Injectors",
 						"data": [
 							"Basic Injector",
-							"Advanced Injector"
+							"Uncommon Injector",
+							"Advanced Injector",
+							"Rare Injector"
 						]
 					},
 					{
@@ -1505,7 +2270,8 @@
 							"Basic Optics",
 							"Uncommon Optics",
 							"Advanced Optics",
-							"Rare Optics"
+							"Rare Optics",
+							"Exotic Optics"
 						]
 					},
 					{
@@ -1523,8 +2289,7 @@
 						"data": [
 							"Basic Processor",
 							"Uncommon Processor",
-							"Advanced Processor",
-							"Exotic Processor"
+							"Advanced Processor"
 						]
 					},
 					{
@@ -1548,7 +2313,7 @@
 						]
 					},
 					{
-						"name": "Solid Warhead",
+						"name": "Solid Warheads",
 						"data": [
 							"Uncommon Solid Warhead",
 							"Advanced Solid Warhead"
@@ -1568,10 +2333,9 @@
 						]
 					},
 					{
-						"name": "Anti-Matter Core Units",
+						"name": "Antimatter Cores",
 						"data": [
-							"Advanced Anti-Matter Core Unit",
-							"Exotic Anti-Matter Core Unit"
+							"Advanced Antimatter Core"
 						]
 					},
 					{
@@ -1585,6 +2349,291 @@
 						"name": "Quantum Barriers",
 						"data": [
 							"Advanced Quantum Barrier"
+						]
+					}
+				]
+			},
+			{
+				"name": "Functional Parts",
+				"data": [
+					{
+						"name": "Antennas",
+						"data": [
+							"Basic Antenna XS",
+							"Basic Antenna S",
+							"Uncommon Antenna S",
+							"Uncommon Antenna M",
+							"Uncommon Antenna L",
+							"Advanced Antenna S",
+							"Advanced Antenna M",
+							"Advanced Antenna L",
+							"Rare Antenna S",
+							"Rare Antenna M",
+							"Rare Antenna L",
+							"Exotic Antenna S",
+							"Exotic Antenna M",
+							"Exotic Antenna L",
+							"Exotic Antenna XL"
+						]
+					},
+					{
+						"name": "Chemical Containers",
+						"data": [
+							"Basic Chemical Container XS",
+							"Basic Chemical Container S",
+							"Basic Chemical Container M",
+							"Basic Chemical Container L",
+							"Basic Chemical Container XL",
+							"Uncommon Chemical Container M",
+							"Advanced Chemical Container S",
+							"Advanced Chemical Container M",
+							"Advanced Chemical Container L",
+							"Advanced Chemical Container XL",
+							"Rare Chemical Container M"
+						]
+					},
+					{
+						"name": "Combustion Chambers",
+						"data": [
+							"Basic Combustion Chamber XS",
+							"Basic Combustion Chamber S",
+							"Basic Combustion Chamber M",
+							"Basic Combustion Chamber L",
+							"Uncommon Combustion Chamber XS",
+							"Uncommon Combustion Chamber S",
+							"Uncommon Combustion Chamber M",
+							"Uncommon Combustion Chamber L",
+							"Advanced Combustion Chamber XS",
+							"Advanced Combustion Chamber S",
+							"Advanced Combustion Chamber M",
+							"Advanced Combustion Chamber L",
+							"Rare Combustion Chamber XS",
+							"Rare Combustion Chamber S",
+							"Rare Combustion Chamber M",
+							"Rare Combustion Chamber L"
+						]
+					},
+					{
+						"name": "Control Systems",
+						"data": [
+							"Basic Control System XS",
+							"Basic Control System S",
+							"Basic Control System M",
+							"Advanced Control System S",
+							"Advanced Control System M",
+							"Advanced Control System L"
+						]
+					},
+					{
+						"name": "Core Systems",
+						"data": [
+							"Basic Core System XS",
+							"Basic Core System S",
+							"Uncommon Core System S",
+							"Uncommon Core System M",
+							"Uncommon Core System L",
+							"Advanced Core System M",
+							"Rare Core System L",
+							"Exotic Core System S"
+						]
+					},
+					{
+						"name": "Electric Engines",
+						"data": [
+							"Basic Electric Engine S",
+							"Basic Electric Engine M",
+							"Uncommon Electric Engine XL"
+						]
+					},
+					{
+						"name": "Firing Systems",
+						"data": [
+							"Basic Firing System XS",
+							"Advanced Firing System XS",
+							"Advanced Firing System S",
+							"Advanced Firing System M",
+							"Advanced Firing System L",
+							"Rare Firing System XS",
+							"Rare Firing System S",
+							"Rare Firing System M",
+							"Rare Firing System L",
+							"Exotic Firing System XS",
+							"Exotic Firing System S",
+							"Exotic Firing System M",
+							"Exotic Firing System L"
+						]
+					},
+					{
+						"name": "Gas Cylinders",
+						"data": [
+							"Basic Gas Cylinder XS",
+							"Basic Gas Cylinder S",
+							"Basic Gas Cylinder M"
+						]
+					},
+					{
+						"name": "Ionic Chambers",
+						"data": [
+							"Basic Ionic Chamber XS",
+							"Basic Ionic Chamber S",
+							"Basic Ionic Chamber M",
+							"Basic Ionic Chamber L",
+							"Basic Ionic Chamber XL",
+							"Uncommon Ionic Chamber XS",
+							"Uncommon Ionic Chamber S",
+							"Uncommon Ionic Chamber M",
+							"Uncommon Ionic Chamber L",
+							"Uncommon Ionic Chamber XL",
+							"Advanced Ionic Chamber XS",
+							"Advanced Ionic Chamber S",
+							"Advanced Ionic Chamber M",
+							"Advanced Ionic Chamber L",
+							"Advanced Ionic Chamber XL",
+							"Rare Ionic Chamber XS",
+							"Rare Ionic Chamber S",
+							"Rare Ionic Chamber M",
+							"Rare Ionic Chamber L",
+							"Rare Ionic Chamber XL"
+						]
+					},
+					{
+						"name": "Laser Chambers",
+						"data": [
+							"Basic Laser Chamber S",
+							"Uncommon Laser Chamber XS",
+							"Advanced Laser Chamber XS",
+							"Advanced Laser Chamber S",
+							"Advanced Laser Chamber M",
+							"Advanced Laser Chamber L",
+							"Rare Laser Chamber XS",
+							"Rare Laser Chamber S",
+							"Rare Laser Chamber M",
+							"Rare Laser Chamber L",
+							"Exotic Laser Chamber XS",
+							"Exotic Laser Chamber S",
+							"Exotic Laser Chamber M",
+							"Exotic Laser Chamber L"
+						]
+					},
+					{
+						"name": "Lights",
+						"data": [
+							"Uncommon Light XS",
+							"Uncommon Light S"
+						]
+					},
+					{
+						"name": "Magnetic Rails",
+						"data": [
+							"Advanced Magnetic Rail XS",
+							"Advanced Magnetic Rail S",
+							"Advanced Magnetic Rail M",
+							"Advanced Magnetic Rail L",
+							"Rare Magnetic Rail XS",
+							"Rare Magnetic Rail S",
+							"Rare Magnetic Rail M",
+							"Rare Magnetic Rail L",
+							"Exotic Magnetic Rail XS",
+							"Exotic Magnetic Rail S",
+							"Exotic Magnetic Rail M",
+							"Exotic Magnetic Rail L"
+						]
+					},
+					{
+						"name": "Mechanical Sensors",
+						"data": [
+							"Basic Mechanical Sensor XS",
+							"Advanced Mechanical Sensor XS",
+							"Exotic Mechanical Sensor XS"
+						]
+					},
+					{
+						"name": "Missile Silos",
+						"data": [
+							"Advanced Missile Silo XS",
+							"Advanced Missile Silo S",
+							"Advanced Missile Silo M",
+							"Advanced Missile Silo L",
+							"Rare Missile Silo XS",
+							"Rare Missile Silo S",
+							"Rare Missile Silo M",
+							"Rare Missile Silo L",
+							"Exotic Missile Silo XS",
+							"Exotic Missile Silo S",
+							"Exotic Missile Silo M",
+							"Exotic Missile Silo L"
+						]
+					},
+					{
+						"name": "Mobile Panels",
+						"data": [
+							"Basic Mobile Panel XS",
+							"Basic Mobile Panel S",
+							"Basic Mobile Panel M",
+							"Basic Mobile Panel L",
+							"Basic Mobile Panel XL",
+							"Uncommon Mobile Panel XS",
+							"Uncommon Mobile Panel S",
+							"Uncommon Mobile Panel M",
+							"Uncommon Mobile Panel L",
+							"Uncommon Mobile Panel XL",
+							"Advanced Mobile Panel XS",
+							"Advanced Mobile Panel S",
+							"Advanced Mobile Panel M",
+							"Advanced Mobile Panel L",
+							"Advanced Mobile Panel XL",
+							"Rare Mobile Panel XS",
+							"Rare Mobile Panel S",
+							"Rare Mobile Panel M",
+							"Rare Mobile Panel L",
+							"Rare Mobile Panel XL"
+						]
+					},
+					{
+						"name": "Motherboards",
+						"data": [
+							"Advanced Motherboard M"
+						]
+					},
+					{
+						"name": "Ore Scanners",
+						"data": [
+							"Uncommon Ore Scanner XL"
+						]
+					},
+					{
+						"name": "Power Transformer",
+						"data": [
+							"Basic Power Transformer M",
+							"Uncommon Power Transformer S",
+							"Uncommon Power Transformer M",
+							"Advanced Power Transformer M",
+							"Rare Power Transformer M",
+							"Rare Power Transformer L",
+							"Rare Power Transformer XL"
+						]
+					},
+					{
+						"name": "Robotic Arms",
+						"data": [
+							"Basic Robotic Arm M",
+							"Basic Robotic Arm L",
+							"Basic Robotic Arm XL",
+							"Uncommon Robotic Arm M",
+							"Advanced Robotic Arm M",
+							"Rare Robotic Arm M"
+						]
+					},
+					{
+						"name": "Screens",
+						"data": [
+							"Basic Screen S",
+							"Basic Screen M",
+							"Uncommon Screen XS",
+							"Uncommon Screen L",
+							"Uncommon Screen XL",
+							"Advanced Screen XS",
+							"Advanced Screen XL"
 						]
 					}
 				]
@@ -1643,212 +2692,6 @@
 				]
 			},
 			{
-				"name": "Functional Parts",
-				"data": [
-					{
-						"name": "Antennas",
-						"data": [
-							"Basic Antenna XS",
-							"Basic Antenna S",
-							"Uncommon Antenna XS",
-							"Uncommon Antenna S",
-							"Uncommon Antenna M",
-							"Uncommon Antenna L",
-							"Exotic Antenna M",
-							"Exotic Antenna L",
-							"Exotic Antenna XL"
-						]
-					},
-					{
-						"name": "Chemical Containers",
-						"data": [
-							"Basic Chemical Container XS",
-							"Basic Chemical Container S",
-							"Basic Chemical Container M",
-							"Basic Chemical Container L",
-							"Basic Chemical Container XL",
-							"Advanced Chemical Container S",
-							"Advanced Chemical Container M",
-							"Advanced Chemical Container L",
-							"Advanced Chemical Container XL"
-						]
-					},
-					{
-						"name": "Combustion Chambers",
-						"data": [
-							"Basic Combustion Chamber XS",
-							"Basic Combustion Chamber S",
-							"Basic Combustion Chamber M",
-							"Basic Combustion Chamber L",
-							"Advanced Combustion Chamber XS",
-							"Advanced Combustion Chamber S",
-							"Advanced Combustion Chamber M"
-						]
-					},
-					{
-						"name": "Control Systems",
-						"data": [
-							"Basic Control System XS",
-							"Basic Control System S",
-							"Basic Control System M",
-							"Advanced Control System S",
-							"Advanced Control System M",
-							"Advanced Control System L"
-						]
-					},
-					{
-						"name": "Core Systems",
-						"data": [
-							"Basic Core System XS",
-							"Basic Core System S",
-							"Uncommon Core System S",
-							"Uncommon Core System M",
-							"Uncommon Core System L",
-							"Advanced Core System M",
-							"Rare Core System L",
-							"Exotic Core System S"
-						]
-					},
-					{
-						"name": "Electric Engines",
-						"data": [
-							"Basic Electric Engine S",
-							"Basic Electric Engine M",
-							"Uncommon Electric Engine XL"
-						]
-					},
-					{
-						"name": "Firing Systems",
-						"data": [
-							"Basic Firing System XS",
-							"Advanced Firing System XS",
-							"Advanced Firing System S",
-							"Advanced Firing System M",
-							"Advanced Firing System L"
-						]
-					},
-					{
-						"name": "Gas Cylinders",
-						"data": [
-							"Basic Gas Cylinder XS",
-							"Basic Gas Cylinder S",
-							"Basic Gas Cylinder M"
-						]
-					},
-					{
-						"name": "Ionic Chambers",
-						"data": [
-							"Basic Ionic Chamber XS",
-							"Basic Ionic Chamber S",
-							"Basic Ionic Chamber M",
-							"Basic Ionic Chamber L",
-							"Basic Ionic Chamber XL",
-							"Uncommon Ionic Chamber XS",
-							"Uncommon Ionic Chamber S",
-							"Uncommon Ionic Chamber M",
-							"Uncommon Ionic Chamber L",
-							"Uncommon Ionic Chamber XL",
-							"Advanced Ionic Chamber M",
-							"Advanced Ionic Chamber L"
-						]
-					},
-					{
-						"name": "Laser Chambers",
-						"data": [
-							"Uncommon Laser Chamber XS",
-							"Advanced Laser Chamber XS",
-							"Advanced Laser Chamber S",
-							"Advanced Laser Chamber M",
-							"Advanced Laser Chamber L",
-							"Rare Laser Chamber S"
-						]
-					},
-					{
-						"name": "Lights",
-						"data": [
-							"Uncommon Light XS",
-							"Uncommon Light S"
-						]
-					},
-					{
-						"name": "Magnetic Rails",
-						"data": [
-							"Advanced Magnetic Rail XS",
-							"Advanced Magnetic Rail S",
-							"Advanced Magnetic Rail M",
-							"Advanced Magnetic Rail L"
-						]
-					},
-					{
-						"name": "Mechanical Sensors",
-						"data": [
-							"Basic Mechanical Sensor XS",
-							"Advanced Mechanical Sensor XS",
-							"Exotic Mechanical Sensor XS"
-						]
-					},
-					{
-						"name": "Missile Silos",
-						"data": [
-							"Advanced Missile Silo XS",
-							"Advanced Missile Silo S",
-							"Advanced Missile Silo M",
-							"Advanced Missile Silo L"
-						]
-					},
-					{
-						"name": "Mobile Panels",
-						"data": [
-							"Basic Mobile Panel XS",
-							"Basic Mobile Panel S",
-							"Basic Mobile Panel M",
-							"Basic Mobile Panel L",
-							"Basic Mobile Panel XL"
-						]
-					},
-					{
-						"name": "Motherboards",
-						"data": [
-							"Advanced Motherboard M"
-						]
-					},
-					{
-						"name": "Ore Scanners",
-						"data": [
-							"Uncommon Ore Scanner XL"
-						]
-					},
-					{
-						"name": "Power Transformers",
-						"data": [
-							"Basic Power Transformer M",
-							"Uncommon Power Transformer S",
-							"Uncommon Power Transformer M",
-							"Rare Power Transformer L",
-							"Rare Power Transformer XL",
-							"Exotic Power Transformer L"
-						]
-					},
-					{
-						"name": "Robotic Arms",
-						"data": [
-							"Basic Robotic Arm M",
-							"Basic Robotic Arm L",
-							"Basic Robotic Arm XL"
-						]
-					},
-					{
-						"name": "Screens",
-						"data": [
-							"Basic Screen M",
-							"Uncommon Screen XS",
-							"Uncommon Screen XL",
-							"Advanced Screen XS"
-						]
-					}
-				]
-			},
-			{
 				"name": "Structural Parts",
 				"data": [
 					{
@@ -1866,7 +2709,6 @@
 							"Advanced Casing L",
 							"Advanced Casing XL",
 							"Rare Casing XS",
-							"Rare Casing S",
 							"Exotic Casing S"
 						]
 					},
@@ -1887,8 +2729,14 @@
 							"Advanced Reinforced Frame S",
 							"Advanced Reinforced Frame M",
 							"Advanced Reinforced Frame L",
+							"Advanced Reinforced Frame XL",
+							"Rare Reinforced Frame XS",
+							"Rare Reinforced Frame S",
+							"Rare Reinforced Frame M",
 							"Rare Reinforced Frame L",
 							"Rare Reinforced Frame XL",
+							"Exotic Reinforced Frame XS",
+							"Exotic Reinforced Frame S",
 							"Exotic Reinforced Frame M",
 							"Exotic Reinforced Frame L",
 							"Exotic Reinforced Frame XL"
@@ -1909,8 +2757,13 @@
 							"Advanced Standard Frame S",
 							"Advanced Standard Frame M",
 							"Advanced Standard Frame L",
+							"Advanced Standard Frame XL",
+							"Rare Standard Frame S",
+							"Rare Standard Frame M",
 							"Rare Standard Frame L",
 							"Exotic Standard Frame XS",
+							"Exotic Standard Frame S",
+							"Exotic Standard Frame M",
 							"Exotic Standard Frame L"
 						]
 					}

--- a/data/itemsAccordion.json
+++ b/data/itemsAccordion.json
@@ -1,1922 +1,1921 @@
 [
-  {
-    "name": "Consumables",
-    "data": [
-		{
-			"name": "Ammo",
-			"data": [
-				{
-					"name": "Cannon Ammo",
-					"data": [
-						{
-							"name": "Extra-Small Cannon Ammo",
-							"data": [
-								{
-									"name": "Kinetic Ammo",
-									"data": [
-										"Cannon Agile Kinetic Ammo XS",
-										"Cannon Defense Kinetic Ammo XS",
-										"Cannon Heavy Kinetic Ammo XS",
-										"Cannon Kinetic Ammo XS",
-										"Cannon Precision Kinetic Ammo XS"
-									]
-								},
-								{
-									"name": "Thermic Ammo",
-									"data": [
-										"Cannon Agile Thermic Ammo XS",
-										"Cannon Defense Thermic Ammo XS",
-										"Cannon Heavy Thermic Ammo XS",
-										"Cannon Thermic Ammo XS",
-										"Cannon Precision Thermic Ammo XS"
-									]
-								}
-							]
-						},
-						{
-							"name": "Small Cannon Ammo",
-							"data": [
-								{
-									"name": "Kinetic Ammo",
-									"data": [
-										"Cannon Agile Kinetic Ammo S",
-										"Cannon Defense Kinetic Ammo S",
-										"Cannon Heavy Kinetic Ammo S",
-										"Cannon Kinetic Ammo S",
-										"Cannon Precision Kinetic Ammo S"
-									]
-								},
-								{
-									"name": "Thermic Ammo",
-									"data": [
-										"Cannon Agile Thermic Ammo S",
-										"Cannon Defense Thermic Ammo S",
-										"Cannon Heavy Thermic Ammo S",
-										"Cannon Thermic Ammo S",
-										"Cannon Precision Thermic Ammo S"
-									]
-								}
-							]
-						},
-						{
-							"name": "Medium Cannon Ammo",
-							"data": [
-								{
-									"name": "Kinetic Ammo",
-									"data": [
-										"Cannon Agile Kinetic Ammo M",
-										"Cannon Defense Kinetic Ammo M",
-										"Cannon Heavy Kinetic Ammo M",
-										"Cannon Kinetic Ammo M",
-										"Cannon Precision Kinetic Ammo M"
-									]
-								},
-								{
-									"name": "Thermic Ammo",
-									"data": [
-										"Cannon Agile Thermic Ammo M",
-										"Cannon Defense Thermic Ammo M",
-										"Cannon Heavy Thermic Ammo M",
-										"Cannon Thermic Ammo M",
-										"Cannon Precision Thermic Ammo M"
-									]
-								}
-							]
-						},
-						{
-							"name": "Large Cannon Ammo",
-							"data": [
-								{
-									"name": "Kinetic Ammo",
-									"data": [
-										"Cannon Agile Kinetic Ammo L",
-										"Cannon Defense Kinetic Ammo L",
-										"Cannon Heavy Kinetic Ammo L",
-										"Cannon Kinetic Ammo L",
-										"Cannon Precision Kinetic Ammo L"
-									]
-								},
-								{
-									"name": "Thermic Ammo",
-									"data": [
-										"Cannon Agile Thermic Ammo L",
-										"Cannon Defense Thermic Ammo L",
-										"Cannon Heavy Thermic Ammo L",
-										"Cannon Thermic Ammo L",
-										"Cannon Precision Thermic Ammo L"
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"name": "Laser Ammo",
-					"data": [
-						{
-							"name": "Extra-Small Laser Ammo",
-							"data": [
-								{
-									"name": "Electromagnetic Ammo",
-									"data": [
-										"Laser Agile Electromagnetic Ammo XS",
-										"Laser Defense Electromagnetic Ammo XS",
-										"Laser Heavy Electromagnetic Ammo XS",
-										"Laser Electromagnetic Ammo XS",
-										"Laser Precision Electromagnetic Ammo XS"
-									]
-								},
-								{
-									"name": "Thermic Ammo",
-									"data": [
-										"Laser Agile Thermic Ammo XS",
-										"Laser Defense Thermic Ammo XS",
-										"Laser Heavy Thermic Ammo XS",
-										"Laser Thermic Ammo XS",
-										"Laser Precision Thermic Ammo XS"
-									]
-								}
-							]
-						},
-						{
-							"name": "Small Laser Ammo",
-							"data": [
-								{
-									"name": "Electromagnetic Ammo",
-									"data": [
-										"Laser Agile Electromagnetic Ammo S",
-										"Laser Defense Electromagnetic Ammo S",
-										"Laser Heavy Electromagnetic Ammo S",
-										"Laser Electromagnetic Ammo S",
-										"Laser Precision Electromagnetic Ammo S"
-									]
-								},
-								{
-									"name": "Thermic Ammo",
-									"data": [
-										"Laser Agile Thermic Ammo S",
-										"Laser Defense Thermic Ammo S",
-										"Laser Heavy Thermic Ammo S",
-										"Laser Thermic Ammo S",
-										"Laser Precision Thermic Ammo S"
-									]
-								}
-							]
-						},
-						{
-							"name": "Medium Laser Ammo",
-							"data": [
-								{
-									"name": "Electromagnetic Ammo",
-									"data": [
-										"Laser Agile Electromagnetic Ammo M",
-										"Laser Defense Electromagnetic Ammo M",
-										"Laser Heavy Electromagnetic Ammo M",
-										"Laser Electromagnetic Ammo M",
-										"Laser Precision Electromagnetic Ammo M"
-									]
-								},
-								{
-									"name": "Thermic Ammo",
-									"data": [
-										"Laser Agile Thermic Ammo M",
-										"Laser Defense Thermic Ammo M",
-										"Laser Heavy Thermic Ammo M",
-										"Laser Thermic Ammo M",
-										"Laser Precision Thermic Ammo M"
-									]
-								}
-							]
-						},
-						{
-							"name": "Large Laser Ammo",
-							"data": [
-								{
-									"name": "Electromagnetic Ammo",
-									"data": [
-										"Laser Agile Electromagnetic Ammo L",
-										"Laser Defense Electromagnetic Ammo L",
-										"Laser Heavy Electromagnetic Ammo L",
-										"Laser Electromagnetic Ammo L",
-										"Laser Precision Electromagnetic Ammo L"
-									]
-								},
-								{
-									"name": "Thermic Ammo",
-									"data": [
-										"Laser Agile Thermic Ammo L",
-										"Laser Defense Thermic Ammo L",
-										"Laser Heavy Thermic Ammo L",
-										"Laser Thermic Ammo L",
-										"Laser Precision Thermic Ammo L"
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"name": "Missile Pod Ammo",
-					"data": [
-						{
-							"name": "Extra-Small Missile Ammo",
-							"data": [
-								{
-									"name": "Antimatter Ammo",
-									"data": [
-										"Missile Agile Antimatter Ammo XS",
-										"Missile Defense Antimatter Ammo XS",
-										"Missile Heavy Antimatter Ammo XS",
-										"Missile Antimatter Ammo XS",
-										"Missile Precision Antimatter Ammo XS"
-									]
-								},
-								{
-									"name": "Kinetic Ammo",
-									"data": [
-										"Missile Agile Kinetic Ammo XS",
-										"Missile Defense Kinetic Ammo XS",
-										"Missile Heavy Kinetic Ammo XS",
-										"Missile Kinetic Ammo XS",
-										"Missile Precision Kinetic Ammo XS"
-									]
-								}
-							]
-						},
-						{
-							"name": "Small Missile Ammo",
-							"data": [
-								{
-									"name": "Antimatter Ammo",
-									"data": [
-										"Missile Agile Antimatter Ammo S",
-										"Missile Defense Antimatter Ammo S",
-										"Missile Heavy Antimatter Ammo S",
-										"Missile Antimatter Ammo S",
-										"Missile Precision Antimatter Ammo S"
-									]
-								},
-								{
-									"name": "Kinetic Ammo",
-									"data": [
-										"Missile Agile Kinetic Ammo S",
-										"Missile Defense Kinetic Ammo S",
-										"Missile Heavy Kinetic Ammo S",
-										"Missile Kinetic Ammo S",
-										"Missile Precision Kinetic Ammo S"
-									]
-								}
-							]
-						},
-						{
-							"name": "Medium Missile Ammo",
-							"data": [
-								{
-									"name": "Antimatter Ammo",
-									"data": [
-										"Missile Agile Antimatter Ammo M",
-										"Missile Defense Antimatter Ammo M",
-										"Missile Heavy Antimatter Ammo M",
-										"Missile Antimatter Ammo M",
-										"Missile Precision Antimatter Ammo M"
-									]
-								},
-								{
-									"name": "Kinetic Ammo",
-									"data": [
-										"Missile Agile Kinetic Ammo M",
-										"Missile Defense Kinetic Ammo M",
-										"Missile Heavy Kinetic Ammo M",
-										"Missile Kinetic Ammo M",
-										"Missile Precision Kinetic Ammo M"
-									]
-								}
-							]
-						},
-						{
-							"name": "Large Missile Ammo",
-							"data": [
-								{
-									"name": "Antimatter Ammo",
-									"data": [
-										"Missile Agile Antimatter Ammo L",
-										"Missile Defense Antimatter Ammo L",
-										"Missile Heavy Antimatter Ammo L",
-										"Missile Antimatter Ammo L",
-										"Missile Precision Antimatter Ammo L"
-									]
-								},
-								{
-									"name": "Kinetic Ammo",
-									"data": [
-										"Missile Agile Kinetic Ammo L",
-										"Missile Defense Kinetic Ammo L",
-										"Missile Heavy Kinetic Ammo L",
-										"Missile Kinetic Ammo L",
-										"Missile Precision Kinetic Ammo L"
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"name": "Railgun Pod Ammo",
-					"data": [
-						{
-							"name": "Extra-Small Railgun Ammo",
-							"data": [
-								{
-									"name": "Antimatter Ammo",
-									"data": [
-										"Railgun Agile Antimatter Ammo XS",
-										"Railgun Defense Antimatter Ammo XS",
-										"Railgun Heavy Antimatter Ammo XS",
-										"Railgun Antimatter Ammo XS",
-										"Railgun Precision Antimatter Ammo XS"
-									]
-								},
-								{
-									"name": "Electromagnetic Ammo",
-									"data": [
-										"Railgun Agile Electromagnetic Ammo XS",
-										"Railgun Defense Electromagnetic Ammo XS",
-										"Railgun Heavy Electromagnetic Ammo XS",
-										"Railgun Electromagnetic Ammo XS",
-										"Railgun Precision Electromagnetic Ammo XS"
-									]
-								}
-							]
-						},
-						{
-							"name": "Small Railgun Ammo",
-							"data": [
-								{
-									"name": "Antimatter Ammo",
-									"data": [
-										"Railgun Agile Antimatter Ammo S",
-										"Railgun Defense Antimatter Ammo S",
-										"Railgun Heavy Antimatter Ammo S",
-										"Railgun Antimatter Ammo S",
-										"Railgun Precision Antimatter Ammo S"
-									]
-								},
-								{
-									"name": "Electromagnetic Ammo",
-									"data": [
-										"Railgun Agile Electromagnetic Ammo S",
-										"Railgun Defense Electromagnetic Ammo S",
-										"Railgun Heavy Electromagnetic Ammo S",
-										"Railgun Electromagnetic Ammo S",
-										"Railgun Precision Electromagnetic Ammo S"
-									]
-								}
-							]
-						},
-						{
-							"name": "Medium Railgun Ammo",
-							"data": [
-								{
-									"name": "Antimatter Ammo",
-									"data": [
-										"Railgun Agile Antimatter Ammo M",
-										"Railgun Defense Antimatter Ammo M",
-										"Railgun Heavy Antimatter Ammo M",
-										"Railgun Antimatter Ammo M",
-										"Railgun Precision Antimatter Ammo M"
-									]
-								},
-								{
-									"name": "Electromagnetic Ammo",
-									"data": [
-										"Railgun Agile Electromagnetic Ammo M",
-										"Railgun Defense Electromagnetic Ammo M",
-										"Railgun Heavy Electromagnetic Ammo M",
-										"Railgun Electromagnetic Ammo M",
-										"Railgun Precision Electromagnetic Ammo M"
-									]
-								}
-							]
-						},
-						{
-							"name": "Large Railgun Ammo",
-							"data": [
-								{
-									"name": "Antimatter Ammo",
-									"data": [
-										"Railgun Agile Antimatter Ammo L",
-										"Railgun Defense Antimatter Ammo L",
-										"Railgun Heavy Antimatter Ammo L",
-										"Railgun Antimatter Ammo L",
-										"Railgun Precision Antimatter Ammo L"
-									]
-								},
-								{
-									"name": "Electromagnetic Ammo",
-									"data": [
-										"Railgun Agile Electromagnetic Ammo L",
-										"Railgun Defense Electromagnetic Ammo L",
-										"Railgun Heavy Electromagnetic Ammo L",
-										"Railgun Electromagnetic Ammo L",
-										"Railgun Precision Electromagnetic Ammo L"
-									]
-								}
-							]
-						}
-					]
-				}
-			]
-		},
-      {
-        "name": "Elements",
-        "data": [
-          {
-            "name": "Construct Elements",
-            "data": [
-              {
-                "name": "Decorative Element",
-                "data": [
-                  {
-                    "name": "Adjuncts",
-                    "data": [
-                      "Vertical Wing",
-                      "Wing Tip S",
-                      "Wing Tip M",
-                      "Wing Tip L"
-                    ]
-                  },
-                  {
-                    "name": "Antennas",
-                    "data": [
-                      "Antenna S",
-                      "Antenna M",
-                      "Antenna L"
-                    ]
-                  },
-                  {
-                    "name": "Barriers",
-                    "data": [
-                      "Barrier Corner",
-                      "Barrier S",
-                      "Barrier M"
-                    ]
-                  },
-                  {
-                    "name": "Bathroom Elements",
-                    "data": [
-                      "Shower Unit",
-                      "Sink Unit",
-                      "Toilet Unit A",
-                      "Toilet Unit B",
-                      "Urinal Unit"
-                    ]
-                  },
-                  {
-                    "name": "Decorative Cables",
-                    "data": [
-                      "Cable Model-A S",
-                      "Cable Model-A M",
-                      "Cable Model-B S",
-                      "Cable Model-B M",
-                      "Cable Model-C S",
-                      "Cable Model-C M",
-                      "Corner Cable Model-A",
-                      "Corner Cable Model-B",
-                      "Corner Cable Model-C"
-                    ]
-                  },
-                  {
-                    "name": "Furnitures",
-                    "data": [
-                      "\"Eye Doll's Workshop\" - Artist Unknown",
-                      "\"HMS Ajax33\" - Artist Unknown",
-                      "\"Parrotos Sanctuary\" - Artist Unknown",
-                      "Bed",
-                      "Bench",
-                      "Dresser",
-                      "Nightstand",
-                      "Round Carpet",
-                      "Shelf Empty",
-                      "Shelf Full",
-                      "Shelf Half Full",
-                      "Sofa",
-                      "Square Carpet",
-                      "Table",
-                      "Trash",
-                      "Wardrobe",
-                      "Wooden Armchair",
-                      "Wooden Chair",
-                      "Wooden Dresser",
-                      "Wooden Low Table",
-                      "Wooden Sofa",
-                      "Wooden Table L",
-                      "Wooden Table M",
-                      "Wooden Wardrobe",
-					  "Navigator Chair",
-					  "Office Chair",
-					  "Encampment Chair"
-                    ]
-                  },
-                  {
-                    "name": "Holograms",
-                    "data": [
-                      "Planet Hologram",
-                      "Planet Hologram L",
-                      "Spaceship Hologram S",
-                      "Spaceship Hologram M",
-                      "Spaceship Hologram L"
-                    ]
-                  },
-                  {
-                    "name": "Hull Decoration",
-                    "data": [
-                      "Hull Decorative Element A",
-                      "Hull Decorative Element B",
-                      "Hull Decorative Element C",
-                      "Steel Column",
-                      "Steel Panel"
-                    ]
-                  },
-                  {
-                    "name": "Pipes",
-                    "data": [
-                      "Pipe A M",
-                      "Pipe B M",
-                      "Pipe C M",
-                      "Pipe D M",
-                      "Pipe Connector M",
-                      "Pipe Corner M"
-                    ]
-                  },
-                  {
-                    "name": "Plants",
-                    "data": [
-                      "Suspended Plant A",
-                      "Bagged Plant A",
-                      "Bagged Plant B",
-                      "Bonsai",
-                      "Eggplant Plant Case",
-                      "Ficus Plant A",
-                      "Ficus Plant B",
-                      "Foliage Plant Case A",
-                      "Foliage Plant Case B",
-                      "Plant",
-                      "Plant Case A",
-                      "Plant Case B",
-                      "Plant Case C",
-                      "Plant Case D",
-                      "Plant Case E",
-                      "Plant Case S",
-                      "Plant Case M"
-                    ]
-                  },
-                  {
-                    "name": "Windows",
-                    "data": [
-                      "Armored Window XS",
-                      "Armored Window S",
-                      "Armored Window M",
-                      "Armored Window L",
-                      "Bay Window XL",
-                      "Glass Panel S",
-                      "Glass Panel M",
-                      "Glass Panel L",
-                      "Window XS",
-                      "Window S",
-                      "Window M",
-                      "Window L"
-                    ]
-                  },
-                  "Keyboard Unit"
-                ]
-              },
-              {
-                "name": "Industry",
-                "data": [
-                  "Assembly Line XS",
-                  "Assembly Line S",
-                  "Assembly Line M",
-                  "Assembly Line L",
-                  "Assembly Line XL",
-                  "3D Printer M",
-                  "Chemical Industry M",
-                  "Electronics Industry M",
-                  "Glass Furnace M",
-                  "Honeycomb Refinery M",
-                  "Metalwork Industry M",
-                  "Recycler M",
-                  "Refiner M",
-                  "Smelter M",
-                  "Transfer Unit"
-                ]
-              },
-              {
-                "name": "Anti-Gravity Generator",
-                "data": [
-                  "Anti-Gravity Generator S",
-                  "Anti-Gravity Generator M",
-                  "Anti-Gravity Generator L"
-                ]
-              },
-              {
-                "name": "Anti-Gravity Pulsors",
-                "data": [
-                  "Anti-Gravity Pulsor"
-                ]
-              },
-              {
-                "name": "Containers",
-                "data": [
-                  {
-                    "name": "Dispensers",
-                    "data": [
-                      "Dispenser",
-                      "Medium Dispenser",
-                      "Heavy Dispenser"
-                    ]
-                  },
-                  {
-                    "name": "Fuel Tanks",
-                    "data": [
-                      {
-                        "name": "Atmospheric Fuel Containers",
-                        "data": [
-                          "Atmospheric Fuel-Tank XS",
-                          "Atmospheric Fuel-Tank S",
-                          "Atmospheric Fuel-Tank M",
-                          "Atmospheric Fuel-Tank L"
-                        ]
-                      },
-                      {
-                        "name": "Rocket Fuel Containers",
-                        "data": [
-                          "Rocket Fuel-Tank XS",
-                          "Rocket Fuel-Tank S",
-                          "Rocket Fuel-Tank M",
-                          "Rocket Fuel-Tank L"
-                        ]
-                      },
-                      {
-                        "name": "Space Fuel Containers",
-                        "data": [
-                          "Space Fuel-Tank S",
-                          "Space Fuel-Tank M",
-                          "Space Fuel-Tank L"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "name": "Item Containers",
-                    "data": [
-                      "Container Hub",
-                      "Container XS",
-                      "Container S",
-                      "Container M",
-                      "Container L"
-                    ]
-                  },
-                  {
-                    "name": "Ammo Containers",
-                    "data": [
-                      "Ammo Container XS",
-                      "Ammo Container S",
-                      "Ammo Container M",
-                      "Ammo Container L"
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "Control Units",
-                "data": [
-                  "Emergency Controller",
-                  "Hovercraft Seat Controller",
-                  "Cockpit Controller",
-                  "Command Seat Controller",
-                  "Programming Board",
-                  "Remote Controller"
-                ]
-              },
-              {
-                "name": "Electronics",
-                "data": [
-                  {
-                    "name": "AND Operators",
-                    "data": [
-                      "AND Operator"
-                    ]
-                  },
-                  {
-                    "name": "NOT Operators",
-                    "data": [
-                      "NOT Operator"
-                    ]
-                  },
-                  {
-                    "name": "OR Operators",
-                    "data": [
-                      "OR Operator"
-                    ]
-                  },
-                  {
-                    "name": "Counters",
-                    "data": [
-                      "2 Counter",
-                      "3 Counter",
-                      "5 Counter",
-                      "7 Counter",
-                      "10 Counter"
-                    ]
-                  },
-                  {
-                    "name": "Data Banks",
-                    "data": [
-                      "Databank"
-                    ]
-                  },
-                  {
-                    "name": "Data Emitters",
-                    "data": [
-                      "Emitter XS",
-                      "Emitter S",
-                      "Emitter M"
-                    ]
-                  },
-                  {
-                    "name": "Delay Lines",
-                    "data": [
-                      "Delay Line"
-                    ]
-                  },
-                  {
-                    "name": "Laser Emitters",
-                    "data": [
-                      "Infra-Red Laser Emitter",
-                      "Laser Emitter"
-                    ]
-                  },
-                  {
-                    "name": "Receivers",
-                    "data": [
-                      "Receiver XS",
-                      "Receiver S",
-                      "Receiver M"
-                    ]
-                  },
-                  {
-                    "name": "Relays",
-                    "data": [
-                      "Relay"
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "Engines",
-                "data": [
-                  {
-                    "name": "Adjustors",
-                    "data": [
-                      "Adjustor XS",
-                      "Adjustor S",
-                      "Adjustor M",
-                      "Adjustor L"
-                    ]
-                  },
-                  {
-                    "name": "Airbrakes",
-                    "data": [
-                      "Atmospheric Airbrake S",
-                      "Atmospheric Airbrake M",
-                      "Atmospheric Airbrake L"
-                    ]
-                  },
-                  {
-                    "name": "Airfoil",
-                    "data": [
-                      {
-                        "name": "Aileron",
-                        "data": [
-                          "Aileron XS",
-                          "Aileron S",
-                          "Aileron M",
-                          "Compact Aileron XS",
-                          "Compact Aileron S",
-                          "Compact Aileron M"
-                        ]
-                      },
-                      {
-                        "name": "Stabilizer",
-                        "data": [
-                          "Stabilizer XS",
-                          "Stabilizer S",
-                          "Stabilizer M",
-                          "Stabilizer L"
-                        ]
-                      },
-                      {
-                        "name": "Wing",
-                        "data": [
-                          "Wing XS",
-                          "Wing S",
-                          "Wing M",
-                          "Wing Variant M"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "name": "Atmospheric Engines",
-                    "data": [
-						{
-							"name": "Atmospheric Engines XS",
-							"data": [
-							  "Atmospheric Engine XS",
-							  "Freight Atmospheric Engine XS",
-							  "Maneuver Atmospheric Engine XS",
-							  "Military Atmospheric Engine XS",
-							  "Safe Atmospheric Engine XS"
-							]
-						},
-						{
-							"name": "Atmospheric Engines S",
-							"data": [
-							  "Atmospheric Engine S",
-							  "Freight Atmospheric Engine S",
-							  "Maneuver Atmospheric Engine S",
-							  "Military Atmospheric Engine S",
-							  "Safe Atmospheric Engine S"
-							]
-						},
-						{
-							"name": "Atmospheric Engines M",
-							"data": [
-							  "Atmospheric Engine M",
-							  "Freight Atmospheric Engine M",
-							  "Maneuver Atmospheric Engine M",
-							  "Military Atmospheric Engine M",
-							  "Safe Atmospheric Engine M"
-							]
-						},
-						{
-							"name": "Atmospheric Engines L",
-							"data": [
-							  "Atmospheric Engine L",
-							  "Freight Atmospheric Engine L",
-							  "Maneuver Atmospheric Engine L",
-							  "Military Atmospheric Engine L",
-							  "Safe Atmospheric Engine L"
-							]
-						}
-                    ]
-                  },
-                  {
-                    "name": "Hovercraft Engines",
-                    "data": [
-                      "Hover Engine S",
-                      "Hover Engine M",
-                      "Hover Engine L",
-                      "Flat Hover Engine L"
-                    ]
-                  },
-                  {
-                    "name": "Rocket Engines",
-                    "data": [
-                      "Rocket Engine S",
-                      "Rocket Engine M",
-                      "Rocket Engine L"
-                    ]
-                  },
-                  {
-                    "name": "Space Brakes",
-                    "data": [
-                      "Retro-Rocket Brake S",
-                      "Retro-Rocket Brake M",
-                      "Retro-Rocket Brake L"
-                    ]
-                  },
-                  {
-                    "name": "Space Engines",
-                    "data": [
-						{
-							"name": "Space Engines XS",
-							"data": [
-							  "Space Engine XS",
-							  "Freight Space Engine XS",
-							  "Maneuver Space Engine XS",
-							  "Military Space Engine XS",
-							  "Safe Space Engine XS"
-							]
-						},
-						{
-							"name": "Space Engines S",
-							"data": [
-							  "Space Engine S",
-							  "Freight Space Engine S",
-							  "Maneuver Space Engine S",
-							  "Military Space Engine S",
-							  "Safe Space Engine S"
-							]
-						},
-						{
-							"name": "Space Engines M",
-							"data": [
-							  "Space Engine M",
-							  "Freight Space Engine M",
-							  "Maneuver Space Engine M",
-							  "Military Space Engine M",
-							  "Safe Space Engine M"
-							]
-						},
-						{
-							"name": "Space Engines L",
-							"data": [
-							  "Space Engine L",
-							  "Freight Space Engine L",
-							  "Maneuver Space Engine L",
-							  "Military Space Engine L",
-							  "Safe Space Engine L"
-							]
-						},
-						{
-							"name": "Space Engines XL",
-							"data": [
-							  "Space Engine XL",
-							  "Freight Space Engine XL",
-							  "Maneuver Space Engine XL",
-							  "Military Space Engine XL",
-							  "Safe Space Engine XL"
-							]
-						}
-                    ]
-                  },
-                  {
-                    "name": "Vertical Boosters",
-                    "data": [
-                      "Vertical Booster XS",
-                      "Vertical Booster S",
-                      "Vertical Booster M",
-                      "Vertical Booster L"
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "Instruments",
-                "data": [
-                  "Gyroscope",
-                  "Telemeter",
-                  "Territory Scanner"
-                ]
-              },
-              {
-                "name": "Interactive Elements",
-                "data": [
-                  {
-                    "name": "Doors",
-                    "data": [
-                      "Airlock",
-                      "Interior Door",
-                      "Reinforced Sliding Door",
-                      "Sliding Door S",
-                      "Sliding Door M",
-                      "Gate XS",
-                      "Expanded Gate S",
-                      "Gate M",
-                      "Expanded Gate L",
-                      "Gate XL",
-					  "Hatch S",
-					  "Fuel Intake XS"
-                    ]
-                  },
-                  {
-                    "name": "Elevators",
-                    "data": [
-                      "Elevator XS"
-                    ]
-                  },
-                  {
-                    "name": "Force Fields",
-                    "data": [
-                      "Force Field XS",
-                      "Force Field S",
-                      "Force Field M",
-                      "Force Field L"
-                    ]
-                  },
-                  {
-                    "name": "Landing Gears",
-                    "data": [
-                      "Landing Gear XS",
-                      "Landing Gear S",
-                      "Landing Gear M",
-                      "Landing Gear L"
-                    ]
-                  },
-                  {
-                    "name": "Screens/Signs",
-                    "data": [
-                      "Screen XS",
-                      "Screen S",
-                      "Screen M",
-                      "Screen XL",
-                      "Transparent Screen XS",
-                      "Transparent Screen S",
-                      "Transparent Screen M",
-                      "Transparent Screen L",
-					  "Sign XS",
-					  "Sign S",
-					  "Sign M",
-					  "Sign L",
-					  "Sign Vertical XS",
-					  "Sign Vertical M",
-					  "Sign Vertical L",
-					  "Sensors S"
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "Lights",
-                "data": [
-                  "Headlight",
-                  "Long Light XS",
-                  "Long Light S",
-                  "Long Light M",
-                  "Long Light L",
-                  "Square Light XS",
-                  "Square Light S",
-                  "Square Light M",
-                  "Square Light L",
-                  "Vertical Light XS",
-                  "Vertical Light S",
-                  "Vertical Light M",
-                  "Vertical Light L"
-                ]
-              },
-              {
-                "name": "Resurrection Nodes",
-                "data": [
-                  "Resurrection Node"
-                ]
-              },
-              {
-                "name": "Sensors",
-                "data": [
-                  {
-                    "name": "Laser Detectors",
-                    "data": [
-                      "Infra-Red Laser Receiver",
-                      "Laser Receiver"
-                    ]
-                  },
-                  {
-                    "name": "Manual Buttons",
-                    "data": [
-                      "Manual Button S",
-                      "Manual Button XS"
-                    ]
-                  },
-                  {
-                    "name": "Manual Switches",
-                    "data": [
-                      "Manual Switch"
-                    ]
-                  },
-                  {
-                    "name": "Pressure Tiles",
-                    "data": [
-                      "Pressure Tile"
-                    ]
-                  },
-                  {
-                    "name": "Radars",
-                    "data": [
-                      "Small Atmospheric Radar PvP S",
-                      "Medium Atmospheric Radar PvP M",
-                      "Large Atmospheric Radar PvP L",
-                      "Space Radar S",
-                      "Space Radar M",
-                      "Space Radar L",
-					  "Transponder"
-                    ]
-                  },
-                  {
-                    "name": "Zone Detectors",
-                    "data": [
-                      "Detection Zone XS",
-                      "Detection Zone S",
-                      "Detection Zone M",
-                      "Detection Zone L"
-                    ]
-                  }
-                ]
-              },
-			  {
-			    "name":"Virtual Projectors",
-				"data": [
-				  "Virtual Scaffolding Projector"
-				]
-			  },
-			  { 
-				"name": "Combat Elements",
-				"data": [
-				  {
-					"name": "Weapon Units",
-					"data": [
-						{
-							"name": "Cannons",
-							"data": [
-								"Cannon XS",
-								"Cannon S",
-								"Cannon M",
-								"Cannon L"
-							]
-						},
-						{
-							"name": "Lasers",
-							"data": [
-								"Laser XS",
-								"Laser S",
-								"Laser M",
-								"Laser L"
-							]
-						},
-						{
-							"name": "Missile Pods",
-							"data": [
-								"Missile XS",
-								"Missile S",
-								"Missile M",
-								"Missile L"
-							]
-						},
-						{
-							"name": "Railguns",
-							"data": [
-								"Railgun XS",
-								"Railgun S",
-								"Railgun M",
-								"Railgun L"
-							]
-						}
-					]
-				  },
-				  {
-					"name":"Gunner Seats",
-					"data":[
-					  "Gunner Module S",
-					  "Gunner Module M",
-					  "Gunner Module L"
-					  ]
-				  },
-				  "Repair Unit"
-				]
-			  },
-			  {
-				"name": "Surrogate VR Elements",
-				"data": [
-					"Surrogate Pod Station",
-					"Surrogate VR Station"
-					]
-			  },
-			  {
-				"name": "Warp Drives",
-				"data": [
-					"Warp Drive L"
-				]
-			  },
-			  {
-				"name": "Warp Beacons",
-				"data": [
-					"Warp Beacon XL"
-				]
-			  }
-			
-			]
-          },
-          {
-            "name": "Planet Elements",
-            "data": [
-              {
-                "name": "Core Units",
-                "data": [
-                  {
-                    "name": "Dynamic Core Units",
-                    "data": [
-                      "Dynamic Core XS",
-                      "Dynamic Core S",
-                      "Dynamic Core M",
-                      "Dynamic Core L"
-                    ]
-                  },
-                  {
-                    "name": "Static Core Units",
-                    "data": [
-                      "Static Core XS",
-                      "Static Core S",
-                      "Static Core M",
-                      "Static Core L"
-                    ]
-                  },
-                  {
-                    "name": "Space Core Units",
-                    "data": [
-                      "Space Core XS",
-                      "Space Core S",
-                      "Space Core M",
-                      "Space Core L"
-                    ]
-                  }
-                ]
-			  },
-			  "Territory Unit"
-            ]
-          }
-        ]
-      },
-      {
-        "name": "Materials",
-        "data": [
-          {
-            "name": "Catalysts",
-            "data": [
-              "Catalyst 3",
-              "Catalyst 4",
-              "Catalyst 5"
-            ]
-          },
-          {
-            "name": "Fuels",
-            "data": [
-              {
-                "name": "Atmospheric Fuels",
-                "data": [
-                  "Nitron Fuel"
-                ]
-              },
-              {
-                "name": "Rocket Fuels",
-                "data": [
-                  "Xeron Fuel"
-                ]
-              },
-              {
-                "name": "Space Fuels",
-                "data": [
-                  "Kergon-X1 Fuel",
-                  "Kergon-X2 Fuel",
-                  "Kergon-X3 Fuel",
-                  "Kergon-X4 Fuel"
-                ]
-              }
-            ]
-          },
-          {
-            "name": "Honeycomb Materials",
-            "data": [
-              {
-                "name": "Product Honeycomb",
-                "data": [
-                  "Brick Honeycomb",
-                  "Carbonfiber Honeycomb",
-                  "Concrete Honeycomb",
-                  "Marble Honeycomb",
-                  "Plastic Honeycomb",
-                  "Steel Honeycomb",
-                  "Wood Honeycomb",
-                  "Luminescent White Glass"
-                ]
-              },
-              {
-                "name": "Pure Honeycomb",
-                "data": [
-                  "Aluminium Honeycomb",
-                  "Carbon Honeycomb",
-                  "Iron Honeycomb",
-                  "Silicon Honeycomb",
-                  "Calcium Honeycomb",
-                  "Chromium Honeycomb",
-                  "Copper Honeycomb",
-                  "Sodium Honeycomb",
-                  "Lithium Honeycomb",
-                  "Nickel Honeycomb",
-                  "Silver Honeycomb",
-                  "Sulfur Honeycomb",
-                  "Cobalt Honeycomb",
-                  "Fluorine Honeycomb",
-                  "Gold Honeycomb",
-                  "Scandium Honeycomb",
-                  "Manganese Honeycomb",
-                  "Niobium Honeycomb",
-                  "Titanium Honeycomb",
-                  "Vanadium Honeycomb"
-                ]
-              }
-            ]
-          },
-          {
-            "name": "Product",
-            "data": [
-              "Advanced Glass",
-              "Ag-Li Reinforced Glass",
-              "Al-Fe Alloy",
-              "Al-Li Alloy",
-              "Biological Matter",
-              "Brick",
-              "Calcium Reinforced Copper",
-              "Carbon Fiber",
-              "Cu-Ag Alloy",
-              "Concrete",
-              "Duralumin",
-              "Fluoropolymer",
-              "Glass",
-              "Gold Coated Glass",
-              "Grade 5 Titanium Alloy",
-              "Inconel",
-              "Mangalloy",
-              "Manganese Reinforced Glass",
-              "Maraging Steel",
-              "Marble",
-              "Polycalcite Plastic",
-              "Polycarbonate Plastic",
-              "Polysulfide Plastic",
-              "Red Gold",
-              "Sc-Al Alloy",
-              "Silumin",
-              "Stainless Steel",
-              "Steel",
-              "Ti-Nb Supraconductor",
-              "Vanamer",
-              "Wood"
-            ]
-          },
-          {
-            "name": "Pure",
-            "data": [
-              "Aluminium Pure",
-              "Calcium Pure",
-              "Carbon Pure",
-              "Chromium Pure",
-              "Cobalt Pure",
-              "Copper Pure",
-              "Gold Pure",
-              "Iron Pure",
-              "Fluorine Pure",
-              "Lithium Pure",
-              "Manganese Pure",
-              "Nickel Pure",
-              "Niobium Pure",
-              "Scandium Pure",
-              "Silicon Pure",
-              "Silver Pure",
-              "Sodium Pure",
-              "Sulfur Pure",
-              "Titanium Pure",
-              "Vanadium Pure"
-            ]
-          },
-          {
-            "name": "Ore",
-            "data": [
-              "Acanthite",
-              "Bauxite",
-              "Chromite",
-              "Coal",
-              "Cobaltite",
-              "Columbite",
-              "Cryolite",
-              "Garnierite",
-              "Gold Nuggets",
-              "Hematite",
-              "Illmenite",
-              "Kolbeckite",
-              "Limestone",
-              "Malachite",
-              "Natron",
-              "Petalite",
-              "Pyrite",
-              "Quartz",
-              "Rhodonite",
-              "Vanadinite"
-            ]
-          }
-        ]
-      },
-      {
-        "name": "Scraps",
-        "data": [
-              "Aluminium Scrap",
-              "Calcium Scrap",
-              "Carbon Scrap",
-              "Chromium Scrap",
-              "Cobalt Scrap",
-              "Copper Scrap",
-              "Gold Scrap",
-              "Iron Scrap",
-              "Fluorine Scrap",
-              "Lithium Scrap",
-              "Nickel Scrap",
-              "Scandium Scrap",
-              "Silicon Scrap",
-              "Silver Scrap",
-              "Sodium Scrap",
-              "Sulfur Scrap"
-        ]
-      },
-	  {
-		"name": "Warp Cells",
+	{
+		"name": "Consumables",
 		"data": [
-			"Warp Cell"
+			{
+				"name": "Ammo",
+				"data": [
+					{
+						"name": "Cannon Ammo",
+						"data": [
+							{
+								"name": "Extra-Small Cannon Ammo",
+								"data": [
+									{
+										"name": "Kinetic Ammo",
+										"data": [
+											"Cannon Agile Kinetic Ammo XS",
+											"Cannon Defense Kinetic Ammo XS",
+											"Cannon Heavy Kinetic Ammo XS",
+											"Cannon Kinetic Ammo XS",
+											"Cannon Precision Kinetic Ammo XS"
+										]
+									},
+									{
+										"name": "Thermic Ammo",
+										"data": [
+											"Cannon Agile Thermic Ammo XS",
+											"Cannon Defense Thermic Ammo XS",
+											"Cannon Heavy Thermic Ammo XS",
+											"Cannon Thermic Ammo XS",
+											"Cannon Precision Thermic Ammo XS"
+										]
+									}
+								]
+							},
+							{
+								"name": "Small Cannon Ammo",
+								"data": [
+									{
+										"name": "Kinetic Ammo",
+										"data": [
+											"Cannon Agile Kinetic Ammo S",
+											"Cannon Defense Kinetic Ammo S",
+											"Cannon Heavy Kinetic Ammo S",
+											"Cannon Kinetic Ammo S",
+											"Cannon Precision Kinetic Ammo S"
+										]
+									},
+									{
+										"name": "Thermic Ammo",
+										"data": [
+											"Cannon Agile Thermic Ammo S",
+											"Cannon Defense Thermic Ammo S",
+											"Cannon Heavy Thermic Ammo S",
+											"Cannon Thermic Ammo S",
+											"Cannon Precision Thermic Ammo S"
+										]
+									}
+								]
+							},
+							{
+								"name": "Medium Cannon Ammo",
+								"data": [
+									{
+										"name": "Kinetic Ammo",
+										"data": [
+											"Cannon Agile Kinetic Ammo M",
+											"Cannon Defense Kinetic Ammo M",
+											"Cannon Heavy Kinetic Ammo M",
+											"Cannon Kinetic Ammo M",
+											"Cannon Precision Kinetic Ammo M"
+										]
+									},
+									{
+										"name": "Thermic Ammo",
+										"data": [
+											"Cannon Agile Thermic Ammo M",
+											"Cannon Defense Thermic Ammo M",
+											"Cannon Heavy Thermic Ammo M",
+											"Cannon Thermic Ammo M",
+											"Cannon Precision Thermic Ammo M"
+										]
+									}
+								]
+							},
+							{
+								"name": "Large Cannon Ammo",
+								"data": [
+									{
+										"name": "Kinetic Ammo",
+										"data": [
+											"Cannon Agile Kinetic Ammo L",
+											"Cannon Defense Kinetic Ammo L",
+											"Cannon Heavy Kinetic Ammo L",
+											"Cannon Kinetic Ammo L",
+											"Cannon Precision Kinetic Ammo L"
+										]
+									},
+									{
+										"name": "Thermic Ammo",
+										"data": [
+											"Cannon Agile Thermic Ammo L",
+											"Cannon Defense Thermic Ammo L",
+											"Cannon Heavy Thermic Ammo L",
+											"Cannon Thermic Ammo L",
+											"Cannon Precision Thermic Ammo L"
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						"name": "Laser Ammo",
+						"data": [
+							{
+								"name": "Extra-Small Laser Ammo",
+								"data": [
+									{
+										"name": "Electromagnetic Ammo",
+										"data": [
+											"Laser Agile Electromagnetic Ammo XS",
+											"Laser Defense Electromagnetic Ammo XS",
+											"Laser Heavy Electromagnetic Ammo XS",
+											"Laser Electromagnetic Ammo XS",
+											"Laser Precision Electromagnetic Ammo XS"
+										]
+									},
+									{
+										"name": "Thermic Ammo",
+										"data": [
+											"Laser Agile Thermic Ammo XS",
+											"Laser Defense Thermic Ammo XS",
+											"Laser Heavy Thermic Ammo XS",
+											"Laser Thermic Ammo XS",
+											"Laser Precision Thermic Ammo XS"
+										]
+									}
+								]
+							},
+							{
+								"name": "Small Laser Ammo",
+								"data": [
+									{
+										"name": "Electromagnetic Ammo",
+										"data": [
+											"Laser Agile Electromagnetic Ammo S",
+											"Laser Defense Electromagnetic Ammo S",
+											"Laser Heavy Electromagnetic Ammo S",
+											"Laser Electromagnetic Ammo S",
+											"Laser Precision Electromagnetic Ammo S"
+										]
+									},
+									{
+										"name": "Thermic Ammo",
+										"data": [
+											"Laser Agile Thermic Ammo S",
+											"Laser Defense Thermic Ammo S",
+											"Laser Heavy Thermic Ammo S",
+											"Laser Thermic Ammo S",
+											"Laser Precision Thermic Ammo S"
+										]
+									}
+								]
+							},
+							{
+								"name": "Medium Laser Ammo",
+								"data": [
+									{
+										"name": "Electromagnetic Ammo",
+										"data": [
+											"Laser Agile Electromagnetic Ammo M",
+											"Laser Defense Electromagnetic Ammo M",
+											"Laser Heavy Electromagnetic Ammo M",
+											"Laser Electromagnetic Ammo M",
+											"Laser Precision Electromagnetic Ammo M"
+										]
+									},
+									{
+										"name": "Thermic Ammo",
+										"data": [
+											"Laser Agile Thermic Ammo M",
+											"Laser Defense Thermic Ammo M",
+											"Laser Heavy Thermic Ammo M",
+											"Laser Thermic Ammo M",
+											"Laser Precision Thermic Ammo M"
+										]
+									}
+								]
+							},
+							{
+								"name": "Large Laser Ammo",
+								"data": [
+									{
+										"name": "Electromagnetic Ammo",
+										"data": [
+											"Laser Agile Electromagnetic Ammo L",
+											"Laser Defense Electromagnetic Ammo L",
+											"Laser Heavy Electromagnetic Ammo L",
+											"Laser Electromagnetic Ammo L",
+											"Laser Precision Electromagnetic Ammo L"
+										]
+									},
+									{
+										"name": "Thermic Ammo",
+										"data": [
+											"Laser Agile Thermic Ammo L",
+											"Laser Defense Thermic Ammo L",
+											"Laser Heavy Thermic Ammo L",
+											"Laser Thermic Ammo L",
+											"Laser Precision Thermic Ammo L"
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						"name": "Missile Pod Ammo",
+						"data": [
+							{
+								"name": "Extra-Small Missile Ammo",
+								"data": [
+									{
+										"name": "Antimatter Ammo",
+										"data": [
+											"Missile Agile Antimatter Ammo XS",
+											"Missile Defense Antimatter Ammo XS",
+											"Missile Heavy Antimatter Ammo XS",
+											"Missile Antimatter Ammo XS",
+											"Missile Precision Antimatter Ammo XS"
+										]
+									},
+									{
+										"name": "Kinetic Ammo",
+										"data": [
+											"Missile Agile Kinetic Ammo XS",
+											"Missile Defense Kinetic Ammo XS",
+											"Missile Heavy Kinetic Ammo XS",
+											"Missile Kinetic Ammo XS",
+											"Missile Precision Kinetic Ammo XS"
+										]
+									}
+								]
+							},
+							{
+								"name": "Small Missile Ammo",
+								"data": [
+									{
+										"name": "Antimatter Ammo",
+										"data": [
+											"Missile Agile Antimatter Ammo S",
+											"Missile Defense Antimatter Ammo S",
+											"Missile Heavy Antimatter Ammo S",
+											"Missile Antimatter Ammo S",
+											"Missile Precision Antimatter Ammo S"
+										]
+									},
+									{
+										"name": "Kinetic Ammo",
+										"data": [
+											"Missile Agile Kinetic Ammo S",
+											"Missile Defense Kinetic Ammo S",
+											"Missile Heavy Kinetic Ammo S",
+											"Missile Kinetic Ammo S",
+											"Missile Precision Kinetic Ammo S"
+										]
+									}
+								]
+							},
+							{
+								"name": "Medium Missile Ammo",
+								"data": [
+									{
+										"name": "Antimatter Ammo",
+										"data": [
+											"Missile Agile Antimatter Ammo M",
+											"Missile Defense Antimatter Ammo M",
+											"Missile Heavy Antimatter Ammo M",
+											"Missile Antimatter Ammo M",
+											"Missile Precision Antimatter Ammo M"
+										]
+									},
+									{
+										"name": "Kinetic Ammo",
+										"data": [
+											"Missile Agile Kinetic Ammo M",
+											"Missile Defense Kinetic Ammo M",
+											"Missile Heavy Kinetic Ammo M",
+											"Missile Kinetic Ammo M",
+											"Missile Precision Kinetic Ammo M"
+										]
+									}
+								]
+							},
+							{
+								"name": "Large Missile Ammo",
+								"data": [
+									{
+										"name": "Antimatter Ammo",
+										"data": [
+											"Missile Agile Antimatter Ammo L",
+											"Missile Defense Antimatter Ammo L",
+											"Missile Heavy Antimatter Ammo L",
+											"Missile Antimatter Ammo L",
+											"Missile Precision Antimatter Ammo L"
+										]
+									},
+									{
+										"name": "Kinetic Ammo",
+										"data": [
+											"Missile Agile Kinetic Ammo L",
+											"Missile Defense Kinetic Ammo L",
+											"Missile Heavy Kinetic Ammo L",
+											"Missile Kinetic Ammo L",
+											"Missile Precision Kinetic Ammo L"
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						"name": "Railgun Pod Ammo",
+						"data": [
+							{
+								"name": "Extra-Small Railgun Ammo",
+								"data": [
+									{
+										"name": "Antimatter Ammo",
+										"data": [
+											"Railgun Agile Antimatter Ammo XS",
+											"Railgun Defense Antimatter Ammo XS",
+											"Railgun Heavy Antimatter Ammo XS",
+											"Railgun Antimatter Ammo XS",
+											"Railgun Precision Antimatter Ammo XS"
+										]
+									},
+									{
+										"name": "Electromagnetic Ammo",
+										"data": [
+											"Railgun Agile Electromagnetic Ammo XS",
+											"Railgun Defense Electromagnetic Ammo XS",
+											"Railgun Heavy Electromagnetic Ammo XS",
+											"Railgun Electromagnetic Ammo XS",
+											"Railgun Precision Electromagnetic Ammo XS"
+										]
+									}
+								]
+							},
+							{
+								"name": "Small Railgun Ammo",
+								"data": [
+									{
+										"name": "Antimatter Ammo",
+										"data": [
+											"Railgun Agile Antimatter Ammo S",
+											"Railgun Defense Antimatter Ammo S",
+											"Railgun Heavy Antimatter Ammo S",
+											"Railgun Antimatter Ammo S",
+											"Railgun Precision Antimatter Ammo S"
+										]
+									},
+									{
+										"name": "Electromagnetic Ammo",
+										"data": [
+											"Railgun Agile Electromagnetic Ammo S",
+											"Railgun Defense Electromagnetic Ammo S",
+											"Railgun Heavy Electromagnetic Ammo S",
+											"Railgun Electromagnetic Ammo S",
+											"Railgun Precision Electromagnetic Ammo S"
+										]
+									}
+								]
+							},
+							{
+								"name": "Medium Railgun Ammo",
+								"data": [
+									{
+										"name": "Antimatter Ammo",
+										"data": [
+											"Railgun Agile Antimatter Ammo M",
+											"Railgun Defense Antimatter Ammo M",
+											"Railgun Heavy Antimatter Ammo M",
+											"Railgun Antimatter Ammo M",
+											"Railgun Precision Antimatter Ammo M"
+										]
+									},
+									{
+										"name": "Electromagnetic Ammo",
+										"data": [
+											"Railgun Agile Electromagnetic Ammo M",
+											"Railgun Defense Electromagnetic Ammo M",
+											"Railgun Heavy Electromagnetic Ammo M",
+											"Railgun Electromagnetic Ammo M",
+											"Railgun Precision Electromagnetic Ammo M"
+										]
+									}
+								]
+							},
+							{
+								"name": "Large Railgun Ammo",
+								"data": [
+									{
+										"name": "Antimatter Ammo",
+										"data": [
+											"Railgun Agile Antimatter Ammo L",
+											"Railgun Defense Antimatter Ammo L",
+											"Railgun Heavy Antimatter Ammo L",
+											"Railgun Antimatter Ammo L",
+											"Railgun Precision Antimatter Ammo L"
+										]
+									},
+									{
+										"name": "Electromagnetic Ammo",
+										"data": [
+											"Railgun Agile Electromagnetic Ammo L",
+											"Railgun Defense Electromagnetic Ammo L",
+											"Railgun Heavy Electromagnetic Ammo L",
+											"Railgun Electromagnetic Ammo L",
+											"Railgun Precision Electromagnetic Ammo L"
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			{
+				"name": "Elements",
+				"data": [
+					{
+						"name": "Construct Elements",
+						"data": [
+							{
+								"name": "Decorative Element",
+								"data": [
+									{
+										"name": "Adjuncts",
+										"data": [
+											"Vertical Wing",
+											"Wing Tip S",
+											"Wing Tip M",
+											"Wing Tip L"
+										]
+									},
+									{
+										"name": "Antennas",
+										"data": [
+											"Antenna S",
+											"Antenna M",
+											"Antenna L"
+										]
+									},
+									{
+										"name": "Barriers",
+										"data": [
+											"Barrier Corner",
+											"Barrier S",
+											"Barrier M"
+										]
+									},
+									{
+										"name": "Bathroom Elements",
+										"data": [
+											"Shower Unit",
+											"Sink Unit",
+											"Toilet Unit A",
+											"Toilet Unit B",
+											"Urinal Unit"
+										]
+									},
+									{
+										"name": "Decorative Cables",
+										"data": [
+											"Cable Model-A S",
+											"Cable Model-A M",
+											"Cable Model-B S",
+											"Cable Model-B M",
+											"Cable Model-C S",
+											"Cable Model-C M",
+											"Corner Cable Model-A",
+											"Corner Cable Model-B",
+											"Corner Cable Model-C"
+										]
+									},
+									{
+										"name": "Furnitures",
+										"data": [
+											"\"Eye Doll's Workshop\" - Artist Unknown",
+											"\"HMS Ajax33\" - Artist Unknown",
+											"\"Parrotos Sanctuary\" - Artist Unknown",
+											"Bed",
+											"Bench",
+											"Dresser",
+											"Nightstand",
+											"Round Carpet",
+											"Shelf Empty",
+											"Shelf Full",
+											"Shelf Half Full",
+											"Sofa",
+											"Square Carpet",
+											"Table",
+											"Trash",
+											"Wardrobe",
+											"Wooden Armchair",
+											"Wooden Chair",
+											"Wooden Dresser",
+											"Wooden Low Table",
+											"Wooden Sofa",
+											"Wooden Table L",
+											"Wooden Table M",
+											"Wooden Wardrobe",
+											"Navigator Chair",
+											"Office Chair",
+											"Encampment Chair"
+										]
+									},
+									{
+										"name": "Holograms",
+										"data": [
+											"Planet Hologram",
+											"Planet Hologram L",
+											"Spaceship Hologram S",
+											"Spaceship Hologram M",
+											"Spaceship Hologram L"
+										]
+									},
+									{
+										"name": "Hull Decoration",
+										"data": [
+											"Hull Decorative Element A",
+											"Hull Decorative Element B",
+											"Hull Decorative Element C",
+											"Steel Column",
+											"Steel Panel"
+										]
+									},
+									{
+										"name": "Pipes",
+										"data": [
+											"Pipe A M",
+											"Pipe B M",
+											"Pipe C M",
+											"Pipe D M",
+											"Pipe Connector M",
+											"Pipe Corner M"
+										]
+									},
+									{
+										"name": "Plants",
+										"data": [
+											"Suspended Plant A",
+											"Bagged Plant A",
+											"Bagged Plant B",
+											"Bonsai",
+											"Eggplant Plant Case",
+											"Ficus Plant A",
+											"Ficus Plant B",
+											"Foliage Plant Case A",
+											"Foliage Plant Case B",
+											"Plant",
+											"Plant Case A",
+											"Plant Case B",
+											"Plant Case C",
+											"Plant Case D",
+											"Plant Case E",
+											"Plant Case S",
+											"Plant Case M"
+										]
+									},
+									{
+										"name": "Windows",
+										"data": [
+											"Armored Window XS",
+											"Armored Window S",
+											"Armored Window M",
+											"Armored Window L",
+											"Bay Window XL",
+											"Glass Panel S",
+											"Glass Panel M",
+											"Glass Panel L",
+											"Window XS",
+											"Window S",
+											"Window M",
+											"Window L"
+										]
+									},
+									"Keyboard Unit"
+								]
+							},
+							{
+								"name": "Industry",
+								"data": [
+									"Assembly Line XS",
+									"Assembly Line S",
+									"Assembly Line M",
+									"Assembly Line L",
+									"Assembly Line XL",
+									"3D Printer M",
+									"Chemical Industry M",
+									"Electronics Industry M",
+									"Glass Furnace M",
+									"Honeycomb Refinery M",
+									"Metalwork Industry M",
+									"Recycler M",
+									"Refiner M",
+									"Smelter M",
+									"Transfer Unit"
+								]
+							},
+							{
+								"name": "Anti-Gravity Generator",
+								"data": [
+									"Anti-Gravity Generator S",
+									"Anti-Gravity Generator M",
+									"Anti-Gravity Generator L"
+								]
+							},
+							{
+								"name": "Anti-Gravity Pulsors",
+								"data": [
+									"Anti-Gravity Pulsor"
+								]
+							},
+							{
+								"name": "Containers",
+								"data": [
+									{
+										"name": "Dispensers",
+										"data": [
+											"Dispenser",
+											"Medium Dispenser",
+											"Heavy Dispenser"
+										]
+									},
+									{
+										"name": "Fuel Tanks",
+										"data": [
+											{
+												"name": "Atmospheric Fuel Containers",
+												"data": [
+													"Atmospheric Fuel-Tank XS",
+													"Atmospheric Fuel-Tank S",
+													"Atmospheric Fuel-Tank M",
+													"Atmospheric Fuel-Tank L"
+												]
+											},
+											{
+												"name": "Rocket Fuel Containers",
+												"data": [
+													"Rocket Fuel-Tank XS",
+													"Rocket Fuel-Tank S",
+													"Rocket Fuel-Tank M",
+													"Rocket Fuel-Tank L"
+												]
+											},
+											{
+												"name": "Space Fuel Containers",
+												"data": [
+													"Space Fuel-Tank S",
+													"Space Fuel-Tank M",
+													"Space Fuel-Tank L"
+												]
+											}
+										]
+									},
+									{
+										"name": "Item Containers",
+										"data": [
+											"Container Hub",
+											"Container XS",
+											"Container S",
+											"Container M",
+											"Container L"
+										]
+									},
+									{
+										"name": "Ammo Containers",
+										"data": [
+											"Ammo Container XS",
+											"Ammo Container S",
+											"Ammo Container M",
+											"Ammo Container L"
+										]
+									}
+								]
+							},
+							{
+								"name": "Control Units",
+								"data": [
+									"Emergency Controller",
+									"Hovercraft Seat Controller",
+									"Cockpit Controller",
+									"Command Seat Controller",
+									"Programming Board",
+									"Remote Controller"
+								]
+							},
+							{
+								"name": "Electronics",
+								"data": [
+									{
+										"name": "AND Operators",
+										"data": [
+											"AND Operator"
+										]
+									},
+									{
+										"name": "NOT Operators",
+										"data": [
+											"NOT Operator"
+										]
+									},
+									{
+										"name": "OR Operators",
+										"data": [
+											"OR Operator"
+										]
+									},
+									{
+										"name": "Counters",
+										"data": [
+											"2 Counter",
+											"3 Counter",
+											"5 Counter",
+											"7 Counter",
+											"10 Counter"
+										]
+									},
+									{
+										"name": "Data Banks",
+										"data": [
+											"Databank"
+										]
+									},
+									{
+										"name": "Data Emitters",
+										"data": [
+											"Emitter XS",
+											"Emitter S",
+											"Emitter M"
+										]
+									},
+									{
+										"name": "Delay Lines",
+										"data": [
+											"Delay Line"
+										]
+									},
+									{
+										"name": "Laser Emitters",
+										"data": [
+											"Infra-Red Laser Emitter",
+											"Laser Emitter"
+										]
+									},
+									{
+										"name": "Receivers",
+										"data": [
+											"Receiver XS",
+											"Receiver S",
+											"Receiver M"
+										]
+									},
+									{
+										"name": "Relays",
+										"data": [
+											"Relay"
+										]
+									}
+								]
+							},
+							{
+								"name": "Engines",
+								"data": [
+									{
+										"name": "Adjustors",
+										"data": [
+											"Adjustor XS",
+											"Adjustor S",
+											"Adjustor M",
+											"Adjustor L"
+										]
+									},
+									{
+										"name": "Airbrakes",
+										"data": [
+											"Atmospheric Airbrake S",
+											"Atmospheric Airbrake M",
+											"Atmospheric Airbrake L"
+										]
+									},
+									{
+										"name": "Airfoil",
+										"data": [
+											{
+												"name": "Aileron",
+												"data": [
+													"Aileron XS",
+													"Aileron S",
+													"Aileron M",
+													"Compact Aileron XS",
+													"Compact Aileron S",
+													"Compact Aileron M"
+												]
+											},
+											{
+												"name": "Stabilizer",
+												"data": [
+													"Stabilizer XS",
+													"Stabilizer S",
+													"Stabilizer M",
+													"Stabilizer L"
+												]
+											},
+											{
+												"name": "Wing",
+												"data": [
+													"Wing XS",
+													"Wing S",
+													"Wing M",
+													"Wing Variant M"
+												]
+											}
+										]
+									},
+									{
+										"name": "Atmospheric Engines",
+										"data": [
+											{
+												"name": "Atmospheric Engines XS",
+												"data": [
+													"Atmospheric Engine XS",
+													"Freight Atmospheric Engine XS",
+													"Maneuver Atmospheric Engine XS",
+													"Military Atmospheric Engine XS",
+													"Safe Atmospheric Engine XS"
+												]
+											},
+											{
+												"name": "Atmospheric Engines S",
+												"data": [
+													"Atmospheric Engine S",
+													"Freight Atmospheric Engine S",
+													"Maneuver Atmospheric Engine S",
+													"Military Atmospheric Engine S",
+													"Safe Atmospheric Engine S"
+												]
+											},
+											{
+												"name": "Atmospheric Engines M",
+												"data": [
+													"Atmospheric Engine M",
+													"Freight Atmospheric Engine M",
+													"Maneuver Atmospheric Engine M",
+													"Military Atmospheric Engine M",
+													"Safe Atmospheric Engine M"
+												]
+											},
+											{
+												"name": "Atmospheric Engines L",
+												"data": [
+													"Atmospheric Engine L",
+													"Freight Atmospheric Engine L",
+													"Maneuver Atmospheric Engine L",
+													"Military Atmospheric Engine L",
+													"Safe Atmospheric Engine L"
+												]
+											}
+										]
+									},
+									{
+										"name": "Hovercraft Engines",
+										"data": [
+											"Hover Engine S",
+											"Hover Engine M",
+											"Hover Engine L",
+											"Flat Hover Engine L"
+										]
+									},
+									{
+										"name": "Rocket Engines",
+										"data": [
+											"Rocket Engine S",
+											"Rocket Engine M",
+											"Rocket Engine L"
+										]
+									},
+									{
+										"name": "Space Brakes",
+										"data": [
+											"Retro-Rocket Brake S",
+											"Retro-Rocket Brake M",
+											"Retro-Rocket Brake L"
+										]
+									},
+									{
+										"name": "Space Engines",
+										"data": [
+											{
+												"name": "Space Engines XS",
+												"data": [
+													"Space Engine XS",
+													"Freight Space Engine XS",
+													"Maneuver Space Engine XS",
+													"Military Space Engine XS",
+													"Safe Space Engine XS"
+												]
+											},
+											{
+												"name": "Space Engines S",
+												"data": [
+													"Space Engine S",
+													"Freight Space Engine S",
+													"Maneuver Space Engine S",
+													"Military Space Engine S",
+													"Safe Space Engine S"
+												]
+											},
+											{
+												"name": "Space Engines M",
+												"data": [
+													"Space Engine M",
+													"Freight Space Engine M",
+													"Maneuver Space Engine M",
+													"Military Space Engine M",
+													"Safe Space Engine M"
+												]
+											},
+											{
+												"name": "Space Engines L",
+												"data": [
+													"Space Engine L",
+													"Freight Space Engine L",
+													"Maneuver Space Engine L",
+													"Military Space Engine L",
+													"Safe Space Engine L"
+												]
+											},
+											{
+												"name": "Space Engines XL",
+												"data": [
+													"Space Engine XL",
+													"Freight Space Engine XL",
+													"Maneuver Space Engine XL",
+													"Military Space Engine XL",
+													"Safe Space Engine XL"
+												]
+											}
+										]
+									},
+									{
+										"name": "Vertical Boosters",
+										"data": [
+											"Vertical Booster XS",
+											"Vertical Booster S",
+											"Vertical Booster M",
+											"Vertical Booster L"
+										]
+									}
+								]
+							},
+							{
+								"name": "Instruments",
+								"data": [
+									"Gyroscope",
+									"Telemeter",
+									"Territory Scanner"
+								]
+							},
+							{
+								"name": "Interactive Elements",
+								"data": [
+									{
+										"name": "Doors",
+										"data": [
+											"Airlock",
+											"Interior Door",
+											"Reinforced Sliding Door",
+											"Sliding Door S",
+											"Sliding Door M",
+											"Gate XS",
+											"Expanded Gate S",
+											"Gate M",
+											"Expanded Gate L",
+											"Gate XL",
+											"Hatch S",
+											"Fuel Intake XS"
+										]
+									},
+									{
+										"name": "Elevators",
+										"data": [
+											"Elevator XS"
+										]
+									},
+									{
+										"name": "Force Fields",
+										"data": [
+											"Force Field XS",
+											"Force Field S",
+											"Force Field M",
+											"Force Field L"
+										]
+									},
+									{
+										"name": "Landing Gears",
+										"data": [
+											"Landing Gear XS",
+											"Landing Gear S",
+											"Landing Gear M",
+											"Landing Gear L"
+										]
+									},
+									{
+										"name": "Screens/Signs",
+										"data": [
+											"Screen XS",
+											"Screen S",
+											"Screen M",
+											"Screen XL",
+											"Transparent Screen XS",
+											"Transparent Screen S",
+											"Transparent Screen M",
+											"Transparent Screen L",
+											"Sign XS",
+											"Sign S",
+											"Sign M",
+											"Sign L",
+											"Sign Vertical XS",
+											"Sign Vertical M",
+											"Sign Vertical L",
+											"Sensors S"
+										]
+									}
+								]
+							},
+							{
+								"name": "Lights",
+								"data": [
+									"Headlight",
+									"Long Light XS",
+									"Long Light S",
+									"Long Light M",
+									"Long Light L",
+									"Square Light XS",
+									"Square Light S",
+									"Square Light M",
+									"Square Light L",
+									"Vertical Light XS",
+									"Vertical Light S",
+									"Vertical Light M",
+									"Vertical Light L"
+								]
+							},
+							{
+								"name": "Resurrection Nodes",
+								"data": [
+									"Resurrection Node"
+								]
+							},
+							{
+								"name": "Sensors",
+								"data": [
+									{
+										"name": "Laser Detectors",
+										"data": [
+											"Infra-Red Laser Receiver",
+											"Laser Receiver"
+										]
+									},
+									{
+										"name": "Manual Buttons",
+										"data": [
+											"Manual Button S",
+											"Manual Button XS"
+										]
+									},
+									{
+										"name": "Manual Switches",
+										"data": [
+											"Manual Switch"
+										]
+									},
+									{
+										"name": "Pressure Tiles",
+										"data": [
+											"Pressure Tile"
+										]
+									},
+									{
+										"name": "Radars",
+										"data": [
+											"Small Atmospheric Radar PvP S",
+											"Medium Atmospheric Radar PvP M",
+											"Large Atmospheric Radar PvP L",
+											"Space Radar S",
+											"Space Radar M",
+											"Space Radar L",
+											"Transponder"
+										]
+									},
+									{
+										"name": "Zone Detectors",
+										"data": [
+											"Detection Zone XS",
+											"Detection Zone S",
+											"Detection Zone M",
+											"Detection Zone L"
+										]
+									}
+								]
+							},
+							{
+								"name": "Virtual Projectors",
+								"data": [
+									"Virtual Scaffolding Projector"
+								]
+							},
+							{
+								"name": "Combat Elements",
+								"data": [
+									{
+										"name": "Weapon Units",
+										"data": [
+											{
+												"name": "Cannons",
+												"data": [
+													"Cannon XS",
+													"Cannon S",
+													"Cannon M",
+													"Cannon L"
+												]
+											},
+											{
+												"name": "Lasers",
+												"data": [
+													"Laser XS",
+													"Laser S",
+													"Laser M",
+													"Laser L"
+												]
+											},
+											{
+												"name": "Missile Pods",
+												"data": [
+													"Missile XS",
+													"Missile S",
+													"Missile M",
+													"Missile L"
+												]
+											},
+											{
+												"name": "Railguns",
+												"data": [
+													"Railgun XS",
+													"Railgun S",
+													"Railgun M",
+													"Railgun L"
+												]
+											}
+										]
+									},
+									{
+										"name": "Gunner Seats",
+										"data": [
+											"Gunner Module S",
+											"Gunner Module M",
+											"Gunner Module L"
+										]
+									},
+									"Repair Unit"
+								]
+							},
+							{
+								"name": "Surrogate VR Elements",
+								"data": [
+									"Surrogate Pod Station",
+									"Surrogate VR Station"
+								]
+							},
+							{
+								"name": "Warp Drives",
+								"data": [
+									"Warp Drive L"
+								]
+							},
+							{
+								"name": "Warp Beacons",
+								"data": [
+									"Warp Beacon XL"
+								]
+							}
+						]
+					},
+					{
+						"name": "Planet Elements",
+						"data": [
+							{
+								"name": "Core Units",
+								"data": [
+									{
+										"name": "Dynamic Core Units",
+										"data": [
+											"Dynamic Core XS",
+											"Dynamic Core S",
+											"Dynamic Core M",
+											"Dynamic Core L"
+										]
+									},
+									{
+										"name": "Static Core Units",
+										"data": [
+											"Static Core XS",
+											"Static Core S",
+											"Static Core M",
+											"Static Core L"
+										]
+									},
+									{
+										"name": "Space Core Units",
+										"data": [
+											"Space Core XS",
+											"Space Core S",
+											"Space Core M",
+											"Space Core L"
+										]
+									}
+								]
+							},
+							"Territory Unit"
+						]
+					}
+				]
+			},
+			{
+				"name": "Materials",
+				"data": [
+					{
+						"name": "Catalysts",
+						"data": [
+							"Catalyst 3",
+							"Catalyst 4",
+							"Catalyst 5"
+						]
+					},
+					{
+						"name": "Fuels",
+						"data": [
+							{
+								"name": "Atmospheric Fuels",
+								"data": [
+									"Nitron Fuel"
+								]
+							},
+							{
+								"name": "Rocket Fuels",
+								"data": [
+									"Xeron Fuel"
+								]
+							},
+							{
+								"name": "Space Fuels",
+								"data": [
+									"Kergon-X1 Fuel",
+									"Kergon-X2 Fuel",
+									"Kergon-X3 Fuel",
+									"Kergon-X4 Fuel"
+								]
+							}
+						]
+					},
+					{
+						"name": "Honeycomb Materials",
+						"data": [
+							{
+								"name": "Product Honeycomb",
+								"data": [
+									"Brick Honeycomb",
+									"Carbonfiber Honeycomb",
+									"Concrete Honeycomb",
+									"Marble Honeycomb",
+									"Plastic Honeycomb",
+									"Steel Honeycomb",
+									"Wood Honeycomb",
+									"Luminescent White Glass"
+								]
+							},
+							{
+								"name": "Pure Honeycomb",
+								"data": [
+									"Aluminium Honeycomb",
+									"Carbon Honeycomb",
+									"Iron Honeycomb",
+									"Silicon Honeycomb",
+									"Calcium Honeycomb",
+									"Chromium Honeycomb",
+									"Copper Honeycomb",
+									"Sodium Honeycomb",
+									"Lithium Honeycomb",
+									"Nickel Honeycomb",
+									"Silver Honeycomb",
+									"Sulfur Honeycomb",
+									"Cobalt Honeycomb",
+									"Fluorine Honeycomb",
+									"Gold Honeycomb",
+									"Scandium Honeycomb",
+									"Manganese Honeycomb",
+									"Niobium Honeycomb",
+									"Titanium Honeycomb",
+									"Vanadium Honeycomb"
+								]
+							}
+						]
+					},
+					{
+						"name": "Product",
+						"data": [
+							"Advanced Glass",
+							"Ag-Li Reinforced Glass",
+							"Al-Fe Alloy",
+							"Al-Li Alloy",
+							"Biological Matter",
+							"Brick",
+							"Calcium Reinforced Copper",
+							"Carbon Fiber",
+							"Cu-Ag Alloy",
+							"Concrete",
+							"Duralumin",
+							"Fluoropolymer",
+							"Glass",
+							"Gold Coated Glass",
+							"Grade 5 Titanium Alloy",
+							"Inconel",
+							"Mangalloy",
+							"Manganese Reinforced Glass",
+							"Maraging Steel",
+							"Marble",
+							"Polycalcite Plastic",
+							"Polycarbonate Plastic",
+							"Polysulfide Plastic",
+							"Red Gold",
+							"Sc-Al Alloy",
+							"Silumin",
+							"Stainless Steel",
+							"Steel",
+							"Ti-Nb Supraconductor",
+							"Vanamer",
+							"Wood"
+						]
+					},
+					{
+						"name": "Pure",
+						"data": [
+							"Aluminium Pure",
+							"Calcium Pure",
+							"Carbon Pure",
+							"Chromium Pure",
+							"Cobalt Pure",
+							"Copper Pure",
+							"Gold Pure",
+							"Iron Pure",
+							"Fluorine Pure",
+							"Lithium Pure",
+							"Manganese Pure",
+							"Nickel Pure",
+							"Niobium Pure",
+							"Scandium Pure",
+							"Silicon Pure",
+							"Silver Pure",
+							"Sodium Pure",
+							"Sulfur Pure",
+							"Titanium Pure",
+							"Vanadium Pure"
+						]
+					},
+					{
+						"name": "Ore",
+						"data": [
+							"Acanthite",
+							"Bauxite",
+							"Chromite",
+							"Coal",
+							"Cobaltite",
+							"Columbite",
+							"Cryolite",
+							"Garnierite",
+							"Gold Nuggets",
+							"Hematite",
+							"Illmenite",
+							"Kolbeckite",
+							"Limestone",
+							"Malachite",
+							"Natron",
+							"Petalite",
+							"Pyrite",
+							"Quartz",
+							"Rhodonite",
+							"Vanadinite"
+						]
+					}
+				]
+			},
+			{
+				"name": "Scraps",
+				"data": [
+					"Aluminium Scrap",
+					"Calcium Scrap",
+					"Carbon Scrap",
+					"Chromium Scrap",
+					"Cobalt Scrap",
+					"Copper Scrap",
+					"Gold Scrap",
+					"Iron Scrap",
+					"Fluorine Scrap",
+					"Lithium Scrap",
+					"Nickel Scrap",
+					"Scandium Scrap",
+					"Silicon Scrap",
+					"Silver Scrap",
+					"Sodium Scrap",
+					"Sulfur Scrap"
+				]
+			},
+			{
+				"name": "Warp Cells",
+				"data": [
+					"Warp Cell"
+				]
+			}
 		]
-		}
-    ]
-  },
-  {
-    "name": "Parts",
-    "data": [
-      {
-        "name": "Complex Parts",
-        "data": [
-		  {
-			"name": "Anti-Matter Capsules",
-			"data": [
-			  "Basic Anti-Matter Capsule",
-			  "Uncommon Anti-Matter Capsule",
-			  "Advanced Anti-Matter Capsule",
-			  "Rare Anti-Matter Capsule",
-			  "Exotic Anti-Matter Capsule"
-			]
-		  },
-		  {
-			"name": "Burners",
-			"data": [
-			  "Basic Burner",
-			  "Uncommon Burner",
-			  "Advanced Burner"
-			]
-		  },
-		  {
-			"name": "Electronics",
-			"data": [
-			  "Basic Electronics",
-			  "Uncommon Electronics",
-			  "Advanced Electronics",
-			  "Rare Electronics",
-			  "Exotic Electronics"
-			]
-		  },
-		  {
-			"name": "Explosive Modules",
-			"data": [
-			  "Basic Explosive Module",
-			  "Uncommon Explosive Module",
-			  "Advanced Explosive Module"
-			]
-		  },
-		  {
-			"name": "Hydraulics",
-			"data": [
-			  "Basic Hydraulics",
-			  "Uncommon Hydraulics",
-			  "Advanced Hydraulics"
-			]
-		  },
-		  {
-			"name": "Injectors",
-			"data": [
-			  "Basic Injector",
-			  "Advanced Injector"
-			]
-		  },
-		  {
-			"name": "Magnets",
-			"data": [
-			  "Basic Magnet",
-			  "Uncommon Magnet",
-			  "Advanced Magnet",
-			  "Rare Magnet",
-			  "Exotic Magnet"
-			]
-		  },
-		  {
-			"name": "Optics",
-			"data": [
-			  "Basic Optics",
-			  "Uncommon Optics",
-			  "Advanced Optics",
-			  "Rare Optics"
-			]
-		  },
-		  {
-			"name": "Power Systems",
-			"data": [
-			  "Basic Power System",
-			  "Uncommon Power System",
-			  "Advanced Power System",
-			  "Rare Power System",
-			  "Exotic Power System"
-			]
-		  },
-		  {
-			"name": "Processors",
-			"data": [
-			  "Basic Processor",
-			  "Uncommon Processor",
-			  "Advanced Processor",
-			  "Exotic Processor"
-			]
-		  },
-		  {
-			"name": "Quantum Cores",
-			"data": [
-			  "Basic Quantum Core",
-			  "Uncommon Quantum Core",
-			  "Advanced Quantum Core",
-			  "Rare Quantum Core",
-			  "Exotic Quantum Core"
-			]
-		  },
-		  {
-			"name": "Singularity Containers",
-			"data": [
-			  "Basic Singularity Container",
-			  "Uncommon Singularity Container",
-			  "Advanced Singularity Container",
-			  "Rare Singularity Container",
-			  "Exotic Singularity Container"
-			]
-		  },
-		  {
-			"name": "Solid Warhead",
-			"data": [
-			  "Uncommon Solid Warhead",
-			  "Advanced Solid Warhead"
-			]
-		  }
-        ]
-      },
-      {
-        "name": "Exceptional Parts",
-        "data": [
-		  {
-			"name": "Anti-Gravity Cores",
-			"data": [
-			  "Advanced Anti-Gravity Core",
-			  "Rare Anti-Gravity Core",
-			  "Exotic Anti-Gravity Core"
-			]
-		  },
-		  {
-			"name": "Anti-Matter Core Units",
-			"data": [
-			  "Advanced Anti-Matter Core Unit",
-			  "Exotic Anti-Matter Core Unit"
-			]
-		  },
-		  {
-			"name": "Quantum Alignment Units",
-			"data": [
-			  "Advanced Quantum Alignment Unit",
-			  "Exotic Quantum Alignment Unit"
-			]
-		  },
-		  {
-			"name": "Quantum Barriers",
-			"data": [
-			  "Advanced Quantum Barrier"
-			]
-		  }
-        ]
-      },
-      {
-        "name": "Intermediary Parts",
-        "data": [
-          {
-            "name": "Components",
-            "data": [
-              "Basic Component",
-              "Uncommon Component",
-              "Advanced Component"
-            ]
-          },
-          {
-            "name": "Connectors",
-            "data": [
-              "Basic Connector",
-              "Uncommon Connector",
-              "Advanced Connector"
-            ]
-          },
-          {
-            "name": "Fixations",
-            "data": [
-              "Basic Fixation",
-              "Uncommon Fixation",
-              "Advanced Fixation"
-            ]
-          },
-          {
-            "name": "LEDs",
-            "data": [
-              "Basic LED",
-              "Uncommon LED",
-              "Advanced LED"
-            ]
-          },
-          {
-            "name": "Pipes",
-            "data": [
-              "Basic Pipe",
-              "Uncommon Pipe",
-              "Advanced Pipe"
-            ]
-          },
-          {
-            "name": "Screws",
-            "data": [
-              "Basic Screw",
-              "Uncommon Screw",
-              "Advanced Screw"
-            ]
-          }
-        ]
-      },
-      {
-        "name": "Functional Parts",
-        "data": [
-          {
-            "name": "Antennas",
-            "data": [
-              "Basic Antenna XS",
-              "Basic Antenna S",
-              "Uncommon Antenna XS",
-              "Uncommon Antenna S",
-              "Uncommon Antenna M",
-              "Uncommon Antenna L",
-              "Exotic Antenna M",
-              "Exotic Antenna L",
-              "Exotic Antenna XL"
-            ]
-          },
-          {
-            "name": "Chemical Containers",
-            "data": [
-              "Basic Chemical Container XS",
-              "Basic Chemical Container S",
-              "Basic Chemical Container M",
-              "Basic Chemical Container L",
-              "Basic Chemical Container XL",
-              "Advanced Chemical Container S",
-              "Advanced Chemical Container M",
-              "Advanced Chemical Container L",
-              "Advanced Chemical Container XL"
-            ]
-          },
-          {
-            "name": "Combustion Chambers",
-            "data": [
-              "Basic Combustion Chamber XS",
-              "Basic Combustion Chamber S",
-              "Basic Combustion Chamber M",
-              "Basic Combustion Chamber L",
-              "Advanced Combustion Chamber XS",
-              "Advanced Combustion Chamber S",
-              "Advanced Combustion Chamber M"
-            ]
-          },
-          {
-            "name": "Control Systems",
-            "data": [
-              "Basic Control System XS",
-              "Basic Control System S",
-              "Basic Control System M",
-              "Advanced Control System S",
-              "Advanced Control System M",
-              "Advanced Control System L"
-            ]
-          },
-          {
-            "name": "Core Systems",
-            "data": [
-              "Basic Core System XS",
-              "Basic Core System S",
-              "Uncommon Core System S",
-              "Uncommon Core System M",
-              "Uncommon Core System L",
-              "Advanced Core System M",
-              "Rare Core System L",
-              "Exotic Core System S"
-            ]
-          },
-          {
-            "name": "Electric Engines",
-            "data": [
-              "Basic Electric Engine S",
-              "Basic Electric Engine M",
-              "Uncommon Electric Engine XL"
-            ]
-          },
-          {
-            "name": "Firing Systems",
-            "data": [
-              "Basic Firing System XS",
-              "Advanced Firing System XS",
-              "Advanced Firing System S",
-              "Advanced Firing System M",
-              "Advanced Firing System L"
-            ]
-          },
-          {
-            "name": "Gas Cylinders",
-            "data": [
-              "Basic Gas Cylinder XS",
-              "Basic Gas Cylinder S",
-              "Basic Gas Cylinder M"
-            ]
-          },
-          {
-            "name": "Ionic Chambers",
-            "data": [
-              "Basic Ionic Chamber XS",
-              "Basic Ionic Chamber S",
-              "Basic Ionic Chamber M",
-              "Basic Ionic Chamber L",
-              "Basic Ionic Chamber XL",
-              "Uncommon Ionic Chamber XS",
-              "Uncommon Ionic Chamber S",
-              "Uncommon Ionic Chamber M",
-              "Uncommon Ionic Chamber L",
-              "Uncommon Ionic Chamber XL",
-              "Advanced Ionic Chamber M",
-              "Advanced Ionic Chamber L"
-            ]
-          },
-          {
-            "name": "Laser Chambers",
-            "data": [
-              "Uncommon Laser Chamber XS",
-              "Advanced Laser Chamber XS",
-              "Advanced Laser Chamber S",
-              "Advanced Laser Chamber M",
-              "Advanced Laser Chamber L",
-              "Rare Laser Chamber S"
-            ]
-          },
-          {
-            "name": "Lights",
-            "data": [
-              "Uncommon Light XS",
-              "Uncommon Light S"
-            ]
-          },
-          {
-            "name": "Magnetic Rails",
-            "data": [
-              "Advanced Magnetic Rail XS",
-              "Advanced Magnetic Rail S",
-              "Advanced Magnetic Rail M",
-              "Advanced Magnetic Rail L"
-            ]
-          },
-          {
-            "name": "Mechanical Sensors",
-            "data": [
-              "Basic Mechanical Sensor XS",
-              "Advanced Mechanical Sensor XS",
-              "Exotic Mechanical Sensor XS"
-            ]
-          },
-          {
-            "name": "Missile Silos",
-            "data": [
-              "Advanced Missile Silo XS",
-              "Advanced Missile Silo S",
-              "Advanced Missile Silo M",
-              "Advanced Missile Silo L"
-            ]
-          },
-          {
-            "name": "Mobile Panels",
-            "data": [
-              "Basic Mobile Panel XS",
-              "Basic Mobile Panel S",
-              "Basic Mobile Panel M",
-              "Basic Mobile Panel L",
-              "Basic Mobile Panel XL"
-            ]
-          },
-          {
-            "name": "Motherboards",
-            "data": [
-              "Advanced Motherboard M"
-            ]
-          },
-          {
-            "name": "Ore Scanners",
-            "data": [
-              "Uncommon Ore Scanner XL"
-            ]
-          },
-          {
-            "name": "Power Transformers",
-            "data": [
-              "Basic Power Transformer M",
-              "Uncommon Power Transformer S",
-              "Uncommon Power Transformer M",
-              "Rare Power Transformer L",
-              "Rare Power Transformer XL",
-              "Exotic Power Transformer L"
-            ]
-          },
-          {
-            "name": "Robotic Arms",
-            "data": [
-              "Basic Robotic Arm M",
-              "Basic Robotic Arm L",
-              "Basic Robotic Arm XL"
-            ]
-          },
-          {
-            "name": "Screens",
-            "data": [
-              "Basic Screen M",
-              "Uncommon Screen XS",
-              "Uncommon Screen XL",
-              "Advanced Screen XS"
-            ]
-          }
-        ]
-      },
-      {
-        "name": "Structural Parts",
-        "data": [
-          {
-            "name": "Casings",
-            "data": [
-              "Basic Casing XS",
-              "Basic Casing S",
-              "Uncommon Casing XS",
-              "Uncommon Casing S",
-              "Uncommon Casing M",
-              "Uncommon Casing XL",
-              "Advanced Casing XS",
-              "Advanced Casing S",
-              "Advanced Casing M",
-              "Advanced Casing L",
-              "Advanced Casing XL",
-              "Rare Casing XS",
-              "Rare Casing S",
-              "Exotic Casing S"
-            ]
-          },
-          {
-            "name": "Reinforced Frames",
-            "data": [
-              "Basic Reinforced Frame XS",
-              "Basic Reinforced Frame S",
-              "Basic Reinforced Frame M",
-              "Basic Reinforced Frame L",
-              "Basic Reinforced Frame XL",
-              "Uncommon Reinforced Frame XS",
-              "Uncommon Reinforced Frame S",
-              "Uncommon Reinforced Frame M",
-              "Uncommon Reinforced Frame L",
-              "Uncommon Reinforced Frame XL",
-              "Advanced Reinforced Frame XS",
-              "Advanced Reinforced Frame S",
-              "Advanced Reinforced Frame M",
-              "Advanced Reinforced Frame L",
-              "Rare Reinforced Frame L",
-              "Rare Reinforced Frame XL",
-              "Exotic Reinforced Frame M",
-              "Exotic Reinforced Frame L",
-              "Exotic Reinforced Frame XL"
-            ]
-          },
-          {
-            "name": "Standard Frames",
-            "data": [
-              "Basic Standard Frame XS",
-              "Basic Standard Frame S",
-              "Basic Standard Frame M",
-              "Basic Standard Frame L",
-              "Uncommon Standard Frame XS",
-              "Uncommon Standard Frame S",
-              "Uncommon Standard Frame M",
-              "Uncommon Standard Frame L",
-              "Advanced Standard Frame XS",
-              "Advanced Standard Frame S",
-              "Advanced Standard Frame M",
-              "Advanced Standard Frame L",
-              "Rare Standard Frame L",
-              "Exotic Standard Frame XS",
-              "Exotic Standard Frame L"
-            ]
-          }
-        ]
-      }
-    ]
-  }
+	},
+	{
+		"name": "Parts",
+		"data": [
+			{
+				"name": "Complex Parts",
+				"data": [
+					{
+						"name": "Anti-Matter Capsules",
+						"data": [
+							"Basic Anti-Matter Capsule",
+							"Uncommon Anti-Matter Capsule",
+							"Advanced Anti-Matter Capsule",
+							"Rare Anti-Matter Capsule",
+							"Exotic Anti-Matter Capsule"
+						]
+					},
+					{
+						"name": "Burners",
+						"data": [
+							"Basic Burner",
+							"Uncommon Burner",
+							"Advanced Burner"
+						]
+					},
+					{
+						"name": "Electronics",
+						"data": [
+							"Basic Electronics",
+							"Uncommon Electronics",
+							"Advanced Electronics",
+							"Rare Electronics",
+							"Exotic Electronics"
+						]
+					},
+					{
+						"name": "Explosive Modules",
+						"data": [
+							"Basic Explosive Module",
+							"Uncommon Explosive Module",
+							"Advanced Explosive Module"
+						]
+					},
+					{
+						"name": "Hydraulics",
+						"data": [
+							"Basic Hydraulics",
+							"Uncommon Hydraulics",
+							"Advanced Hydraulics"
+						]
+					},
+					{
+						"name": "Injectors",
+						"data": [
+							"Basic Injector",
+							"Advanced Injector"
+						]
+					},
+					{
+						"name": "Magnets",
+						"data": [
+							"Basic Magnet",
+							"Uncommon Magnet",
+							"Advanced Magnet",
+							"Rare Magnet",
+							"Exotic Magnet"
+						]
+					},
+					{
+						"name": "Optics",
+						"data": [
+							"Basic Optics",
+							"Uncommon Optics",
+							"Advanced Optics",
+							"Rare Optics"
+						]
+					},
+					{
+						"name": "Power Systems",
+						"data": [
+							"Basic Power System",
+							"Uncommon Power System",
+							"Advanced Power System",
+							"Rare Power System",
+							"Exotic Power System"
+						]
+					},
+					{
+						"name": "Processors",
+						"data": [
+							"Basic Processor",
+							"Uncommon Processor",
+							"Advanced Processor",
+							"Exotic Processor"
+						]
+					},
+					{
+						"name": "Quantum Cores",
+						"data": [
+							"Basic Quantum Core",
+							"Uncommon Quantum Core",
+							"Advanced Quantum Core",
+							"Rare Quantum Core",
+							"Exotic Quantum Core"
+						]
+					},
+					{
+						"name": "Singularity Containers",
+						"data": [
+							"Basic Singularity Container",
+							"Uncommon Singularity Container",
+							"Advanced Singularity Container",
+							"Rare Singularity Container",
+							"Exotic Singularity Container"
+						]
+					},
+					{
+						"name": "Solid Warhead",
+						"data": [
+							"Uncommon Solid Warhead",
+							"Advanced Solid Warhead"
+						]
+					}
+				]
+			},
+			{
+				"name": "Exceptional Parts",
+				"data": [
+					{
+						"name": "Anti-Gravity Cores",
+						"data": [
+							"Advanced Anti-Gravity Core",
+							"Rare Anti-Gravity Core",
+							"Exotic Anti-Gravity Core"
+						]
+					},
+					{
+						"name": "Anti-Matter Core Units",
+						"data": [
+							"Advanced Anti-Matter Core Unit",
+							"Exotic Anti-Matter Core Unit"
+						]
+					},
+					{
+						"name": "Quantum Alignment Units",
+						"data": [
+							"Advanced Quantum Alignment Unit",
+							"Exotic Quantum Alignment Unit"
+						]
+					},
+					{
+						"name": "Quantum Barriers",
+						"data": [
+							"Advanced Quantum Barrier"
+						]
+					}
+				]
+			},
+			{
+				"name": "Intermediary Parts",
+				"data": [
+					{
+						"name": "Components",
+						"data": [
+							"Basic Component",
+							"Uncommon Component",
+							"Advanced Component"
+						]
+					},
+					{
+						"name": "Connectors",
+						"data": [
+							"Basic Connector",
+							"Uncommon Connector",
+							"Advanced Connector"
+						]
+					},
+					{
+						"name": "Fixations",
+						"data": [
+							"Basic Fixation",
+							"Uncommon Fixation",
+							"Advanced Fixation"
+						]
+					},
+					{
+						"name": "LEDs",
+						"data": [
+							"Basic LED",
+							"Uncommon LED",
+							"Advanced LED"
+						]
+					},
+					{
+						"name": "Pipes",
+						"data": [
+							"Basic Pipe",
+							"Uncommon Pipe",
+							"Advanced Pipe"
+						]
+					},
+					{
+						"name": "Screws",
+						"data": [
+							"Basic Screw",
+							"Uncommon Screw",
+							"Advanced Screw"
+						]
+					}
+				]
+			},
+			{
+				"name": "Functional Parts",
+				"data": [
+					{
+						"name": "Antennas",
+						"data": [
+							"Basic Antenna XS",
+							"Basic Antenna S",
+							"Uncommon Antenna XS",
+							"Uncommon Antenna S",
+							"Uncommon Antenna M",
+							"Uncommon Antenna L",
+							"Exotic Antenna M",
+							"Exotic Antenna L",
+							"Exotic Antenna XL"
+						]
+					},
+					{
+						"name": "Chemical Containers",
+						"data": [
+							"Basic Chemical Container XS",
+							"Basic Chemical Container S",
+							"Basic Chemical Container M",
+							"Basic Chemical Container L",
+							"Basic Chemical Container XL",
+							"Advanced Chemical Container S",
+							"Advanced Chemical Container M",
+							"Advanced Chemical Container L",
+							"Advanced Chemical Container XL"
+						]
+					},
+					{
+						"name": "Combustion Chambers",
+						"data": [
+							"Basic Combustion Chamber XS",
+							"Basic Combustion Chamber S",
+							"Basic Combustion Chamber M",
+							"Basic Combustion Chamber L",
+							"Advanced Combustion Chamber XS",
+							"Advanced Combustion Chamber S",
+							"Advanced Combustion Chamber M"
+						]
+					},
+					{
+						"name": "Control Systems",
+						"data": [
+							"Basic Control System XS",
+							"Basic Control System S",
+							"Basic Control System M",
+							"Advanced Control System S",
+							"Advanced Control System M",
+							"Advanced Control System L"
+						]
+					},
+					{
+						"name": "Core Systems",
+						"data": [
+							"Basic Core System XS",
+							"Basic Core System S",
+							"Uncommon Core System S",
+							"Uncommon Core System M",
+							"Uncommon Core System L",
+							"Advanced Core System M",
+							"Rare Core System L",
+							"Exotic Core System S"
+						]
+					},
+					{
+						"name": "Electric Engines",
+						"data": [
+							"Basic Electric Engine S",
+							"Basic Electric Engine M",
+							"Uncommon Electric Engine XL"
+						]
+					},
+					{
+						"name": "Firing Systems",
+						"data": [
+							"Basic Firing System XS",
+							"Advanced Firing System XS",
+							"Advanced Firing System S",
+							"Advanced Firing System M",
+							"Advanced Firing System L"
+						]
+					},
+					{
+						"name": "Gas Cylinders",
+						"data": [
+							"Basic Gas Cylinder XS",
+							"Basic Gas Cylinder S",
+							"Basic Gas Cylinder M"
+						]
+					},
+					{
+						"name": "Ionic Chambers",
+						"data": [
+							"Basic Ionic Chamber XS",
+							"Basic Ionic Chamber S",
+							"Basic Ionic Chamber M",
+							"Basic Ionic Chamber L",
+							"Basic Ionic Chamber XL",
+							"Uncommon Ionic Chamber XS",
+							"Uncommon Ionic Chamber S",
+							"Uncommon Ionic Chamber M",
+							"Uncommon Ionic Chamber L",
+							"Uncommon Ionic Chamber XL",
+							"Advanced Ionic Chamber M",
+							"Advanced Ionic Chamber L"
+						]
+					},
+					{
+						"name": "Laser Chambers",
+						"data": [
+							"Uncommon Laser Chamber XS",
+							"Advanced Laser Chamber XS",
+							"Advanced Laser Chamber S",
+							"Advanced Laser Chamber M",
+							"Advanced Laser Chamber L",
+							"Rare Laser Chamber S"
+						]
+					},
+					{
+						"name": "Lights",
+						"data": [
+							"Uncommon Light XS",
+							"Uncommon Light S"
+						]
+					},
+					{
+						"name": "Magnetic Rails",
+						"data": [
+							"Advanced Magnetic Rail XS",
+							"Advanced Magnetic Rail S",
+							"Advanced Magnetic Rail M",
+							"Advanced Magnetic Rail L"
+						]
+					},
+					{
+						"name": "Mechanical Sensors",
+						"data": [
+							"Basic Mechanical Sensor XS",
+							"Advanced Mechanical Sensor XS",
+							"Exotic Mechanical Sensor XS"
+						]
+					},
+					{
+						"name": "Missile Silos",
+						"data": [
+							"Advanced Missile Silo XS",
+							"Advanced Missile Silo S",
+							"Advanced Missile Silo M",
+							"Advanced Missile Silo L"
+						]
+					},
+					{
+						"name": "Mobile Panels",
+						"data": [
+							"Basic Mobile Panel XS",
+							"Basic Mobile Panel S",
+							"Basic Mobile Panel M",
+							"Basic Mobile Panel L",
+							"Basic Mobile Panel XL"
+						]
+					},
+					{
+						"name": "Motherboards",
+						"data": [
+							"Advanced Motherboard M"
+						]
+					},
+					{
+						"name": "Ore Scanners",
+						"data": [
+							"Uncommon Ore Scanner XL"
+						]
+					},
+					{
+						"name": "Power Transformers",
+						"data": [
+							"Basic Power Transformer M",
+							"Uncommon Power Transformer S",
+							"Uncommon Power Transformer M",
+							"Rare Power Transformer L",
+							"Rare Power Transformer XL",
+							"Exotic Power Transformer L"
+						]
+					},
+					{
+						"name": "Robotic Arms",
+						"data": [
+							"Basic Robotic Arm M",
+							"Basic Robotic Arm L",
+							"Basic Robotic Arm XL"
+						]
+					},
+					{
+						"name": "Screens",
+						"data": [
+							"Basic Screen M",
+							"Uncommon Screen XS",
+							"Uncommon Screen XL",
+							"Advanced Screen XS"
+						]
+					}
+				]
+			},
+			{
+				"name": "Structural Parts",
+				"data": [
+					{
+						"name": "Casings",
+						"data": [
+							"Basic Casing XS",
+							"Basic Casing S",
+							"Uncommon Casing XS",
+							"Uncommon Casing S",
+							"Uncommon Casing M",
+							"Uncommon Casing XL",
+							"Advanced Casing XS",
+							"Advanced Casing S",
+							"Advanced Casing M",
+							"Advanced Casing L",
+							"Advanced Casing XL",
+							"Rare Casing XS",
+							"Rare Casing S",
+							"Exotic Casing S"
+						]
+					},
+					{
+						"name": "Reinforced Frames",
+						"data": [
+							"Basic Reinforced Frame XS",
+							"Basic Reinforced Frame S",
+							"Basic Reinforced Frame M",
+							"Basic Reinforced Frame L",
+							"Basic Reinforced Frame XL",
+							"Uncommon Reinforced Frame XS",
+							"Uncommon Reinforced Frame S",
+							"Uncommon Reinforced Frame M",
+							"Uncommon Reinforced Frame L",
+							"Uncommon Reinforced Frame XL",
+							"Advanced Reinforced Frame XS",
+							"Advanced Reinforced Frame S",
+							"Advanced Reinforced Frame M",
+							"Advanced Reinforced Frame L",
+							"Rare Reinforced Frame L",
+							"Rare Reinforced Frame XL",
+							"Exotic Reinforced Frame M",
+							"Exotic Reinforced Frame L",
+							"Exotic Reinforced Frame XL"
+						]
+					},
+					{
+						"name": "Standard Frames",
+						"data": [
+							"Basic Standard Frame XS",
+							"Basic Standard Frame S",
+							"Basic Standard Frame M",
+							"Basic Standard Frame L",
+							"Uncommon Standard Frame XS",
+							"Uncommon Standard Frame S",
+							"Uncommon Standard Frame M",
+							"Uncommon Standard Frame L",
+							"Advanced Standard Frame XS",
+							"Advanced Standard Frame S",
+							"Advanced Standard Frame M",
+							"Advanced Standard Frame L",
+							"Rare Standard Frame L",
+							"Exotic Standard Frame XS",
+							"Exotic Standard Frame L"
+						]
+					}
+				]
+			}
+		]
+	}
 ]

--- a/data/recipes.json
+++ b/data/recipes.json
@@ -251,7 +251,7 @@
 		"industries": [],
 		"input": {}
 	},
-	"Oxygen Pure": {
+	"Pure Oxygen": {
 		"tier": 1,
 		"type": "Pure",
 		"mass": 1,
@@ -266,7 +266,7 @@
 		],
 		"input": {}
 	},
-	"Hydrogen Pure": {
+	"Pure Hydrogen": {
 		"tier": 1,
 		"type": "Pure",
 		"mass": 0.07,
@@ -281,7 +281,7 @@
 		],
 		"input": {}
 	},
-	"Aluminium Pure": {
+	"Pure Aluminium": {
 		"tier": 1,
 		"type": "Pure",
 		"mass": 2.7,
@@ -290,7 +290,7 @@
 		"time": 225,
 		"skill": "",
 		"byproducts": {
-			"Hydrogen Pure": 135
+			"Pure Hydrogen": 135
 		},
 		"industries": [
 			"Nanopack",
@@ -300,7 +300,7 @@
 			"Bauxite": 585
 		}
 	},
-	"Carbon Pure": {
+	"Pure Carbon": {
 		"tier": 1,
 		"type": "Pure",
 		"mass": 2.27,
@@ -309,8 +309,8 @@
 		"time": 225,
 		"skill": "",
 		"byproducts": {
-			"Oxygen Pure": 67.5,
-			"Hydrogen Pure": 67.5
+			"Pure Oxygen": 67.5,
+			"Pure Hydrogen": 67.5
 		},
 		"industries": [
 			"Nanopack",
@@ -320,7 +320,7 @@
 			"Coal": 585
 		}
 	},
-	"Silicon Pure": {
+	"Pure Silicon": {
 		"tier": 1,
 		"type": "Pure",
 		"mass": 2.33,
@@ -329,7 +329,7 @@
 		"time": 225,
 		"skill": "",
 		"byproducts": {
-			"Oxygen Pure": 135
+			"Pure Oxygen": 135
 		},
 		"industries": [
 			"Nanopack",
@@ -339,7 +339,7 @@
 			"Quartz": 585
 		}
 	},
-	"Iron Pure": {
+	"Pure Iron": {
 		"tier": 1,
 		"type": "Pure",
 		"mass": 7.85,
@@ -348,7 +348,7 @@
 		"time": 225,
 		"skill": "",
 		"byproducts": {
-			"Oxygen Pure": 135
+			"Pure Oxygen": 135
 		},
 		"industries": [
 			"Nanopack",
@@ -358,17 +358,17 @@
 			"Hematite": 585
 		}
 	},
-	"Calcium Pure": {
+	"Pure Calcium": {
 		"tier": 2,
 		"type": "Pure",
 		"mass": 1.55,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 120,
+		"time": 125,
 		"skill": "",
 		"byproducts": {
-			"Oxygen Pure": 7.5,
-			"Carbon Pure": 7.5
+			"Pure Oxygen": 7.5,
+			"Pure Carbon": 7.5
 		},
 		"industries": [
 			"Refiner M"
@@ -377,17 +377,17 @@
 			"Limestone": 65
 		}
 	},
-	"Chromium Pure": {
+	"Pure Chromium": {
 		"tier": 2,
 		"type": "Pure",
 		"mass": 7.19,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 120,
+		"time": 125,
 		"skill": "",
 		"byproducts": {
-			"Oxygen Pure": 7.5,
-			"Iron Pure": 7.5
+			"Pure Oxygen": 7.5,
+			"Pure Iron": 7.5
 		},
 		"industries": [
 			"Refiner M"
@@ -396,17 +396,17 @@
 			"Chromite": 65
 		}
 	},
-	"Copper Pure": {
+	"Pure Copper": {
 		"tier": 2,
 		"type": "Pure",
 		"mass": 8.96,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 120,
+		"time": 125,
 		"skill": "",
 		"byproducts": {
-			"Hydrogen Pure": 7.5,
-			"Carbon Pure": 7.5
+			"Pure Hydrogen": 7.5,
+			"Pure Carbon": 7.5
 		},
 		"industries": [
 			"Refiner M"
@@ -415,17 +415,17 @@
 			"Malachite": 65
 		}
 	},
-	"Sodium Pure": {
+	"Pure Sodium": {
 		"tier": 2,
 		"type": "Pure",
 		"mass": 0.97,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 120,
+		"time": 125,
 		"skill": "",
 		"byproducts": {
-			"Hydrogen Pure": 7.5,
-			"Carbon Pure": 7.5
+			"Pure Hydrogen": 7.5,
+			"Pure Carbon": 7.5
 		},
 		"industries": [
 			"Refiner M"
@@ -434,17 +434,17 @@
 			"Natron": 65
 		}
 	},
-	"Lithium Pure": {
+	"Pure Lithium": {
 		"tier": 3,
 		"type": "Pure",
 		"mass": 0.53,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 600,
+		"time": 625,
 		"skill": "",
 		"byproducts": {
-			"Silicon Pure": 7.5,
-			"Aluminium Pure": 7.5
+			"Pure Silicon": 7.5,
+			"Pure Aluminium": 7.5
 		},
 		"industries": [
 			"Refiner M"
@@ -453,17 +453,17 @@
 			"Petalite": 65
 		}
 	},
-	"Nickel Pure": {
+	"Pure Nickel": {
 		"tier": 3,
 		"type": "Pure",
 		"mass": 8.91,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 600,
+		"time": 625,
 		"skill": "",
 		"byproducts": {
-			"Oxygen Pure": 7.5,
-			"Silicon Pure": 7.5
+			"Pure Oxygen": 7.5,
+			"Pure Silicon": 7.5
 		},
 		"industries": [
 			"Refiner M"
@@ -472,16 +472,16 @@
 			"Garnierite": 65
 		}
 	},
-	"Silver Pure": {
+	"Pure Silver": {
 		"tier": 3,
 		"type": "Pure",
 		"mass": 10.49,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 600,
+		"time": 625,
 		"skill": "",
 		"byproducts": {
-			"Sulfur Pure": 15
+			"Pure Sulfur": 15
 		},
 		"industries": [
 			"Refiner M"
@@ -490,16 +490,16 @@
 			"Acanthite": 65
 		}
 	},
-	"Sulfur Pure": {
+	"Pure Sulfur": {
 		"tier": 3,
 		"type": "Pure",
 		"mass": 1.82,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 600,
+		"time": 625,
 		"skill": "",
 		"byproducts": {
-			"Iron Pure": 15
+			"Pure Iron": 15
 		},
 		"industries": [
 			"Refiner M"
@@ -508,16 +508,16 @@
 			"Pyrite": 65
 		}
 	},
-	"Cobalt Pure": {
+	"Pure Cobalt": {
 		"tier": 4,
 		"type": "Pure",
 		"mass": 8.9,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 3120,
+		"time": 3125,
 		"skill": "",
 		"byproducts": {
-			"Sulfur Pure": 15
+			"Pure Sulfur": 15
 		},
 		"industries": [
 			"Refiner M"
@@ -526,17 +526,17 @@
 			"Cobaltite": 65
 		}
 	},
-	"Fluorine Pure": {
+	"Pure Fluorine": {
 		"tier": 4,
 		"type": "Pure",
 		"mass": 1.7,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 3120,
+		"time": 3125,
 		"skill": "",
 		"byproducts": {
-			"Sodium Pure": 7.5,
-			"Aluminium Pure": 7.5
+			"Pure Sodium": 7.5,
+			"Pure Aluminium": 7.5
 		},
 		"industries": [
 			"Refiner M"
@@ -545,13 +545,13 @@
 			"Cryolite": 65
 		}
 	},
-	"Gold Pure": {
+	"Pure Gold": {
 		"tier": 4,
 		"type": "Pure",
 		"mass": 19.3,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 3120,
+		"time": 3125,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -561,17 +561,17 @@
 			"Gold Nuggets": 65
 		}
 	},
-	"Scandium Pure": {
+	"Pure Scandium": {
 		"tier": 4,
 		"type": "Pure",
 		"mass": 2.98,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 3120,
+		"time": 3125,
 		"skill": "",
 		"byproducts": {
-			"Oxygen Pure": 7.5,
-			"Hydrogen Pure": 7.5
+			"Pure Oxygen": 7.5,
+			"Pure Hydrogen": 7.5
 		},
 		"industries": [
 			"Refiner M"
@@ -580,18 +580,18 @@
 			"Kolbeckite": 65
 		}
 	},
-	"Manganese Pure": {
+	"Pure Manganese": {
 		"tier": 5,
 		"type": "Pure",
 		"mass": 7.21,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 14400,
+		"time": 15600,
 		"skill": "",
 		"byproducts": {
-			"Calcium Pure": 5,
-			"Silicon Pure": 5,
-			"Oxygen Pure": 5
+			"Pure Calcium": 5,
+			"Pure Silicon": 5,
+			"Pure Oxygen": 5
 		},
 		"industries": [
 			"Refiner M"
@@ -600,18 +600,18 @@
 			"Rhodonite": 65
 		}
 	},
-	"Niobium Pure": {
+	"Pure Niobium": {
 		"tier": 5,
 		"type": "Pure",
 		"mass": 8.57,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 14400,
+		"time": 15600,
 		"skill": "",
 		"byproducts": {
-			"Iron Pure": 5,
-			"Manganese Pure": 5,
-			"Oxygen Pure": 5
+			"Pure Iron": 5,
+			"Pure Manganese": 5,
+			"Pure Oxygen": 5
 		},
 		"industries": [
 			"Refiner M"
@@ -620,17 +620,17 @@
 			"Columbite": 65
 		}
 	},
-	"Titanium Pure": {
+	"Pure Titanium": {
 		"tier": 5,
 		"type": "Pure",
 		"mass": 4.51,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 14400,
+		"time": 15600,
 		"skill": "",
 		"byproducts": {
-			"Iron Pure": 7.5,
-			"Oxygen Pure": 7.5
+			"Pure Iron": 7.5,
+			"Pure Oxygen": 7.5
 		},
 		"industries": [
 			"Refiner M"
@@ -639,16 +639,16 @@
 			"Illmenite": 65
 		}
 	},
-	"Vanadium Pure": {
+	"Pure Vanadium": {
 		"tier": 5,
 		"type": "Pure",
 		"mass": 6,
 		"volume": 1,
 		"outputQuantity": 45,
-		"time": 14400,
+		"time": 15600,
 		"skill": "",
 		"byproducts": {
-			"Oxygen Pure": 15
+			"Pure Oxygen": 15
 		},
 		"industries": [
 			"Refiner M"
@@ -662,7 +662,7 @@
 		"type": "Catalyst",
 		"mass": 649.39,
 		"volume": 1,
-		"outputQuantity": 1,
+		"outputQuantity": 10,
 		"time": 2500,
 		"skill": "",
 		"byproducts": {},
@@ -670,10 +670,10 @@
 			"Chemical Industry M"
 		],
 		"input": {
-			"Hydrogen Pure": 300,
-			"Iron Pure": 200,
-			"Sodium Pure": 100,
-			"Sulfur Pure": 50
+			"Pure Hydrogen": 300,
+			"Pure Iron": 200,
+			"Pure Sodium": 100,
+			"Pure Sulfur": 50
 		}
 	},
 	"Catalyst 4": {
@@ -681,7 +681,7 @@
 		"type": "Catalyst",
 		"mass": 606.65,
 		"volume": 1,
-		"outputQuantity": 1,
+		"outputQuantity": 10,
 		"time": 12480,
 		"skill": "",
 		"byproducts": {},
@@ -689,11 +689,11 @@
 			"Chemical Industry M"
 		],
 		"input": {
-			"Hydrogen Pure": 300,
-			"Iron Pure": 500,
-			"Sodium Pure": 200,
-			"Sulfur Pure": 100,
-			"Fluorine Pure": 50
+			"Pure Hydrogen": 300,
+			"Pure Iron": 500,
+			"Pure Sodium": 200,
+			"Pure Sulfur": 100,
+			"Pure Fluorine": 50
 		}
 	},
 	"Catalyst 5": {
@@ -701,7 +701,7 @@
 		"type": "Catalyst",
 		"mass": 657.68,
 		"volume": 1,
-		"outputQuantity": 1,
+		"outputQuantity": 10,
 		"time": 62520,
 		"skill": "",
 		"byproducts": {},
@@ -709,12 +709,12 @@
 			"Chemical Industry M"
 		],
 		"input": {
-			"Hydrogen Pure": 300,
-			"Iron Pure": 1000,
-			"Sodium Pure": 500,
-			"Sulfur Pure": 200,
-			"Fluorine Pure": 100,
-			"Manganese Pure": 50
+			"Pure Hydrogen": 300,
+			"Pure Iron": 1000,
+			"Pure Sodium": 500,
+			"Pure Sulfur": 200,
+			"Pure Fluorine": 100,
+			"Pure Manganese": 50
 		}
 	},
 	"Nitron Fuel": {
@@ -722,8 +722,8 @@
 		"type": "Fuel",
 		"mass": 4,
 		"volume": 1,
-		"outputQuantity": 100,
-		"time": 20,
+		"outputQuantity": 300,
+		"time": 180,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -731,10 +731,10 @@
 			"Chemical Industry M"
 		],
 		"input": {
-			"Silicon Pure": 20,
-			"Carbon Pure": 20,
-			"Oxygen Pure": 40,
-			"Hydrogen Pure": 20
+			"Pure Silicon": 60,
+			"Pure Carbon": 60,
+			"Pure Oxygen": 120,
+			"Pure Hydrogen": 60
 		}
 	},
 	"Kergon-X1 Fuel": {
@@ -743,16 +743,16 @@
 		"mass": 6,
 		"volume": 1,
 		"outputQuantity": 100,
-		"time": 40,
+		"time": 120,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
 			"Chemical Industry M"
 		],
 		"input": {
-			"Sodium Pure": 40,
-			"Oxygen Pure": 30,
-			"Hydrogen Pure": 30
+			"Pure Sodium": 40,
+			"Pure Oxygen": 30,
+			"Pure Hydrogen": 30
 		}
 	},
 	"Kergon-X2 Fuel": {
@@ -761,16 +761,16 @@
 		"mass": 6,
 		"volume": 1,
 		"outputQuantity": 100,
-		"time": 40,
+		"time": 120,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
 			"Chemical Industry M"
 		],
 		"input": {
-			"Calcium Pure": 40,
-			"Oxygen Pure": 25,
-			"Hydrogen Pure": 35
+			"Pure Calcium": 40,
+			"Pure Oxygen": 25,
+			"Pure Hydrogen": 35
 		}
 	},
 	"Kergon-X3 Fuel": {
@@ -779,16 +779,16 @@
 		"mass": 6,
 		"volume": 1,
 		"outputQuantity": 100,
-		"time": 40,
+		"time": 120,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
 			"Chemical Industry M"
 		],
 		"input": {
-			"Chromium Pure": 40,
-			"Oxygen Pure": 35,
-			"Hydrogen Pure": 25
+			"Pure Chromium": 40,
+			"Pure Oxygen": 35,
+			"Pure Hydrogen": 25
 		}
 	},
 	"Kergon-X4 Fuel": {
@@ -797,16 +797,16 @@
 		"mass": 6,
 		"volume": 1,
 		"outputQuantity": 100,
-		"time": 40,
+		"time": 120,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
 			"Chemical Industry M"
 		],
 		"input": {
-			"Copper Pure": 40,
-			"Oxygen Pure": 30,
-			"Hydrogen Pure": 30
+			"Pure Copper": 40,
+			"Pure Oxygen": 30,
+			"Pure Hydrogen": 30
 		}
 	},
 	"Xeron Fuel": {
@@ -815,17 +815,17 @@
 		"mass": 0.8,
 		"volume": 1,
 		"outputQuantity": 100,
-		"time": 60,
+		"time": 240,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
 			"Chemical Industry M"
 		],
 		"input": {
-			"Chromium Pure": 10,
-			"Sodium Pure": 10,
-			"Hydrogen Pure": 60,
-			"Oxygen Pure": 20
+			"Pure Chromium": 10,
+			"Pure Sodium": 10,
+			"Pure Hydrogen": 60,
+			"Pure Oxygen": 20
 		}
 	},
 	"Al-Fe Alloy": {
@@ -842,8 +842,8 @@
 			"Smelter M"
 		],
 		"input": {
-			"Aluminium Pure": 100,
-			"Iron Pure": 50
+			"Pure Aluminium": 100,
+			"Pure Iron": 50
 		}
 	},
 	"Al-Li Alloy": {
@@ -852,7 +852,7 @@
 		"mass": 2.5,
 		"volume": 1,
 		"outputQuantity": 75,
-		"time": 3780,
+		"time": 3750,
 		"skill": "",
 		"byproducts": {
 			"Catalyst 3": 1
@@ -861,8 +861,8 @@
 			"Smelter M"
 		],
 		"input": {
-			"Lithium Pure": 100,
-			"Aluminium Pure": 50,
+			"Pure Lithium": 100,
+			"Pure Aluminium": 50,
 			"Catalyst 3": 1
 		}
 	},
@@ -879,8 +879,8 @@
 			"Smelter M"
 		],
 		"input": {
-			"Copper Pure": 100,
-			"Calcium Pure": 50
+			"Pure Copper": 100,
+			"Pure Calcium": 50
 		}
 	},
 	"Cu-Ag Alloy": {
@@ -889,7 +889,7 @@
 		"mass": 9.2,
 		"volume": 1,
 		"outputQuantity": 75,
-		"time": 3780,
+		"time": 3750,
 		"skill": "",
 		"byproducts": {
 			"Catalyst 3": 1
@@ -898,8 +898,8 @@
 			"Smelter M"
 		],
 		"input": {
-			"Silver Pure": 100,
-			"Copper Pure": 50,
+			"Pure Silver": 100,
+			"Pure Copper": 50,
 			"Catalyst 3": 1
 		}
 	},
@@ -916,8 +916,8 @@
 			"Smelter M"
 		],
 		"input": {
-			"Copper Pure": 100,
-			"Aluminium Pure": 50
+			"Pure Copper": 100,
+			"Pure Aluminium": 50
 		}
 	},
 	"Grade 5 Titanium Alloy": {
@@ -935,9 +935,9 @@
 			"Smelter M"
 		],
 		"input": {
-			"Titanium Pure": 100,
-			"Vanadium Pure": 50,
-			"Aluminium Pure": 50,
+			"Pure Titanium": 100,
+			"Pure Vanadium": 50,
+			"Pure Aluminium": 50,
 			"Catalyst 5": 1
 		}
 	},
@@ -956,9 +956,9 @@
 			"Smelter M"
 		],
 		"input": {
-			"Nickel Pure": 100,
-			"Chromium Pure": 50,
-			"Iron Pure": 50,
+			"Pure Nickel": 100,
+			"Pure Chromium": 50,
+			"Pure Iron": 50,
 			"Catalyst 3": 1
 		}
 	},
@@ -977,9 +977,9 @@
 			"Smelter M"
 		],
 		"input": {
-			"Manganese Pure": 100,
-			"Niobium Pure": 50,
-			"Iron Pure": 50,
+			"Pure Manganese": 100,
+			"Pure Niobium": 50,
+			"Pure Iron": 50,
 			"Catalyst 5": 1
 		}
 	},
@@ -998,9 +998,9 @@
 			"Smelter M"
 		],
 		"input": {
-			"Cobalt Pure": 100,
-			"Nickel Pure": 50,
-			"Iron Pure": 50,
+			"Pure Cobalt": 100,
+			"Pure Nickel": 50,
+			"Pure Iron": 50,
 			"Catalyst 4": 1
 		}
 	},
@@ -1019,8 +1019,8 @@
 			"Smelter M"
 		],
 		"input": {
-			"Gold Pure": 100,
-			"Copper Pure": 50,
+			"Pure Gold": 100,
+			"Pure Copper": 50,
 			"Catalyst 4": 1
 		}
 	},
@@ -1039,9 +1039,9 @@
 			"Smelter M"
 		],
 		"input": {
-			"Scandium Pure": 100,
-			"Aluminium Pure": 50,
-			"Lithium Pure": 50,
+			"Pure Scandium": 100,
+			"Pure Aluminium": 50,
+			"Pure Lithium": 50,
 			"Catalyst 4": 1
 		}
 	},
@@ -1058,9 +1058,9 @@
 			"Smelter M"
 		],
 		"input": {
-			"Chromium Pure": 100,
-			"Iron Pure": 50,
-			"Carbon Pure": 50
+			"Pure Chromium": 100,
+			"Pure Iron": 50,
+			"Pure Carbon": 50
 		}
 	},
 	"Ti-Nb Supraconductor": {
@@ -1078,8 +1078,8 @@
 			"Smelter M"
 		],
 		"input": {
-			"Niobium Pure": 100,
-			"Titanium Pure": 50,
+			"Pure Niobium": 100,
+			"Pure Titanium": 50,
 			"Catalyst 5": 1
 		}
 	},
@@ -1097,9 +1097,9 @@
 			"Chemical Industry M"
 		],
 		"input": {
-			"Carbon Pure": 100,
-			"Oxygen Pure": 50,
-			"Hydrogen Pure": 50
+			"Pure Carbon": 100,
+			"Pure Oxygen": 50,
+			"Pure Hydrogen": 50
 		}
 	},
 	"Brick": {
@@ -1116,9 +1116,9 @@
 			"Smelter M"
 		],
 		"input": {
-			"Silicon Pure": 50,
-			"Aluminium Pure": 50,
-			"Oxygen Pure": 50
+			"Pure Silicon": 50,
+			"Pure Aluminium": 50,
+			"Pure Oxygen": 50
 		}
 	},
 	"Marble": {
@@ -1134,9 +1134,9 @@
 			"Refiner M"
 		],
 		"input": {
-			"Calcium Pure": 50,
-			"Carbon Pure": 50,
-			"Oxygen Pure": 50
+			"Pure Calcium": 50,
+			"Pure Carbon": 50,
+			"Pure Oxygen": 50
 		}
 	},
 	"Concrete": {
@@ -1152,9 +1152,9 @@
 			"Refiner M"
 		],
 		"input": {
-			"Calcium Pure": 5,
-			"Carbon Pure": 37.5,
-			"Silicon Pure": 37.5
+			"Pure Calcium": 5,
+			"Pure Carbon": 37.5,
+			"Pure Silicon": 37.5
 		}
 	},
 	"Carbon Fiber": {
@@ -1172,7 +1172,7 @@
 		],
 		"input": {
 			"Polycarbonate Plastic": 50,
-			"Carbon Pure": 50
+			"Pure Carbon": 50
 		}
 	},
 	"Glass": {
@@ -1189,8 +1189,8 @@
 			"Glass Furnace M"
 		],
 		"input": {
-			"Silicon Pure": 100,
-			"Oxygen Pure": 50
+			"Pure Silicon": 100,
+			"Pure Oxygen": 50
 		}
 	},
 	"Advanced Glass": {
@@ -1206,10 +1206,10 @@
 			"Glass Furnace M"
 		],
 		"input": {
-			"Sodium Pure": 100,
-			"Calcium Pure": 50,
-			"Silicon Pure": 50,
-			"Oxygen Pure": 50
+			"Pure Sodium": 100,
+			"Pure Calcium": 50,
+			"Pure Silicon": 50,
+			"Pure Oxygen": 50
 		}
 	},
 	"Ag-Li Reinforced Glass": {
@@ -1227,14 +1227,14 @@
 			"Glass Furnace M"
 		],
 		"input": {
-			"Silver Pure": 100,
-			"Lithium Pure": 50,
-			"Silicon Pure": 50,
-			"Oxygen Pure": 50,
+			"Pure Silver": 100,
+			"Pure Lithium": 50,
+			"Pure Silicon": 50,
+			"Pure Oxygen": 50,
 			"Catalyst 3": 1
 		}
 	},
-	"Gold Coated Glass": {
+	"Gold-Coated Glass": {
 		"tier": 4,
 		"type": "Product",
 		"mass": 3,
@@ -1249,10 +1249,10 @@
 			"Glass Furnace M"
 		],
 		"input": {
-			"Gold Pure": 100,
-			"Silicon Pure": 50,
-			"Sodium Pure": 50,
-			"Oxygen Pure": 50,
+			"Pure Gold": 100,
+			"Pure Silicon": 50,
+			"Pure Sodium": 50,
+			"Pure Oxygen": 50,
 			"Catalyst 4": 1
 		}
 	},
@@ -1271,10 +1271,10 @@
 			"Glass Furnace M"
 		],
 		"input": {
-			"Manganese Pure": 100,
-			"Calcium Pure": 50,
-			"Silicon Pure": 50,
-			"Oxygen Pure": 50,
+			"Pure Manganese": 100,
+			"Pure Calcium": 50,
+			"Pure Silicon": 50,
+			"Pure Oxygen": 50,
 			"Catalyst 5": 1
 		}
 	},
@@ -1292,8 +1292,8 @@
 			"Chemical Industry M"
 		],
 		"input": {
-			"Carbon Pure": 100,
-			"Hydrogen Pure": 50
+			"Pure Carbon": 100,
+			"Pure Hydrogen": 50
 		}
 	},
 	"Polycalcite Plastic": {
@@ -1309,9 +1309,9 @@
 			"Chemical Industry M"
 		],
 		"input": {
-			"Calcium Pure": 100,
-			"Carbon Pure": 50,
-			"Hydrogen Pure": 50
+			"Pure Calcium": 100,
+			"Pure Carbon": 50,
+			"Pure Hydrogen": 50
 		}
 	},
 	"Polysulfide Plastic": {
@@ -1329,9 +1329,9 @@
 			"Chemical Industry M"
 		],
 		"input": {
-			"Sulfur Pure": 100,
-			"Carbon Pure": 50,
-			"Hydrogen Pure": 50,
+			"Pure Sulfur": 100,
+			"Pure Carbon": 50,
+			"Pure Hydrogen": 50,
 			"Catalyst 3": 1
 		}
 	},
@@ -1350,9 +1350,9 @@
 			"Chemical Industry M"
 		],
 		"input": {
-			"Fluorine Pure": 100,
-			"Carbon Pure": 50,
-			"Hydrogen Pure": 50,
+			"Pure Fluorine": 100,
+			"Pure Carbon": 50,
+			"Pure Hydrogen": 50,
 			"Catalyst 4": 1
 		}
 	},
@@ -1371,10 +1371,10 @@
 			"Chemical Industry M"
 		],
 		"input": {
-			"Vanadium Pure": 100,
-			"Sulfur Pure": 50,
-			"Carbon Pure": 50,
-			"Hydrogen Pure": 50,
+			"Pure Vanadium": 100,
+			"Pure Sulfur": 50,
+			"Pure Carbon": 50,
+			"Pure Hydrogen": 50,
 			"Catalyst 5": 1
 		}
 	},
@@ -1392,8 +1392,8 @@
 			"Smelter M"
 		],
 		"input": {
-			"Aluminium Pure": 100,
-			"Silicon Pure": 50
+			"Pure Aluminium": 100,
+			"Pure Silicon": 50
 		}
 	},
 	"Steel": {
@@ -1410,8 +1410,8 @@
 			"Smelter M"
 		],
 		"input": {
-			"Iron Pure": 100,
-			"Carbon Pure": 50
+			"Pure Iron": 100,
+			"Pure Carbon": 50
 		}
 	},
 	"Wood": {
@@ -1428,8 +1428,8 @@
 			"Refiner M"
 		],
 		"input": {
-			"Carbon Pure": 50,
-			"Oxygen Pure": 50
+			"Pure Carbon": 50,
+			"Pure Oxygen": 50
 		}
 	},
 	"Basic Component": {
@@ -1437,8 +1437,8 @@
 		"type": "Intermediary Part",
 		"mass": 2.25,
 		"volume": 0.5,
-		"outputQuantity": 20,
-		"time": 240,
+		"outputQuantity": 10,
+		"time": 120,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -1446,7 +1446,7 @@
 			"Electronics Industry M"
 		],
 		"input": {
-			"Al-Fe Alloy": 20
+			"Al-Fe Alloy": 10
 		}
 	},
 	"Uncommon Component": {
@@ -1489,8 +1489,8 @@
 		"type": "Intermediary Part",
 		"mass": 3.75,
 		"volume": 0.8,
-		"outputQuantity": 20,
-		"time": 240,
+		"outputQuantity": 10,
+		"time": 120,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -1498,7 +1498,7 @@
 			"Electronics Industry M"
 		],
 		"input": {
-			"Al-Fe Alloy": 20
+			"Al-Fe Alloy": 10
 		}
 	},
 	"Uncommon Connector": {
@@ -1542,7 +1542,7 @@
 		"mass": 1.12,
 		"volume": 1,
 		"outputQuantity": 10,
-		"time": 240,
+		"time": 120,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -1559,7 +1559,7 @@
 		"mass": 1.16,
 		"volume": 1,
 		"outputQuantity": 10,
-		"time": 120,
+		"time": 480,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -1583,9 +1583,9 @@
 			"3D Printer M"
 		],
 		"input": {
-			"Polycarbonate Plastic": 5,
-			"Polycalcite Plastic": 5,
-			"Polysulfide Plastic": 5
+			"Polycarbonate Plastic": 3,
+			"Polycalcite Plastic": 3,
+			"Polysulfide Plastic": 4
 		}
 	},
 	"Basic LED": {
@@ -1645,7 +1645,7 @@
 		"type": "Intermediary Part",
 		"mass": 2.4,
 		"volume": 1,
-		"outputQuantity": 20,
+		"outputQuantity": 10,
 		"time": 240,
 		"skill": "",
 		"byproducts": {},
@@ -1654,7 +1654,7 @@
 			"Metalwork Industry M"
 		],
 		"input": {
-			"Silumin": 20
+			"Silumin": 10
 		}
 	},
 	"Uncommon Pipe": {
@@ -1697,8 +1697,8 @@
 		"type": "Intermediary Part",
 		"mass": 8.05,
 		"volume": 1,
-		"outputQuantity": 20,
-		"time": 240,
+		"outputQuantity": 10,
+		"time": 120,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -1706,7 +1706,7 @@
 			"Metalwork Industry M"
 		],
 		"input": {
-			"Steel": 20
+			"Steel": 10
 		}
 	},
 	"Uncommon Screw": {
@@ -1744,13 +1744,13 @@
 			"Inconel": 4
 		}
 	},
-	"Basic Anti-Matter Capsule": {
+	"Basic Antimatter Capsule": {
 		"tier": 1,
 		"type": "Complex Part",
 		"mass": 24,
 		"volume": 4.6,
-		"outputQuantity": 1,
-		"time": 60,
+		"outputQuantity": 3,
+		"time": 180,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -1758,11 +1758,11 @@
 			"Glass Furnace M"
 		],
 		"input": {
-			"Glass": 6,
-			"Basic Connector": 4
+			"Glass": 18,
+			"Basic Connector": 12
 		}
 	},
-	"Uncommon Anti-Matter Capsule": {
+	"Uncommon Antimatter Capsule": {
 		"tier": 2,
 		"type": "Complex Part",
 		"mass": 24.32,
@@ -1780,7 +1780,7 @@
 			"Advanced Glass": 4
 		}
 	},
-	"Advanced Anti-Matter Capsule": {
+	"Advanced Antimatter Capsule": {
 		"tier": 3,
 		"type": "Complex Part",
 		"mass": 24.88,
@@ -1798,47 +1798,6 @@
 			"Advanced Glass": 2,
 			"Uncommon Connector": 2,
 			"Ag-Li Reinforced Glass": 2
-		}
-	},
-	"Rare Anti-Matter Capsule": {
-		"tier": 4,
-		"type": "Complex Part",
-		"mass": 25.8,
-		"volume": 4.6,
-		"outputQuantity": 1,
-		"time": 3840,
-		"skill": "",
-		"byproducts": {},
-		"industries": [
-			"Glass Furnace M"
-		],
-		"input": {
-			"Basic Connector": 1,
-			"Advanced Glass": 2,
-			"Uncommon Connector": 3,
-			"Ag-Li Reinforced Glass": 2,
-			"Gold Coated Glass": 2
-		}
-	},
-	"Exotic Anti-Matter Capsule": {
-		"tier": 5,
-		"type": "Complex Part",
-		"mass": 26.73,
-		"volume": 4.6,
-		"outputQuantity": 1,
-		"time": 15360,
-		"skill": "",
-		"byproducts": {},
-		"industries": [
-			"Glass Furnace M"
-		],
-		"input": {
-			"Basic Connector": 1,
-			"Uncommon Connector": 1,
-			"Ag-Li Reinforced Glass": 2,
-			"Advanced Connector": 2,
-			"Gold Coated Glass": 2,
-			"Manganese Reinforced Glass": 2
 		}
 	},
 	"Basic Burner": {
@@ -1895,6 +1854,47 @@
 			"Duralumin": 2,
 			"Uncommon Screw": 2,
 			"Al-Li Alloy": 2
+		}
+	},
+	"Rare Burner": {
+		"tier": 4,
+		"type": "Complex Part",
+		"mass": 48.5,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Duralumin": 2,
+			"Uncommon Screw": 3,
+			"Al-Li Alloy": 2,
+			"Sc-Al Alloy": 2
+		}
+	},
+	"Exotic Burner": {
+		"tier": 5,
+		"type": "Complex Part",
+		"mass": 48.5,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 15360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Al-Li Alloy": 2,
+			"Advanced Screw": 2,
+			"Sc-Al Alloy": 2,
+			"Grade 5 Titanium Alloy": 2
 		}
 	},
 	"Basic Electronics": {
@@ -1999,8 +1999,8 @@
 		"type": "Complex Part",
 		"mass": 18.72,
 		"volume": 4.6,
-		"outputQuantity": 1,
-		"time": 60,
+		"outputQuantity": 3,
+		"time": 180,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -2008,8 +2008,8 @@
 			"Chemical Industry M"
 		],
 		"input": {
-			"Polycarbonate Plastic": 6,
-			"Basic Connector": 4
+			"Polycarbonate Plastic": 18,
+			"Basic Connector": 12
 		}
 	},
 	"Uncommon Explosive Module": {
@@ -2106,13 +2106,54 @@
 			"Inconel": 2
 		}
 	},
+	"Rare Hydraulics": {
+		"tier": 4,
+		"type": "Complex Part",
+		"mass": 29.02,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 1,
+			"Stainless Steel": 2,
+			"Uncommon Pipe": 3,
+			"Inconel": 2,
+			"Maraging Steel": 2
+		}
+	},
+	"Exotic Hydraulics": {
+		"tier": 5,
+		"type": "Complex Part",
+		"mass": 29.02,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 15360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 1,
+			"Uncommon Pipe": 1,
+			"Inconel": 2,
+			"Advanced Pipe": 2,
+			"Maraging Steel": 2,
+			"Mangalloy": 2
+		}
+	},
 	"Basic Injector": {
 		"tier": 1,
 		"type": "Complex Part",
 		"mass": 20.3,
 		"volume": 10,
-		"outputQuantity": 1,
-		"time": 60,
+		"outputQuantity": 3,
+		"time": 180,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -2120,8 +2161,8 @@
 			"3D Printer M"
 		],
 		"input": {
-			"Polycarbonate Plastic": 6,
-			"Basic Screw": 4
+			"Polycarbonate Plastic": 18,
+			"Basic Screw": 12
 		}
 	},
 	"Uncommon Injector": {
@@ -2161,6 +2202,26 @@
 			"Polycalcite Plastic": 2,
 			"Uncommon Screw": 4,
 			"Polysulfide Plastic": 2
+		}
+	},
+	"Rare Injector": {
+		"tier": 4,
+		"type": "Complex Part",
+		"mass": 20.45,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Polycalcite Plastic": 2,
+			"Uncommon Screw": 3,
+			"Polysulfide Plastic": 2,
+			"Fluoropolymer": 2
 		}
 	},
 	"Basic Magnet": {
@@ -2265,8 +2326,8 @@
 		"type": "Complex Part",
 		"mass": 9.74,
 		"volume": 10,
-		"outputQuantity": 1,
-		"time": 60,
+		"outputQuantity": 3,
+		"time": 180,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -2274,8 +2335,8 @@
 			"Glass Furnace M"
 		],
 		"input": {
-			"Glass": 6,
-			"Basic Fixation": 4
+			"Glass": 18,
+			"Basic Fixation": 12
 		}
 	},
 	"Uncommon Optics": {
@@ -2333,7 +2394,28 @@
 			"Advanced Glass": 2,
 			"Uncommon Fixation": 3,
 			"Ag-Li Reinforced Glass": 2,
-			"Gold Coated Glass": 2
+			"Gold-Coated Glass": 2
+		}
+	},
+	"Exotic Optics": {
+		"tier": 5,
+		"type": "Complex Part",
+		"mass": 10.7,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 15360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Basic Fixation": 1,
+			"Uncommon Fixation": 1,
+			"Ag-Li Reinforced Glass": 2,
+			"Advanced Fixation": 2,
+			"Gold-Coated Glass": 2,
+			"Manganese Reinforced Glass": 2
 		}
 	},
 	"Basic Power System": {
@@ -2489,34 +2571,13 @@
 			"Cu-Ag Alloy": 2
 		}
 	},
-	"Exotic Processor": {
-		"tier": 5,
-		"type": "Complex Part",
-		"mass": 21.47,
-		"volume": 5,
-		"outputQuantity": 1,
-		"time": 15360,
-		"skill": "",
-		"byproducts": {},
-		"industries": [
-			"Electronics Industry M"
-		],
-		"input": {
-			"Basic Fixation": 1,
-			"Uncommon Fixation": 1,
-			"Cu-Ag Alloy": 2,
-			"Advanced Fixation": 2,
-			"Red Gold": 2,
-			"Ti-Nb Supraconductor": 2
-		}
-	},
 	"Basic Quantum Core": {
 		"tier": 1,
 		"type": "Complex Part",
 		"mass": 10.72,
 		"volume": 5,
-		"outputQuantity": 1,
-		"time": 60,
+		"outputQuantity": 3,
+		"time": 180,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -2524,8 +2585,8 @@
 			"3D Printer M"
 		],
 		"input": {
-			"Polycarbonate Plastic": 6,
-			"Basic LED": 4
+			"Polycarbonate Plastic": 18,
+			"Basic LED": 12
 		}
 	},
 	"Uncommon Quantum Core": {
@@ -2717,9 +2778,9 @@
 			"Metalwork Industry M"
 		],
 		"input": {
-			"Steel": 6,
+			"Steel": 2,
 			"Basic Pipe": 4,
-			"Stainless Steel": 6
+			"Stainless Steel": 4
 		}
 	},
 	"Advanced Solid Warhead": {
@@ -2748,7 +2809,7 @@
 		"mass": 117.05,
 		"volume": 20,
 		"outputQuantity": 1,
-		"time": 3780,
+		"time": 3750,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -2822,7 +2883,7 @@
 		"mass": 35.78,
 		"volume": 25,
 		"outputQuantity": 1,
-		"time": 3780,
+		"time": 3750,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -2871,7 +2932,7 @@
 		"mass": 43.38,
 		"volume": 25,
 		"outputQuantity": 1,
-		"time": 3780,
+		"time": 3750,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -2887,13 +2948,13 @@
 			"Advanced Quantum Core": 1
 		}
 	},
-	"Advanced Anti-Matter Core Unit": {
+	"Advanced Antimatter Core": {
 		"tier": 3,
 		"type": "Exceptional Part",
 		"mass": 107.08,
 		"volume": 21.5,
 		"outputQuantity": 1,
-		"time": 3780,
+		"time": 3750,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -2902,38 +2963,11 @@
 		"input": {
 			"Al-Fe Alloy": 5,
 			"Basic Component": 10,
-			"Basic Anti-Matter Capsule": 3,
+			"Basic Antimatter Capsule": 3,
 			"Calcium Reinforced Copper": 5,
-			"Uncommon Anti-Matter Capsule": 1,
+			"Uncommon Antimatter Capsule": 1,
 			"Cu-Ag Alloy": 5,
-			"Advanced Anti-Matter Capsule": 1
-		}
-	},
-	"Exotic Anti-Matter Core Unit": {
-		"tier": 5,
-		"type": "Exceptional Part",
-		"mass": 158.05,
-		"volume": 26.5,
-		"outputQuantity": 1,
-		"time": 93780,
-		"skill": "",
-		"byproducts": {},
-		"industries": [
-			"Electronics Industry M"
-		],
-		"input": {
-			"Al-Fe Alloy": 5,
-			"Basic Anti-Matter Capsule": 1,
-			"Calcium Reinforced Copper": 5,
-			"Uncommon Component": 5,
-			"Uncommon Anti-Matter Capsule": 1,
-			"Cu-Ag Alloy": 5,
-			"Advanced Component": 5,
-			"Advanced Anti-Matter Capsule": 1,
-			"Red Gold": 5,
-			"Rare Anti-Matter Capsule": 1,
-			"Ti-Nb Supraconductor": 5,
-			"Exotic Anti-Matter Capsule": 1
+			"Advanced Antimatter Capsule": 1
 		}
 	},
 	"Basic Antenna XS": {
@@ -2978,7 +3012,7 @@
 		"mass": 117.16,
 		"volume": 17.12,
 		"outputQuantity": 1,
-		"time": 168,
+		"time": 240,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -3058,7 +3092,7 @@
 		"mass": 389.74,
 		"volume": 54.56,
 		"outputQuantity": 1,
-		"time": 2016,
+		"time": 2880,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -3072,6 +3106,133 @@
 			"Cu-Ag Alloy": 7,
 			"Advanced Screw": 2,
 			"Advanced Power System": 2
+		}
+	},
+	"Advanced Antenna M": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 1830,
+		"volume": 251.36,
+		"outputQuantity": 1,
+		"time": 8640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Screw": 8,
+			"Basic Power System": 8,
+			"Uncommon Screw": 8,
+			"Uncommon Power System": 8,
+			"Cu-Ag Alloy": 49,
+			"Advanced Screw": 10,
+			"Advanced Power System": 10
+		}
+	},
+	"Advanced Antenna L": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 9650,
+		"volume": 1302.56,
+		"outputQuantity": 1,
+		"time": 25920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Screw": 38,
+			"Basic Power System": 38,
+			"Uncommon Screw": 38,
+			"Uncommon Power System": 38,
+			"Cu-Ag Alloy": 343,
+			"Advanced Screw": 50,
+			"Advanced Power System": 50
+		}
+	},
+	"Rare Antenna S": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 446.79,
+		"volume": 54.56,
+		"outputQuantity": 1,
+		"time": 11520,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Uncommon Screw": 2,
+			"Uncommon Power System": 2,
+			"Advanced Screw": 4,
+			"Advanced Power System": 2,
+			"Red Gold": 7,
+			"Rare Power System": 2
+		}
+	},
+	"Rare Antenna M": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 2160,
+		"volume": 251.36,
+		"outputQuantity": 1,
+		"time": 34560,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Uncommon Screw": 8,
+			"Uncommon Power System": 8,
+			"Advanced Screw": 18,
+			"Advanced Power System": 8,
+			"Red Gold": 49,
+			"Rare Power System": 10
+		}
+	},
+	"Rare Antenna L": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 11690,
+		"volume": 1302.56,
+		"outputQuantity": 1,
+		"time": 103680,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Uncommon Screw": 38,
+			"Uncommon Power System": 38,
+			"Advanced Screw": 88,
+			"Advanced Power System": 38,
+			"Red Gold": 343,
+			"Rare Power System": 50
+		}
+	},
+	"Exotic Antenna S": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 450.84,
+		"volume": 53.76,
+		"outputQuantity": 1,
+		"time": 46080,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Advanced Screw": 5,
+			"Advanced Power System": 2,
+			"Rare Power System": 2,
+			"Ti-Nb Supraconductor": 7,
+			"Exotic Power System": 2
 		}
 	},
 	"Exotic Antenna M": {
@@ -3222,6 +3383,26 @@
 			"Basic Screw": 625
 		}
 	},
+	"Uncommon Chemical Container M": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 240.84,
+		"volume": 143.2,
+		"outputQuantity": 1,
+		"time": 2160,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 8,
+			"Basic Electronics": 8,
+			"Duralumin": 49,
+			"Uncommon Screw": 18,
+			"Uncommon Electronics": 18
+		}
+	},
 	"Advanced Chemical Container S": {
 		"tier": 3,
 		"type": "Functional Part",
@@ -3310,6 +3491,27 @@
 			"Advanced Electronics": 250
 		}
 	},
+	"Rare Chemical Container M": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 246.01,
+		"volume": 143.2,
+		"outputQuantity": 1,
+		"time": 34560,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Screw": 8,
+			"Uncommon Electronics": 8,
+			"Advanced Screw": 18,
+			"Advanced Electronics": 8,
+			"Sc-Al Alloy": 49,
+			"Rare Electronics": 10
+		}
+	},
 	"Basic Combustion Chamber XS": {
 		"tier": 1,
 		"type": "Functional Part",
@@ -3391,7 +3593,6 @@
 		"skill": "",
 		"byproducts": {},
 		"industries": [
-			"Nanopack",
 			"Metalwork Industry M"
 		],
 		"input": {
@@ -3412,7 +3613,6 @@
 		"skill": "",
 		"byproducts": {},
 		"industries": [
-			"Nanopack",
 			"Metalwork Industry M"
 		],
 		"input": {
@@ -3433,7 +3633,6 @@
 		"skill": "",
 		"byproducts": {},
 		"industries": [
-			"Nanopack",
 			"Metalwork Industry M"
 		],
 		"input": {
@@ -3528,6 +3727,112 @@
 			"Inconel": 49,
 			"Advanced Pipe": 10,
 			"Advanced Burner": 10
+		}
+	},
+	"Advanced Combustion Chamber L": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 9410,
+		"volume": 1383.2,
+		"outputQuantity": 1,
+		"time": 25920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 38,
+			"Basic Burner": 38,
+			"Uncommon Pipe": 38,
+			"Uncommon Burner": 38,
+			"Inconel": 343,
+			"Advanced Pipe": 50,
+			"Advanced Burner": 50
+		}
+	},
+	"Rare Combustion Chamber XS": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 158.69,
+		"volume": 26.4,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 1,
+			"Uncommon Burner": 1,
+			"Advanced Pipe": 1,
+			"Advanced Burner": 1,
+			"Maraging Steel": 1,
+			"Rare Burner": 1
+		}
+	},
+	"Rare Combustion Chamber S": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 362.92,
+		"volume": 58.4,
+		"outputQuantity": 1,
+		"time": 11520,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 2,
+			"Uncommon Burner": 2,
+			"Advanced Pipe": 4,
+			"Advanced Burner": 2,
+			"Maraging Steel": 7,
+			"Rare Burner": 2
+		}
+	},
+	"Rare Combustion Chamber M": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 1720,
+		"volume": 268,
+		"outputQuantity": 1,
+		"time": 34560,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 8,
+			"Uncommon Burner": 8,
+			"Advanced Pipe": 18,
+			"Advanced Burner": 8,
+			"Maraging Steel": 49,
+			"Rare Burner": 10
+		}
+	},
+	"Rare Combustion Chamber L": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 9230,
+		"volume": 1383.2,
+		"outputQuantity": 1,
+		"time": 103680,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 38,
+			"Uncommon Burner": 38,
+			"Advanced Pipe": 88,
+			"Advanced Burner": 38,
+			"Maraging Steel": 343,
+			"Rare Burner": 50
 		}
 	},
 	"Basic Control System XS": {
@@ -3970,6 +4275,170 @@
 			"Advanced Burner": 50
 		}
 	},
+	"Rare Firing System XS": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 158.69,
+		"volume": 26.4,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 1,
+			"Uncommon Burner": 1,
+			"Advanced Pipe": 1,
+			"Advanced Burner": 1,
+			"Maraging Steel": 1,
+			"Rare Burner": 1
+		}
+	},
+	"Rare Firing System S": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 362.92,
+		"volume": 58.4,
+		"outputQuantity": 1,
+		"time": 11520,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 2,
+			"Uncommon Burner": 2,
+			"Advanced Pipe": 4,
+			"Advanced Burner": 2,
+			"Maraging Steel": 7,
+			"Rare Burner": 2
+		}
+	},
+	"Rare Firing System M": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 1720,
+		"volume": 268,
+		"outputQuantity": 1,
+		"time": 11520,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 8,
+			"Uncommon Burner": 8,
+			"Advanced Pipe": 18,
+			"Advanced Burner": 8,
+			"Maraging Steel": 49,
+			"Rare Burner": 10
+		}
+	},
+	"Rare Firing System L": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 9230,
+		"volume": 1383.2,
+		"outputQuantity": 1,
+		"time": 103680,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 38,
+			"Uncommon Burner": 38,
+			"Advanced Pipe": 88,
+			"Advanced Burner": 38,
+			"Maraging Steel": 343,
+			"Rare Burner": 50
+		}
+	},
+	"Exotic Firing System XS": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 158.36,
+		"volume": 25.6,
+		"outputQuantity": 1,
+		"time": 15360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Advanced Pipe": 1,
+			"Advanced Burner": 1,
+			"Rare Burner": 1,
+			"Mangalloy": 1,
+			"Exotic Burner": 1
+		}
+	},
+	"Exotic Firing System S": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 362.47,
+		"volume": 57.6,
+		"outputQuantity": 1,
+		"time": 46080,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Advanced Pipe": 5,
+			"Advanced Burner": 2,
+			"Rare Burner": 2,
+			"Mangalloy": 7,
+			"Exotic Burner": 2
+		}
+	},
+	"Exotic Firing System M": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 1730,
+		"volume": 267.2,
+		"outputQuantity": 1,
+		"time": 138240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Advanced Pipe": 25,
+			"Advanced Burner": 8,
+			"Rare Burner": 8,
+			"Mangalloy": 49,
+			"Exotic Burner": 10
+		}
+	},
+	"Exotic Firing System L": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 9220,
+		"volume": 1382.4,
+		"outputQuantity": 1,
+		"time": 414000,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Advanced Pipe": 125,
+			"Advanced Burner": 38,
+			"Rare Burner": 38,
+			"Mangalloy": 343,
+			"Exotic Burner": 50
+		}
+	},
 	"Basic Gas Cylinder XS": {
 		"tier": 1,
 		"type": "Functional Part",
@@ -4212,6 +4681,50 @@
 			"Uncommon Magnet": 438
 		}
 	},
+	"Advanced Ionic Chamber XS": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 209.62,
+		"volume": 20.38,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Basic Magnet": 1,
+			"Uncommon Connector": 1,
+			"Uncommon Magnet": 1,
+			"Inconel": 1,
+			"Advanced Connector": 1,
+			"Advanced Magnet": 1
+		}
+	},
+	"Advanced Ionic Chamber S": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 461.73,
+		"volume": 44.77,
+		"outputQuantity": 1,
+		"time": 2880,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Connector": 2,
+			"Basic Magnet": 2,
+			"Uncommon Connector": 2,
+			"Uncommon Magnet": 2,
+			"Inconel": 7,
+			"Advanced Connector": 2,
+			"Advanced Magnet": 2
+		}
+	},
 	"Advanced Ionic Chamber M": {
 		"tier": 3,
 		"type": "Functional Part",
@@ -4240,7 +4753,7 @@
 		"mass": 11370,
 		"volume": 1096.93,
 		"outputQuantity": 1,
-		"time": 15540,
+		"time": 25920,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -4262,7 +4775,7 @@
 		"mass": 62430,
 		"volume": 6007.33,
 		"outputQuantity": 1,
-		"time": 15540,
+		"time": 77760,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -4276,6 +4789,128 @@
 			"Inconel": 2401,
 			"Advanced Connector": 250,
 			"Advanced Magnet": 250
+		}
+	},
+	"Rare Ionic Chamber XS": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 206.71,
+		"volume": 19.74,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Uncommon Magnet": 1,
+			"Advanced Connector": 1,
+			"Advanced Magnet": 1,
+			"Maraging Steel": 1,
+			"Rare Magnet": 1
+		}
+	},
+	"Rare Ionic Chamber S": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 462.93,
+		"volume": 44.77,
+		"outputQuantity": 1,
+		"time": 11520,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Connector": 2,
+			"Uncommon Magnet": 2,
+			"Advanced Connector": 4,
+			"Advanced Magnet": 2,
+			"Maraging Steel": 7,
+			"Rare Magnet": 2
+		}
+	},
+	"Rare Ionic Chamber M": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 2160,
+		"volume": 208.93,
+		"outputQuantity": 1,
+		"time": 34560,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Connector": 8,
+			"Uncommon Magnet": 8,
+			"Advanced Connector": 18,
+			"Advanced Magnet": 8,
+			"Maraging Steel": 49,
+			"Rare Magnet": 10
+		}
+	},
+	"Rare Ionic Chamber L": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 11350,
+		"volume": 1096.93,
+		"outputQuantity": 1,
+		"time": 103680,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Connector": 38,
+			"Uncommon Magnet": 38,
+			"Advanced Connector": 88,
+			"Advanced Magnet": 38,
+			"Maraging Steel": 343,
+			"Rare Magnet": 50
+		}
+	},
+	"Rare Ionic Chamber XL": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 62110,
+		"volume": 6007.33,
+		"outputQuantity": 1,
+		"time": 309600,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Connector": 188,
+			"Uncommon Magnet": 188,
+			"Advanced Connector": 438,
+			"Advanced Magnet": 188,
+			"Maraging Steel": 2401,
+			"Rare Magnet": 250
+		}
+	},
+	"Basic Laser Chamber S": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 72.45,
+		"volume": 49.6,
+		"outputQuantity": 1,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Glass": 7,
+			"Basic LED": 5
 		}
 	},
 	"Uncommon Laser Chamber XS": {
@@ -4386,6 +5021,27 @@
 			"Advanced Optics": 50
 		}
 	},
+	"Rare Laser Chamber XS": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 36.42,
+		"volume": 26.4,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Uncommon LED": 1,
+			"Uncommon Optics": 1,
+			"Advanced LED": 1,
+			"Advanced Optics": 1,
+			"Gold-Coated Glass": 1,
+			"Rare Optics": 1
+		}
+	},
 	"Rare Laser Chamber S": {
 		"tier": 4,
 		"type": "Functional Part",
@@ -4403,8 +5059,130 @@
 			"Uncommon Optics": 2,
 			"Advanced LED": 2,
 			"Advanced Optics": 2,
-			"Gold Coated Glass": 7,
+			"Gold-Coated Glass": 7,
 			"Rare Optics": 2
+		}
+	},
+	"Rare Laser Chamber M": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 449.01,
+		"volume": 268,
+		"outputQuantity": 1,
+		"time": 34560,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Uncommon LED": 8,
+			"Uncommon Optics": 8,
+			"Advanced LED": 18,
+			"Advanced Optics": 8,
+			"Gold-Coated Glass": 49,
+			"Rare Optics": 10
+		}
+	},
+	"Rare Laser Chamber L": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 2490,
+		"volume": 1383.2,
+		"outputQuantity": 1,
+		"time": 103680,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Uncommon LED": 38,
+			"Uncommon Optics": 38,
+			"Advanced LED": 88,
+			"Advanced Optics": 38,
+			"Gold-Coated Glass": 343,
+			"Rare Optics": 50
+		}
+	},
+	"Exotic Laser Chamber XS": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 36.15,
+		"volume": 25.6,
+		"outputQuantity": 1,
+		"time": 15360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Advanced LED": 1,
+			"Advanced Optics": 1,
+			"Rare Optics": 1,
+			"Manganese Reinforced Glass": 1,
+			"Exotic Optics": 1
+		}
+	},
+	"Exotic Laser Chamber S": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 90.78,
+		"volume": 57.6,
+		"outputQuantity": 1,
+		"time": 46080,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Advanced LED": 5,
+			"Advanced Optics": 2,
+			"Rare Optics": 2,
+			"Manganese Reinforced Glass": 7,
+			"Exotic Optics": 2
+		}
+	},
+	"Exotic Laser Chamber M": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 452.75,
+		"volume": 267.2,
+		"outputQuantity": 1,
+		"time": 138240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Advanced LED": 25,
+			"Advanced Optics": 8,
+			"Rare Optics": 8,
+			"Manganese Reinforced Glass": 49,
+			"Exotic Optics": 10
+		}
+	},
+	"Exotic Laser Chamber L": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 2510,
+		"volume": 1382.4,
+		"outputQuantity": 1,
+		"time": 414000,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Advanced LED": 125,
+			"Advanced Optics": 38,
+			"Rare Optics": 38,
+			"Manganese Reinforced Glass": 343,
+			"Exotic Optics": 50
 		}
 	},
 	"Uncommon Light XS": {
@@ -4533,6 +5311,170 @@
 			"Inconel": 343,
 			"Advanced Pipe": 50,
 			"Advanced Magnet": 50
+		}
+	},
+	"Rare Magnetic Rail XS": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 203.4,
+		"volume": 20.06,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 1,
+			"Uncommon Magnet": 1,
+			"Advanced Pipe": 1,
+			"Advanced Magnet": 1,
+			"Maraging Steel": 1,
+			"Rare Magnet": 1
+		}
+	},
+	"Rare Magnetic Rail S": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 451.81,
+		"volume": 45.73,
+		"outputQuantity": 1,
+		"time": 11520,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 2,
+			"Uncommon Magnet": 2,
+			"Advanced Pipe": 4,
+			"Advanced Magnet": 2,
+			"Maraging Steel": 7,
+			"Rare Magnet": 2
+		}
+	},
+	"Rare Magnetic Rail M": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 2110,
+		"volume": 213.09,
+		"outputQuantity": 1,
+		"time": 34560,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 8,
+			"Uncommon Magnet": 8,
+			"Advanced Pipe": 18,
+			"Advanced Magnet": 8,
+			"Maraging Steel": 49,
+			"Rare Magnet": 10
+		}
+	},
+	"Rare Magnetic Rail L": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 11110,
+		"volume": 1117.09,
+		"outputQuantity": 1,
+		"time": 103680,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 38,
+			"Uncommon Magnet": 38,
+			"Advanced Pipe": 88,
+			"Advanced Magnet": 38,
+			"Maraging Steel": 343,
+			"Rare Magnet": 50
+		}
+	},
+	"Exotic Magnetic Rail XS": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 203.45,
+		"volume": 19.26,
+		"outputQuantity": 1,
+		"time": 15360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Advanced Pipe": 1,
+			"Advanced Magnet": 1,
+			"Rare Magnet": 1,
+			"Mangalloy": 1,
+			"Exotic Magnet": 1
+		}
+	},
+	"Exotic Magnetic Rail S": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 452.65,
+		"volume": 44.93,
+		"outputQuantity": 1,
+		"time": 46080,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Advanced Pipe": 5,
+			"Advanced Magnet": 2,
+			"Rare Magnet": 2,
+			"Mangalloy": 7,
+			"Exotic Magnet": 2
+		}
+	},
+	"Exotic Magnetic Rail M": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 2120,
+		"volume": 212.29,
+		"outputQuantity": 1,
+		"time": 138240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Advanced Pipe": 25,
+			"Advanced Magnet": 8,
+			"Rare Magnet": 8,
+			"Mangalloy": 49,
+			"Exotic Magnet": 10
+		}
+	},
+	"Exotic Magnetic Rail L": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 11090,
+		"volume": 1116.29,
+		"outputQuantity": 1,
+		"time": 414000,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Advanced Pipe": 125,
+			"Advanced Magnet": 38,
+			"Rare Magnet": 38,
+			"Mangalloy": 343,
+			"Exotic Magnet": 50
 		}
 	},
 	"Basic Mechanical Sensor XS": {
@@ -4683,6 +5625,170 @@
 			"Advanced Burner": 50
 		}
 	},
+	"Rare Missile Silo XS": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 153.31,
+		"volume": 26.4,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 1,
+			"Uncommon Burner": 1,
+			"Advanced Pipe": 1,
+			"Advanced Burner": 1,
+			"Sc-Al Alloy": 1,
+			"Rare Burner": 1
+		}
+	},
+	"Rare Missile Silo S": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 325.26,
+		"volume": 58.4,
+		"outputQuantity": 1,
+		"time": 11520,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 2,
+			"Uncommon Burner": 2,
+			"Advanced Pipe": 4,
+			"Advanced Burner": 2,
+			"Sc-Al Alloy": 7,
+			"Rare Burner": 2
+		}
+	},
+	"Rare Missile Silo M": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 1460,
+		"volume": 268,
+		"outputQuantity": 1,
+		"time": 34560,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 8,
+			"Uncommon Burner": 8,
+			"Advanced Pipe": 18,
+			"Advanced Burner": 8,
+			"Sc-Al Alloy": 49,
+			"Rare Burner": 10
+		}
+	},
+	"Rare Missile Silo L": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 7380,
+		"volume": 1383.2,
+		"outputQuantity": 1,
+		"time": 103680,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Pipe": 38,
+			"Uncommon Burner": 38,
+			"Advanced Pipe": 88,
+			"Advanced Burner": 38,
+			"Sc-Al Alloy": 343,
+			"Rare Burner": 50
+		}
+	},
+	"Exotic Missile Silo XS": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 154.96,
+		"volume": 25.6,
+		"outputQuantity": 1,
+		"time": 15360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Advanced Pipe": 1,
+			"Advanced Burner": 1,
+			"Rare Burner": 1,
+			"Grade 5 Titanium Alloy": 1,
+			"Exotic Burner": 1
+		}
+	},
+	"Exotic Missile Silo S": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 338.65,
+		"volume": 57.6,
+		"outputQuantity": 1,
+		"time": 46080,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Advanced Pipe": 5,
+			"Advanced Burner": 2,
+			"Rare Burner": 2,
+			"Grade 5 Titanium Alloy": 7,
+			"Exotic Burner": 2
+		}
+	},
+	"Exotic Missile Silo M": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 1560,
+		"volume": 267.2,
+		"outputQuantity": 1,
+		"time": 138240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Advanced Pipe": 25,
+			"Advanced Burner": 8,
+			"Rare Burner": 8,
+			"Grade 5 Titanium Alloy": 49,
+			"Exotic Burner": 10
+		}
+	},
+	"Exotic Missile Silo L": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 8050,
+		"volume": 1382.4,
+		"outputQuantity": 1,
+		"time": 414000,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Advanced Pipe": 125,
+			"Advanced Burner": 38,
+			"Rare Burner": 38,
+			"Grade 5 Titanium Alloy": 343,
+			"Exotic Burner": 50
+		}
+	},
 	"Basic Mobile Panel XS": {
 		"tier": 1,
 		"type": "Functional Part",
@@ -4771,6 +5877,321 @@
 			"Basic Screw": 625
 		}
 	},
+	"Uncommon Mobile Panel XS": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 38.02,
+		"volume": 18.4,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Hydraulics": 1,
+			"Duralumin": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Hydraulics": 1
+		}
+	},
+	"Uncommon Mobile Panel S": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 119.3,
+		"volume": 58.4,
+		"outputQuantity": 1,
+		"time": 720,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 2,
+			"Basic Hydraulics": 2,
+			"Duralumin": 7,
+			"Uncommon Screw": 4,
+			"Uncommon Hydraulics": 4
+		}
+	},
+	"Uncommon Mobile Panel M": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 542.85,
+		"volume": 268,
+		"outputQuantity": 1,
+		"time": 2160,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 8,
+			"Basic Hydraulics": 8,
+			"Duralumin": 49,
+			"Uncommon Screw": 18,
+			"Uncommon Hydraulics": 18
+		}
+	},
+	"Uncommon Mobile Panel L": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 2780,
+		"volume": 1383.2,
+		"outputQuantity": 1,
+		"time": 6480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 38,
+			"Basic Hydraulics": 38,
+			"Duralumin": 343,
+			"Uncommon Screw": 88,
+			"Uncommon Hydraulics": 88
+		}
+	},
+	"Uncommon Mobile Panel XL": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 14780,
+		"volume": 7429.6,
+		"outputQuantity": 1,
+		"time": 19440,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 188,
+			"Basic Hydraulics": 188,
+			"Duralumin": 2401,
+			"Uncommon Screw": 438,
+			"Uncommon Hydraulics": 438
+		}
+	},
+	"Advanced Mobile Panel XS": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 56.45,
+		"volume": 27.2,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Hydraulics": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Hydraulics": 1,
+			"Al-Li Alloy": 1,
+			"Advanced Screw": 1,
+			"Advanced Hydraulics": 1
+		}
+	},
+	"Advanced Mobile Panel S": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 119.16,
+		"volume": 58.4,
+		"outputQuantity": 1,
+		"time": 2880,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 2,
+			"Basic Hydraulics": 2,
+			"Uncommon Screw": 2,
+			"Uncommon Hydraulics": 2,
+			"Al-Li Alloy": 7,
+			"Advanced Screw": 2,
+			"Advanced Hydraulics": 2
+		}
+	},
+	"Advanced Mobile Panel M": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 540.03,
+		"volume": 268,
+		"outputQuantity": 1,
+		"time": 8640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 8,
+			"Basic Hydraulics": 8,
+			"Uncommon Screw": 8,
+			"Uncommon Hydraulics": 8,
+			"Al-Li Alloy": 49,
+			"Advanced Screw": 10,
+			"Advanced Hydraulics": 10
+		}
+	},
+	"Advanced Mobile Panel L": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 2750,
+		"volume": 1383.2,
+		"outputQuantity": 1,
+		"time": 25920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 38,
+			"Basic Hydraulics": 38,
+			"Uncommon Screw": 38,
+			"Uncommon Hydraulics": 38,
+			"Al-Li Alloy": 343,
+			"Advanced Screw": 50,
+			"Advanced Hydraulics": 50
+		}
+	},
+	"Advanced Mobile Panel XL": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 14530,
+		"volume": 7429.6,
+		"outputQuantity": 1,
+		"time": 77760,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 188,
+			"Basic Hydraulics": 188,
+			"Uncommon Screw": 188,
+			"Uncommon Hydraulics": 188,
+			"Al-Li Alloy": 2401,
+			"Advanced Screw": 250,
+			"Advanced Hydraulics": 250
+		}
+	},
+	"Rare Mobile Panel XS": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 52.71,
+		"volume": 26.4,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Uncommon Hydraulics": 1,
+			"Advanced Screw": 1,
+			"Advanced Hydraulics": 1,
+			"Sc-Al Alloy": 1,
+			"Rare Hydraulics": 1
+		}
+	},
+	"Rare Mobile Panel S": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 120.68,
+		"volume": 58.4,
+		"outputQuantity": 1,
+		"time": 11520,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Screw": 2,
+			"Uncommon Hydraulics": 2,
+			"Advanced Screw": 4,
+			"Advanced Hydraulics": 2,
+			"Sc-Al Alloy": 7,
+			"Rare Hydraulics": 2
+		}
+	},
+	"Rare Mobile Panel M": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 549.93,
+		"volume": 268,
+		"outputQuantity": 1,
+		"time": 34560,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Screw": 8,
+			"Uncommon Hydraulics": 8,
+			"Advanced Screw": 18,
+			"Advanced Hydraulics": 8,
+			"Sc-Al Alloy": 49,
+			"Rare Hydraulics": 10
+		}
+	},
+	"Rare Mobile Panel L": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 2820,
+		"volume": 1383.2,
+		"outputQuantity": 1,
+		"time": 103680,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Screw": 38,
+			"Uncommon Hydraulics": 38,
+			"Advanced Screw": 88,
+			"Advanced Hydraulics": 38,
+			"Sc-Al Alloy": 343,
+			"Rare Hydraulics": 50
+		}
+	},
+	"Rare Mobile Panel XL": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 14980,
+		"volume": 7429.6,
+		"outputQuantity": 1,
+		"time": 309600,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Screw": 188,
+			"Uncommon Hydraulics": 188,
+			"Advanced Screw": 438,
+			"Advanced Hydraulics": 188,
+			"Sc-Al Alloy": 2401,
+			"Rare Hydraulics": 250
+		}
+	},
 	"Advanced Motherboard M": {
 		"tier": 3,
 		"type": "Functional Part",
@@ -4837,11 +6258,10 @@
 		"mass": 221.56,
 		"volume": 43.33,
 		"outputQuantity": 1,
-		"time": 540,
+		"time": 720,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
-			"Nanopack",
 			"Electronics Industry M"
 		],
 		"input": {
@@ -4858,11 +6278,10 @@
 		"mass": 1030,
 		"volume": 202.69,
 		"outputQuantity": 1,
-		"time": 1512,
+		"time": 2160,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
-			"Nanopack",
 			"Electronics Industry M"
 		],
 		"input": {
@@ -4871,6 +6290,49 @@
 			"Stainless Steel": 49,
 			"Uncommon Component": 18,
 			"Uncommon Magnet": 18
+		}
+	},
+	"Advanced Power Transformer M": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 1060,
+		"volume": 202.69,
+		"outputQuantity": 1,
+		"time": 8640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Component": 8,
+			"Basic Magnet": 8,
+			"Uncommon Component": 8,
+			"Uncommon Magnet": 8,
+			"Inconel": 49,
+			"Advanced Component": 10,
+			"Advanced Magnet": 10
+		}
+	},
+	"Rare Power Transformer M": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 1060,
+		"volume": 202.69,
+		"outputQuantity": 1,
+		"time": 34560,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Uncommon Component": 8,
+			"Uncommon Magnet": 8,
+			"Advanced Component": 18,
+			"Advanced Magnet": 8,
+			"Maraging Steel": 49,
+			"Rare Magnet": 10
 		}
 	},
 	"Rare Power Transformer L": {
@@ -4913,26 +6375,6 @@
 			"Advanced Magnet": 188,
 			"Maraging Steel": 343,
 			"Rare Magnet": 250
-		}
-	},
-	"Exotic Power Transformer L": {
-		"tier": 5,
-		"type": "Functional Part",
-		"mass": 5570,
-		"volume": 1066.29,
-		"outputQuantity": 1,
-		"time": 414720,
-		"skill": "",
-		"byproducts": {},
-		"industries": [
-			"Electronics Industry M"
-		],
-		"input": {
-			"Advanced Component": 125,
-			"Advanced Magnet": 38,
-			"Rare Magnet": 38,
-			"Mangalloy": 343,
-			"Exotic Magnet": 50
 		}
 	},
 	"Basic Robotic Arm M": {
@@ -4987,13 +6429,76 @@
 			"Basic Component": 625
 		}
 	},
+	"Uncommon Robotic Arm M": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 939.22,
+		"volume": 257.6,
+		"outputQuantity": 1,
+		"time": 2160,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Component": 8,
+			"Basic Hydraulics": 8,
+			"Duralumin": 49,
+			"Uncommon Component": 18,
+			"Uncommon Hydraulics": 18
+		}
+	},
+	"Advanced Robotic Arm M": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 932.87,
+		"volume": 257.6,
+		"outputQuantity": 1,
+		"time": 8640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Component": 8,
+			"Basic Hydraulics": 8,
+			"Uncommon Component": 8,
+			"Uncommon Hydraulics": 8,
+			"Al-Li Alloy": 49,
+			"Advanced Component": 10,
+			"Advanced Hydraulics": 10
+		}
+	},
+	"Rare Robotic Arm M": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 954.02,
+		"volume": 257.6,
+		"outputQuantity": 1,
+		"time": 34560,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Uncommon Component": 8,
+			"Uncommon Hydraulics": 8,
+			"Advanced Component": 18,
+			"Advanced Hydraulics": 8,
+			"Sc-Al Alloy": 49,
+			"Rare Hydraulics": 10
+		}
+	},
 	"Basic Screen S": {
 		"tier": 1,
 		"type": "Functional Part",
 		"mass": 21.07,
 		"volume": 25.6,
 		"outputQuantity": 1,
-		"time": 63,
+		"time": 180,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -5049,7 +6554,7 @@
 		"mass": 671.24,
 		"volume": 778.4,
 		"outputQuantity": 1,
-		"time": 4536,
+		"time": 6480,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -5111,7 +6616,7 @@
 		"mass": 4000,
 		"volume": 4424.8,
 		"outputQuantity": 1,
-		"time": 54420,
+		"time": 77760,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -5132,15 +6637,15 @@
 		"type": "Structural Part",
 		"mass": 1.4,
 		"volume": 2,
-		"outputQuantity": 1,
-		"time": 40,
+		"outputQuantity": 5,
+		"time": 200,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
 			"3D Printer M"
 		],
 		"input": {
-			"Polycarbonate Plastic": 2
+			"Polycarbonate Plastic": 10
 		}
 	},
 	"Basic Casing S": {
@@ -5330,23 +6835,6 @@
 			"Fluoropolymer": 1
 		}
 	},
-	"Rare Casing S": {
-		"tier": 4,
-		"type": "Structural Part",
-		"mass": 8.57,
-		"volume": 11,
-		"outputQuantity": 1,
-		"time": 7680,
-		"skill": "",
-		"byproducts": {},
-		"industries": [
-			"3D Printer M"
-		],
-		"input": {
-			"Polycarbonate Plastic": 4,
-			"Fluoropolymer": 7
-		}
-	},
 	"Exotic Casing S": {
 		"tier": 5,
 		"type": "Structural Part",
@@ -5425,7 +6913,6 @@
 		"skill": "",
 		"byproducts": {},
 		"industries": [
-			"Nanopack",
 			"Metalwork Industry M"
 		],
 		"input": {
@@ -5442,7 +6929,6 @@
 		"skill": "",
 		"byproducts": {},
 		"industries": [
-			"Nanopack",
 			"Metalwork Industry M"
 		],
 		"input": {
@@ -5619,6 +7105,57 @@
 			"Inconel": 2401
 		}
 	},
+	"Rare Reinforced Frame XS": {
+		"tier": 4,
+		"type": "Structural Part",
+		"mass": 13.02,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 2560,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 1,
+			"Maraging Steel": 1
+		}
+	},
+	"Rare Reinforced Frame S": {
+		"tier": 4,
+		"type": "Structural Part",
+		"mass": 71.85,
+		"volume": 11,
+		"outputQuantity": 1,
+		"time": 7680,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 4,
+			"Maraging Steel": 7
+		}
+	},
+	"Rare Reinforced Frame M": {
+		"tier": 4,
+		"type": "Structural Part",
+		"mass": 483.62,
+		"volume": 74,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 25,
+			"Maraging Steel": 49
+		}
+	},
 	"Rare Reinforced Frame L": {
 		"tier": 4,
 		"type": "Structural Part",
@@ -5653,6 +7190,40 @@
 			"Maraging Steel": 2401
 		}
 	},
+	"Exotic Reinforced Frame XS": {
+		"tier": 5,
+		"type": "Structural Part",
+		"mass": 12.71,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 10260,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 1,
+			"Mangalloy": 1
+		}
+	},
+	"Exotic Reinforced Frame S": {
+		"tier": 5,
+		"type": "Structural Part",
+		"mass": 69.62,
+		"volume": 11,
+		"outputQuantity": 1,
+		"time": 30720,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 4,
+			"Mangalloy": 7
+		}
+	},
 	"Exotic Reinforced Frame M": {
 		"tier": 5,
 		"type": "Structural Part",
@@ -5676,7 +7247,7 @@
 		"mass": 3260,
 		"volume": 515,
 		"outputQuantity": 1,
-		"time": 276480,
+		"time": 277200,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -5693,7 +7264,7 @@
 		"mass": 22780,
 		"volume": 3602,
 		"outputQuantity": 1,
-		"time": 829440,
+		"time": 828000,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -5765,7 +7336,6 @@
 		"skill": "",
 		"byproducts": {},
 		"industries": [
-			"Nanopack",
 			"Metalwork Industry M"
 		],
 		"input": {
@@ -5914,7 +7484,7 @@
 		"mass": 6720,
 		"volume": 3602,
 		"outputQuantity": 1,
-		"time": 36300,
+		"time": 51840,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -5923,6 +7493,40 @@
 		"input": {
 			"Silumin": 1201,
 			"Al-Li Alloy": 2401
+		}
+	},
+	"Rare Standard Frame S": {
+		"tier": 4,
+		"type": "Structural Part",
+		"mass": 22.36,
+		"volume": 11,
+		"outputQuantity": 1,
+		"time": 7680,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 4,
+			"Sc-Al Alloy": 7
+		}
+	},
+	"Rare Standard Frame M": {
+		"tier": 4,
+		"type": "Structural Part",
+		"mass": 150.25,
+		"volume": 74,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 25,
+			"Sc-Al Alloy": 49
 		}
 	},
 	"Rare Standard Frame L": {
@@ -5948,7 +7552,7 @@
 		"mass": 5.2,
 		"volume": 2,
 		"outputQuantity": 1,
-		"time": 10240,
+		"time": 10260,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -5959,13 +7563,47 @@
 			"Grade 5 Titanium Alloy": 1
 		}
 	},
+	"Exotic Standard Frame S": {
+		"tier": 5,
+		"type": "Structural Part",
+		"mass": 30.11,
+		"volume": 11,
+		"outputQuantity": 1,
+		"time": 30720,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 4,
+			"Grade 5 Titanium Alloy": 7
+		}
+	},
+	"Exotic Standard Frame M": {
+		"tier": 5,
+		"type": "Structural Part",
+		"mass": 204.45,
+		"volume": 74,
+		"outputQuantity": 1,
+		"time": 92160,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 25,
+			"Grade 5 Titanium Alloy": 49
+		}
+	},
 	"Exotic Standard Frame L": {
 		"tier": 5,
 		"type": "Structural Part",
 		"mass": 1420,
 		"volume": 515,
 		"outputQuantity": 1,
-		"time": 276480,
+		"time": 277200,
 		"skill": "",
 		"byproducts": {},
 		"industries": [
@@ -5976,7 +7614,7 @@
 			"Grade 5 Titanium Alloy": 343
 		}
 	},
-	"Dynamic Core XS": {
+	"Dynamic Core Unit XS": {
 		"tier": 1,
 		"type": "Core Unit",
 		"mass": 70.89,
@@ -5996,7 +7634,7 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Dynamic Core S": {
+	"Dynamic Core Unit S": {
 		"tier": 2,
 		"type": "Core Unit",
 		"mass": 375.97,
@@ -6016,7 +7654,7 @@
 			"Uncommon Standard Frame S": 1
 		}
 	},
-	"Dynamic Core M": {
+	"Dynamic Core Unit M": {
 		"tier": 3,
 		"type": "Core Unit",
 		"mass": 1980,
@@ -6035,7 +7673,7 @@
 			"Advanced Standard Frame M": 1
 		}
 	},
-	"Dynamic Core L": {
+	"Dynamic Core Unit L": {
 		"tier": 4,
 		"type": "Core Unit",
 		"mass": 12140,
@@ -6055,7 +7693,7 @@
 			"Rare Standard Frame L": 1
 		}
 	},
-	"Static Core XS": {
+	"Static Core Unit XS": {
 		"tier": 1,
 		"type": "Core Unit",
 		"mass": 70.89,
@@ -6075,7 +7713,7 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Static Core S": {
+	"Static Core Unit S": {
 		"tier": 1,
 		"type": "Core Unit",
 		"mass": 360.18,
@@ -6095,7 +7733,7 @@
 			"Basic Standard Frame S": 1
 		}
 	},
-	"Static Core M": {
+	"Static Core Unit M": {
 		"tier": 2,
 		"type": "Core Unit",
 		"mass": 1930,
@@ -6115,13 +7753,13 @@
 			"Uncommon Standard Frame M": 1
 		}
 	},
-	"Static Core L": {
+	"Static Core Unit L": {
 		"tier": 2,
 		"type": "Core Unit",
 		"mass": 10700,
 		"volume": 2501,
 		"outputQuantity": 1,
-		"time": 21600,
+		"time": 23040,
 		"skill": "InIn",
 		"byproducts": {},
 		"industries": [
@@ -6135,7 +7773,7 @@
 			"Uncommon Standard Frame L": 1
 		}
 	},
-	"Space Core XS": {
+	"Space Core Unit XS": {
 		"tier": 1,
 		"type": "Core Unit",
 		"mass": 38.99,
@@ -6155,7 +7793,7 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Space Core S": {
+	"Space Core Unit S": {
 		"tier": 2,
 		"type": "Core Unit",
 		"mass": 459.57,
@@ -6175,7 +7813,7 @@
 			"Uncommon Standard Frame S": 1
 		}
 	},
-	"Space Core M": {
+	"Space Core Unit M": {
 		"tier": 3,
 		"type": "Core Unit",
 		"mass": 3040,
@@ -6195,7 +7833,7 @@
 			"Advanced Standard Frame M": 1
 		}
 	},
-	"Space Core L": {
+	"Space Core Unit L": {
 		"tier": 4,
 		"type": "Core Unit",
 		"mass": 7680,
@@ -6242,7 +7880,7 @@
 		"mass": 55.8,
 		"volume": 44.3,
 		"outputQuantity": 1,
-		"time": 1380,
+		"time": 1350,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -6317,7 +7955,7 @@
 		"mass": 14842.7,
 		"volume": 3746,
 		"outputQuantity": 1,
-		"time": 5760,
+		"time": 11520,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -6327,6 +7965,156 @@
 			"Basic Component": 432,
 			"Basic Hydraulics": 250,
 			"Basic Reinforced Frame L": 2
+		}
+	},
+	"Container XL": {
+		"tier": 1,
+		"type": "Container",
+		"mass": 44210,
+		"volume": 10500,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Component": 1296,
+			"Basic Hydraulics": 625,
+			"Basic Reinforced Frame XL": 1
+		}
+	},
+	"Expanded Container XL": {
+		"tier": 1,
+		"type": "Container",
+		"mass": 88410,
+		"volume": 21000,
+		"outputQuantity": 1,
+		"time": 46080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Component": 2592,
+			"Basic Hydraulics": 1250,
+			"Basic Reinforced Frame XL": 2
+		}
+	},
+	"Parcel Container XS": {
+		"tier": 1,
+		"type": "Parcel",
+		"mass": 224.68,
+		"volume": 64,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Component": 3,
+			"Uncommon Component": 3,
+			"Uncommon Hydraulics": 5,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Parcel Container S": {
+		"tier": 1,
+		"type": "Parcel",
+		"mass": 1260,
+		"volume": 342,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Component": 18,
+			"Uncommon Component": 18,
+			"Uncommon Hydraulics": 25,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Parcel Container M": {
+		"tier": 1,
+		"type": "Parcel",
+		"mass": 7270,
+		"volume": 1873,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Component": 108,
+			"Uncommon Component": 108,
+			"Uncommon Hydraulics": 125,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Parcel Container L": {
+		"tier": 1,
+		"type": "Parcel",
+		"mass": 14550,
+		"volume": 3746,
+		"outputQuantity": 1,
+		"time": 34560,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Component": 216,
+			"Uncommon Component": 216,
+			"Uncommon Hydraulics": 250,
+			"Uncommon Reinforced Frame L": 2
+		}
+	},
+	"Parcel Container XL": {
+		"tier": 1,
+		"type": "Parcel",
+		"mass": 43310,
+		"volume": 10500,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Component": 648,
+			"Uncommon Component": 648,
+			"Uncommon Hydraulics": 625,
+			"Uncommon Reinforced Frame XL": 1
+		}
+	},
+	"Expanded Parcel Container XL": {
+		"tier": 1,
+		"type": "Parcel",
+		"mass": 86630,
+		"volume": 21000,
+		"outputQuantity": 1,
+		"time": 138240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Component": 1296,
+			"Uncommon Component": 1296,
+			"Uncommon Hydraulics": 1250,
+			"Uncommon Reinforced Frame XL": 2
 		}
 	},
 	"Dispenser": {
@@ -6348,46 +8136,26 @@
 			"Basic Standard Frame M": 1
 		}
 	},
-	"Heavy Dispenser": {
-		"tier": 3,
+	"Deprecated Dispenser": {
+		"tier": 1,
 		"type": "Container",
-		"mass": 61520,
-		"volume": 15070,
+		"mass": 2060,
+		"volume": 479.2,
 		"outputQuantity": 1,
-		"time": 277200,
+		"time": 1920,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
-			"Assembly Line XL"
+			"Assembly Line M"
 		],
 		"input": {
-			"Uncommon Screw": 1296,
-			"Advanced Power System": 625,
-			"Advanced Screen XL": 1,
-			"Advanced Standard Frame XL": 1
+			"Basic Screw": 36,
+			"Basic Power System": 25,
+			"Basic Screen M": 1,
+			"Basic Standard Frame M": 1
 		}
 	},
-	"Medium Dispenser": {
-		"tier": 2,
-		"type": "Container",
-		"mass": 11230,
-		"volume": 2659.4,
-		"outputQuantity": 1,
-		"time": 23040,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line L"
-		],
-		"input": {
-			"Basic Screw": 108,
-			"Uncommon Screw": 108,
-			"Uncommon Power System": 125,
-			"Uncommon Screen L": 1,
-			"Uncommon Standard Frame L": 1
-		}
-	},
-	"Atmospheric Fuel-Tank XS": {
+	"Atmospheric Fuel Tank XS": {
 		"tier": 1,
 		"type": "Piloting",
 		"mass": 35.03,
@@ -6407,7 +8175,7 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Atmospheric Fuel-Tank S": {
+	"Atmospheric Fuel Tank S": {
 		"tier": 1,
 		"type": "Piloting",
 		"mass": 182.67,
@@ -6427,7 +8195,7 @@
 			"Basic Standard Frame S": 1
 		}
 	},
-	"Atmospheric Fuel-Tank M": {
+	"Atmospheric Fuel Tank M": {
 		"tier": 1,
 		"type": "Piloting",
 		"mass": 988.67,
@@ -6446,13 +8214,13 @@
 			"Basic Standard Frame M": 1
 		}
 	},
-	"Atmospheric Fuel-Tank L": {
+	"Atmospheric Fuel Tank L": {
 		"tier": 1,
 		"type": "Container",
 		"mass": 5480,
 		"volume": 2755.4,
 		"outputQuantity": 1,
-		"time": 7200,
+		"time": 7680,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -6465,7 +8233,7 @@
 			"Basic Standard Frame L": 1
 		}
 	},
-	"Space Fuel-Tank S": {
+	"Space Fuel Tank S": {
 		"tier": 2,
 		"type": "Container",
 		"mass": 182.67,
@@ -6485,7 +8253,7 @@
 			"Basic Standard Frame S": 1
 		}
 	},
-	"Space Fuel-Tank M": {
+	"Space Fuel Tank M": {
 		"tier": 2,
 		"type": "Container",
 		"mass": 988.67,
@@ -6504,13 +8272,13 @@
 			"Basic Standard Frame M": 1
 		}
 	},
-	"Space Fuel-Tank L": {
+	"Space Fuel Tank L": {
 		"tier": 2,
 		"type": "Container",
 		"mass": 5480,
 		"volume": 2755.4,
 		"outputQuantity": 1,
-		"time": 7200,
+		"time": 7680,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -6523,7 +8291,7 @@
 			"Basic Standard Frame L": 1
 		}
 	},
-	"Rocket Fuel-Tank XS": {
+	"Rocket Fuel Tank XS": {
 		"tier": 3,
 		"type": "Container",
 		"mass": 173.42,
@@ -6542,13 +8310,13 @@
 			"Advanced Casing S": 1
 		}
 	},
-	"Rocket Fuel-Tank S": {
+	"Rocket Fuel Tank S": {
 		"tier": 3,
 		"type": "Container",
 		"mass": 886.72,
 		"volume": 503.2,
 		"outputQuantity": 1,
-		"time": 18000,
+		"time": 17280,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -6561,13 +8329,13 @@
 			"Advanced Casing M": 1
 		}
 	},
-	"Rocket Fuel-Tank M": {
+	"Rocket Fuel Tank M": {
 		"tier": 3,
 		"type": "Container",
 		"mass": 6231,
 		"volume": 6400,
 		"outputQuantity": 1,
-		"time": 68400,
+		"time": 69120,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -6580,13 +8348,13 @@
 			"Advanced Casing L": 1
 		}
 	},
-	"Rocket Fuel-Tank L": {
+	"Rocket Fuel Tank L": {
 		"tier": 3,
 		"type": "Container",
 		"mass": 25740,
 		"volume": 15570,
 		"outputQuantity": 1,
-		"time": 259200,
+		"time": 277200,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -6605,7 +8373,7 @@
 		"mass": 216.15,
 		"volume": 67,
 		"outputQuantity": 1,
-		"time": 720,
+		"time": 360,
 		"skill": "Combat",
 		"byproducts": {},
 		"industries": [
@@ -6660,7 +8428,7 @@
 		"mass": 12880,
 		"volume": 3962,
 		"outputQuantity": 1,
-		"time": 5760,
+		"time": 11520,
 		"skill": "Combat",
 		"byproducts": {},
 		"industries": [
@@ -6672,7 +8440,7 @@
 			"Basic Standard Frame L": 2
 		}
 	},
-	"Assembly Line XS": {
+	"Basic Assembly Line XS": {
 		"tier": 1,
 		"type": "Industry",
 		"mass": 100.93,
@@ -6692,7 +8460,66 @@
 			"Basic Reinforced Frame XS": 1
 		}
 	},
-	"Assembly Line S": {
+	"Uncommon Assembly Line XS": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 100.93,
+		"volume": 21.8,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Power System": 1,
+			"Uncommon Mobile Panel XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Assembly Line XS": {
+		"tier": 3,
+		"type": "Industry",
+		"mass": 100.93,
+		"volume": 21.8,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Power System": 1,
+			"Advanced Mobile Panel XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Rare Assembly Line XS": {
+		"tier": 4,
+		"type": "Industry",
+		"mass": 100.93,
+		"volume": 21.8,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Power System": 1,
+			"Rare Mobile Panel XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Basic Assembly Line S": {
 		"tier": 1,
 		"type": "Industry",
 		"mass": 522.14,
@@ -6703,7 +8530,6 @@
 		"byproducts": {},
 		"industries": [
 			"Nanopack",
-			"Assembly Line XS",
 			"Assembly Line S"
 		],
 		"input": {
@@ -6713,7 +8539,66 @@
 			"Basic Reinforced Frame S": 1
 		}
 	},
-	"Assembly Line M": {
+	"Uncommon Assembly Line S": {
+		"tier": 2,
+		"type": "Industry",
+		"mass": 522.14,
+		"volume": 112.6,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Power System": 5,
+			"Uncommon Mobile Panel S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Advanced Assembly Line S": {
+		"tier": 3,
+		"type": "Industry",
+		"mass": 522.14,
+		"volume": 112.6,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Power System": 5,
+			"Advanced Mobile Panel S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Rare Assembly Line S": {
+		"tier": 4,
+		"type": "Industry",
+		"mass": 522.14,
+		"volume": 112.6,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Power System": 5,
+			"Rare Mobile Panel S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Basic Assembly Line M": {
 		"tier": 1,
 		"type": "Industry",
 		"mass": 2800,
@@ -6733,13 +8618,72 @@
 			"Basic Reinforced Frame M": 1
 		}
 	},
-	"Assembly Line L": {
+	"Uncommon Assembly Line M": {
+		"tier": 2,
+		"type": "Industry",
+		"mass": 2800,
+		"volume": 599.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Power System": 25,
+			"Uncommon Mobile Panel M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Advanced Assembly Line M": {
+		"tier": 3,
+		"type": "Industry",
+		"mass": 2800,
+		"volume": 599.2,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Power System": 25,
+			"Advanced Mobile Panel M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare Assembly Line M": {
+		"tier": 4,
+		"type": "Industry",
+		"mass": 2800,
+		"volume": 599.2,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Screw": 36,
+			"Rare Power System": 25,
+			"Rare Mobile Panel M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Basic Assembly Line L": {
 		"tier": 1,
 		"type": "Industry",
 		"mass": 15380,
 		"volume": 3255.4,
 		"outputQuantity": 1,
-		"time": 7200,
+		"time": 7680,
 		"skill": "InIn",
 		"byproducts": {},
 		"industries": [
@@ -6753,13 +8697,72 @@
 			"Basic Reinforced Frame L": 1
 		}
 	},
-	"Assembly Line XL": {
+	"Uncommon Assembly Line L": {
+		"tier": 2,
+		"type": "Industry",
+		"mass": 15380,
+		"volume": 3255.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Power System": 125,
+			"Uncommon Mobile Panel L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Advanced Assembly Line L": {
+		"tier": 3,
+		"type": "Industry",
+		"mass": 15380,
+		"volume": 3255.4,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Power System": 125,
+			"Advanced Mobile Panel L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Rare Assembly Line L": {
+		"tier": 4,
+		"type": "Industry",
+		"mass": 15380,
+		"volume": 3255.4,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Power System": 125,
+			"Rare Mobile Panel L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Basic Assembly Line XL": {
 		"tier": 1,
 		"type": "Industry",
 		"mass": 86290,
 		"volume": 18070,
 		"outputQuantity": 1,
-		"time": 32400,
+		"time": 30720,
 		"skill": "InIn",
 		"byproducts": {},
 		"industries": [
@@ -6773,7 +8776,66 @@
 			"Basic Reinforced Frame XL": 1
 		}
 	},
-	"3D Printer M": {
+	"Uncommon Assembly Line XL": {
+		"tier": 2,
+		"type": "Industry",
+		"mass": 86290,
+		"volume": 18070,
+		"outputQuantity": 1,
+		"time": 92160,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 648,
+			"Uncommon Screw": 648,
+			"Uncommon Power System": 625,
+			"Uncommon Mobile Panel XL": 1,
+			"Uncommon Reinforced Frame XL": 1
+		}
+	},
+	"Advanced Assembly Line XL": {
+		"tier": 3,
+		"type": "Industry",
+		"mass": 86290,
+		"volume": 18070,
+		"outputQuantity": 1,
+		"time": 277200,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Uncommon Screw": 1296,
+			"Advanced Power System": 625,
+			"Advanced Mobile Panel XL": 1,
+			"Advanced Reinforced Frame XL": 1
+		}
+	},
+	"Rare Assembly Line XL": {
+		"tier": 4,
+		"type": "Industry",
+		"mass": 86290,
+		"volume": 18070,
+		"outputQuantity": 1,
+		"time": 828000,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Uncommon Screw": 648,
+			"Advanced Screw": 648,
+			"Rare Power System": 625,
+			"Rare Mobile Panel XL": 1,
+			"Rare Reinforced Frame XL": 1
+		}
+	},
+	"Basic 3D Printer M": {
 		"tier": 1,
 		"type": "Industry",
 		"mass": 2000,
@@ -6792,7 +8854,66 @@
 			"Basic Reinforced Frame M": 1
 		}
 	},
-	"Chemical Industry M": {
+	"Uncommon 3D Printer M": {
+		"tier": 2,
+		"type": "Industry",
+		"mass": 2000,
+		"volume": 609.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 18,
+			"Uncommon Pipe": 18,
+			"Uncommon Injector": 25,
+			"Uncommon Robotic Arm M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Advanced 3D Printer M": {
+		"tier": 3,
+		"type": "Industry",
+		"mass": 2000,
+		"volume": 609.2,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 36,
+			"Advanced Injector": 25,
+			"Advanced Robotic Arm M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare 3D Printer M": {
+		"tier": 4,
+		"type": "Industry",
+		"mass": 2000,
+		"volume": 609.2,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 18,
+			"Advanced Pipe": 18,
+			"Rare Injector": 25,
+			"Rare Robotic Arm M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Basic Chemical Industry M": {
 		"tier": 1,
 		"type": "Industry",
 		"mass": 2300,
@@ -6811,7 +8932,66 @@
 			"Basic Reinforced Frame M": 1
 		}
 	},
-	"Electronics Industry M": {
+	"Uncommon Chemical Industry M": {
+		"tier": 2,
+		"type": "Industry",
+		"mass": 2300,
+		"volume": 479.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 18,
+			"Uncommon Pipe": 18,
+			"Uncommon Power System": 25,
+			"Uncommon Chemical Container M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Advanced Chemical Industry M": {
+		"tier": 3,
+		"type": "Industry",
+		"mass": 2300,
+		"volume": 479.2,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 36,
+			"Advanced Power System": 25,
+			"Advanced Chemical Container M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare Chemical Industry M": {
+		"tier": 4,
+		"type": "Industry",
+		"mass": 2300,
+		"volume": 479.2,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 18,
+			"Advanced Pipe": 18,
+			"Rare Power System": 25,
+			"Rare Chemical Container M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Basic Electronics Industry M": {
 		"tier": 1,
 		"type": "Industry",
 		"mass": 1620,
@@ -6830,7 +9010,66 @@
 			"Basic Reinforced Frame M": 1
 		}
 	},
-	"Glass Furnace M": {
+	"Uncommon Electronics Industry M": {
+		"tier": 2,
+		"type": "Industry",
+		"mass": 1620,
+		"volume": 459.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 18,
+			"Uncommon Pipe": 18,
+			"Uncommon Electronics": 25,
+			"Uncommon Robotic Arm M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Advanced Electronics Industry M": {
+		"tier": 3,
+		"type": "Industry",
+		"mass": 1620,
+		"volume": 459.2,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 36,
+			"Advanced Electronics": 25,
+			"Advanced Robotic Arm M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare Electronics Industry M": {
+		"tier": 4,
+		"type": "Industry",
+		"mass": 1620,
+		"volume": 459.2,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 18,
+			"Advanced Pipe": 18,
+			"Rare Electronics": 25,
+			"Rare Robotic Arm M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Basic Glass Furnace M": {
 		"tier": 1,
 		"type": "Industry",
 		"mass": 2830,
@@ -6849,7 +9088,66 @@
 			"Basic Reinforced Frame M": 1
 		}
 	},
-	"Honeycomb Refinery M": {
+	"Uncommon Glass Furnace M": {
+		"tier": 2,
+		"type": "Industry",
+		"mass": 2830,
+		"volume": 556.4,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 18,
+			"Uncommon Pipe": 18,
+			"Uncommon Burner": 25,
+			"Uncommon Power Transformer M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Advanced Glass Furnace M": {
+		"tier": 3,
+		"type": "Industry",
+		"mass": 2830,
+		"volume": 556.4,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 36,
+			"Advanced Burner": 25,
+			"Advanced Power Transformer M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare Glass Furnace M": {
+		"tier": 4,
+		"type": "Industry",
+		"mass": 2830,
+		"volume": 556.4,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 18,
+			"Rare Pipe": 18,
+			"Rare Burner": 25,
+			"Rare Power Transformer M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Basic Honeycomb Refinery M": {
 		"tier": 1,
 		"type": "Industry",
 		"mass": 2990,
@@ -6868,7 +9166,66 @@
 			"Basic Reinforced Frame M": 1
 		}
 	},
-	"Metalwork Industry M": {
+	"Uncommon Honeycomb Refinery M": {
+		"tier": 2,
+		"type": "Industry",
+		"mass": 2990,
+		"volume": 589.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 18,
+			"Uncommon Pipe": 18,
+			"Uncommon Power System": 25,
+			"Uncommon Robotic Arm M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Advanced Honeycomb Refinery M": {
+		"tier": 3,
+		"type": "Industry",
+		"mass": 2990,
+		"volume": 589.2,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 36,
+			"Advanced Power System": 25,
+			"Advanced Robotic Arm M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare Honeycomb Refinery M": {
+		"tier": 4,
+		"type": "Industry",
+		"mass": 2990,
+		"volume": 589.2,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 18,
+			"Advanced Pipe": 18,
+			"Rare Power System": 25,
+			"Rare Robotic Arm M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Basic Metalwork Industry M": {
 		"tier": 1,
 		"type": "Industry",
 		"mass": 2600,
@@ -6887,7 +9244,66 @@
 			"Basic Reinforced Frame M": 1
 		}
 	},
-	"Recycler M": {
+	"Uncommon Metalwork Industry M": {
+		"tier": 2,
+		"type": "Industry",
+		"mass": 2600,
+		"volume": 599.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 18,
+			"Uncommon Pipe": 18,
+			"Uncommon Power System": 25,
+			"Uncommon Mobile Panel M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Advanced Metalwork Industry M": {
+		"tier": 3,
+		"type": "Industry",
+		"mass": 2600,
+		"volume": 599.2,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 36,
+			"Advanced Power System": 25,
+			"Advanced Mobile Panel M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare Metalwork Industry M": {
+		"tier": 4,
+		"type": "Industry",
+		"mass": 2600,
+		"volume": 599.2,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 18,
+			"Advanced Pipe": 18,
+			"Rare Power System": 25,
+			"Rare Mobile Panel M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Basic Recycler M": {
 		"tier": 1,
 		"type": "Industry",
 		"mass": 2350,
@@ -6906,7 +9322,66 @@
 			"Basic Reinforced Frame M": 1
 		}
 	},
-	"Refiner M": {
+	"Uncommon Recycler M": {
+		"tier": 2,
+		"type": "Industry",
+		"mass": 2350,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 18,
+			"Uncommon Pipe": 18,
+			"Uncommon Burner": 25,
+			"Uncommon Mobile Panel M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Advanced Recycler M": {
+		"tier": 3,
+		"type": "Industry",
+		"mass": 2350,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 36,
+			"Advanced Burner": 25,
+			"Advanced Mobile Panel M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare Recycler M": {
+		"tier": 4,
+		"type": "Industry",
+		"mass": 2350,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 18,
+			"Advanced Pipe": 18,
+			"Rare Burner": 25,
+			"Rare Mobile Panel M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Basic Refiner M": {
 		"tier": 1,
 		"type": "Industry",
 		"mass": 2300,
@@ -6925,7 +9400,66 @@
 			"Basic Reinforced Frame M": 1
 		}
 	},
-	"Smelter M": {
+	"Uncommon Refiner M": {
+		"tier": 2,
+		"type": "Industry",
+		"mass": 2300,
+		"volume": 479.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 18,
+			"Uncommon Pipe": 18,
+			"Uncommon Power System": 25,
+			"Uncommon Chemical Container M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Advanced Refiner M": {
+		"tier": 3,
+		"type": "Industry",
+		"mass": 2300,
+		"volume": 479.2,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 36,
+			"Advanced Power System": 25,
+			"Advanced Chemical Container M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare Refiner M": {
+		"tier": 4,
+		"type": "Industry",
+		"mass": 2300,
+		"volume": 479.2,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 18,
+			"Advanced Pipe": 18,
+			"Rare Power System": 25,
+			"Rare Chemical Container M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Basic Smelter M": {
 		"tier": 1,
 		"type": "Industry",
 		"mass": 2060,
@@ -6944,13 +9478,72 @@
 			"Basic Reinforced Frame M": 1
 		}
 	},
+	"Uncommon Smelter M": {
+		"tier": 2,
+		"type": "Industry",
+		"mass": 2060,
+		"volume": 499.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 18,
+			"Uncommon Pipe": 18,
+			"Uncommon Burner": 25,
+			"Uncommon Chemical Container M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Advanced Smelter M": {
+		"tier": 3,
+		"type": "Industry",
+		"mass": 2060,
+		"volume": 499.2,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 36,
+			"Advanced Burner": 25,
+			"Advanced Chemical Container M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare Smelter M": {
+		"tier": 4,
+		"type": "Industry",
+		"mass": 2060,
+		"volume": 499.2,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 18,
+			"Advanced Pipe": 18,
+			"Advanced Burner": 25,
+			"Advanced Chemical Container M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
 	"Transfer Unit": {
 		"tier": 1,
 		"type": "Industry",
 		"mass": 10150,
 		"volume": 3305.4,
 		"outputQuantity": 1,
-		"time": 7200,
+		"time": 7680,
 		"skill": "InIn",
 		"byproducts": {},
 		"industries": [
@@ -7146,7 +9739,7 @@
 		"mass": 122.4,
 		"volume": 45.2,
 		"outputQuantity": 1,
-		"time": 120,
+		"time": 240,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -7166,7 +9759,7 @@
 		"mass": 638.3,
 		"volume": 233.2,
 		"outputQuantity": 1,
-		"time": 480,
+		"time": 960,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -7186,7 +9779,7 @@
 		"mass": 3410,
 		"volume": 1238.4,
 		"outputQuantity": 1,
-		"time": 1920,
+		"time": 3840,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -7264,7 +9857,7 @@
 		"mass": 11500,
 		"volume": 3355.4,
 		"outputQuantity": 1,
-		"time": 7200,
+		"time": 7680,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -7355,10 +9948,10 @@
 			"Basic Standard Frame M": 1
 		}
 	},
-	"Atmospheric Engine XS": {
+	"Basic Atmospheric Engine XS": {
 		"tier": 1,
 		"type": "Atmospheric Engine",
-		"mass": 101.88,
+		"mass": 100,
 		"volume": 22.6,
 		"outputQuantity": 1,
 		"time": 120,
@@ -7375,10 +9968,246 @@
 			"Basic Reinforced Frame XS": 1
 		}
 	},
-	"Atmospheric Engine S": {
+	"Uncommon Freight Atmospheric Engine XS": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 80,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Injector": 1,
+			"Uncommon Combustion Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Uncommon Maneuver Atmospheric Engine XS": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 100,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Injector": 1,
+			"Uncommon Combustion Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Uncommon Military Atmospheric Engine XS": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 100,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Injector": 1,
+			"Uncommon Combustion Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Uncommon Safe Atmospheric Engine XS": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 100,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Injector": 1,
+			"Uncommon Combustion Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Freight Atmospheric Engine XS": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 64,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Injector": 1,
+			"Advanced Combustion Chamber XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Maneuver Atmospheric Engine XS": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 100,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Injector": 1,
+			"Advanced Combustion Chamber XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Military Atmospheric Engine XS": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 100,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Injector": 1,
+			"Advanced Combustion Chamber XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Safe Atmospheric Engine XS": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 100,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Injector": 1,
+			"Advanced Combustion Chamber XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Rare Freight Atmospheric Engine XS": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 51.2,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Injector": 1,
+			"Rare Combustion Chamber XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Maneuver Atmospheric Engine XS": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 100,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Injector": 1,
+			"Rare Combustion Chamber XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Military Atmospheric Engine XS": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 100,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Injector": 1,
+			"Rare Combustion Chamber XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Safe Atmospheric Engine XS": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 100,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Injector": 1,
+			"Rare Combustion Chamber XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Basic Atmospheric Engine S": {
 		"tier": 1,
 		"type": "Atmospheric Engine",
-		"mass": 539.99,
+		"mass": 540,
 		"volume": 116.6,
 		"outputQuantity": 1,
 		"time": 480,
@@ -7395,10 +10224,246 @@
 			"Basic Reinforced Frame S": 1
 		}
 	},
-	"Atmospheric Engine M": {
+	"Uncommon Freight Atmospheric Engine S": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 432,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Injector": 5,
+			"Uncommon Combustion Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Uncommon Maneuver Atmospheric Engine S": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 540,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Injector": 5,
+			"Uncommon Combustion Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Uncommon Military Atmospheric Engine S": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 540,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Injector": 5,
+			"Uncommon Combustion Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Uncommon Safe Atmospheric Engine S": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 540,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Injector": 5,
+			"Uncommon Combustion Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Advanced Freight Atmospheric Engine S": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 345.6,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Injector": 5,
+			"Advanced Combustion Chamber S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Maneuver Atmospheric Engine S": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 540,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Injector": 5,
+			"Advanced Combustion Chamber S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Military Atmospheric Engine S": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 540,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Injector": 5,
+			"Advanced Combustion Chamber S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Safe Atmospheric Engine S": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 540,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Injector": 5,
+			"Advanced Combustion Chamber S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Rare Freight Atmospheric Engine S": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 276.48,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Injector": 5,
+			"Rare Combustion Chamber S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Maneuver Atmospheric Engine S": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 540,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Injector": 5,
+			"Rare Combustion Chamber S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Military Atmospheric Engine S": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 540,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Injector": 5,
+			"Rare Combustion Chamber S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Safe Atmospheric Engine S": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 540,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Injector": 5,
+			"Rare Combustion Chamber S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Basic Atmospheric Engine M": {
 		"tier": 1,
 		"type": "Atmospheric Engine",
-		"mass": 2980,
+		"mass": 3000,
 		"volume": 619.2,
 		"outputQuantity": 1,
 		"time": 1920,
@@ -7414,13 +10479,249 @@
 			"Basic Reinforced Frame M": 1
 		}
 	},
-	"Atmospheric Engine L": {
+	"Uncommon Freight Atmospheric Engine M": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 2400,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Injector": 25,
+			"Uncommon Combustion Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Uncommon Maneuver Atmospheric Engine M": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 3000,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Injector": 25,
+			"Uncommon Combustion Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Uncommon Military Atmospheric Engine M": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 3000,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Injector": 25,
+			"Uncommon Combustion Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Uncommon Safe Atmospheric Engine M": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 3000,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Injector": 25,
+			"Uncommon Combustion Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Advanced Freight Atmospheric Engine M": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 1920,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Injector": 25,
+			"Advanced Combustion Chamber M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Maneuver Atmospheric Engine M": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 3000,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Injector": 25,
+			"Advanced Combustion Chamber M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Military Atmospheric Engine M": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 3000,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Injector": 25,
+			"Advanced Combustion Chamber M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Safe Atmospheric Engine M": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 3000,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Injector": 25,
+			"Advanced Combustion Chamber M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare Freight Atmospheric Engine M": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 1540,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Injector": 25,
+			"Rare Combustion Chamber M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Maneuver Atmospheric Engine M": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 3000,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Injector": 25,
+			"Rare Combustion Chamber M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Military Atmospheric Engine M": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 3000,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Injector": 25,
+			"Rare Combustion Chamber M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Safe Atmospheric Engine M": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 3000,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Injector": 25,
+			"Rare Combustion Chamber M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Basic Atmospheric Engine L": {
 		"tier": 1,
 		"type": "Atmospheric Engine",
-		"mass": 16930,
+		"mass": 17000,
 		"volume": 3355.4,
 		"outputQuantity": 1,
-		"time": 7200,
+		"time": 7680,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -7433,7 +10734,243 @@
 			"Basic Reinforced Frame L": 1
 		}
 	},
-	"Space Engine XS": {
+	"Uncommon Freight Atmospheric Engine L": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 13600,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Injector": 125,
+			"Uncommon Combustion Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Uncommon Maneuver Atmospheric Engine L": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 17000,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Injector": 125,
+			"Uncommon Combustion Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Uncommon Military Atmospheric Engine L": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 17000,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Injector": 125,
+			"Uncommon Combustion Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Uncommon Safe Atmospheric Engine L": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 17000,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Injector": 125,
+			"Uncommon Combustion Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Advanced Freight Atmospheric Engine L": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 10880,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Injector": 125,
+			"Advanced Combustion Chamber L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Maneuver Atmospheric Engine L": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 17000,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Injector": 125,
+			"Advanced Combustion Chamber L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Military Atmospheric Engine L": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 17000,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Injector": 125,
+			"Advanced Combustion Chamber L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Safe Atmospheric Engine L": {
+		"tier": 3,
+		"type": "Atmospheric Engine",
+		"mass": 17000,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Injector": 125,
+			"Advanced Combustion Chamber L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Rare Freight Atmospheric Engine L": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 8700,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Injector": 125,
+			"Rare Combustion Chamber L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Maneuver Atmospheric Engine L": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 17000,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Injector": 125,
+			"Rare Combustion Chamber L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Military Atmospheric Engine L": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 17000,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Injector": 125,
+			"Rare Combustion Chamber L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Safe Atmospheric Engine L": {
+		"tier": 4,
+		"type": "Atmospheric Engine",
+		"mass": 17000,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Injector": 125,
+			"Rare Combustion Chamber L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Basic Space Engine XS": {
 		"tier": 1,
 		"type": "Space Engine",
 		"mass": 146.23,
@@ -7453,7 +10990,243 @@
 			"Basic Reinforced Frame XS": 1
 		}
 	},
-	"Space Engine S": {
+	"Uncommon Freight Space Engine XS": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 116.98,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Burner": 1,
+			"Uncommon Ionic Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Uncommon Maneuver Space Engine XS": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 146.23,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Burner": 1,
+			"Uncommon Ionic Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Uncommon Military Space Engine XS": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 146.23,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Burner": 1,
+			"Uncommon Ionic Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Uncommon Safe Space Engine XS": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 146.23,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Burner": 1,
+			"Uncommon Ionic Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Freight Space Engine XS": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 93.59,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Burner": 1,
+			"Advanced Ionic Chamber XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Maneuver Space Engine XS": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 146.23,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Burner": 1,
+			"Advanced Ionic Chamber XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Military Space Engine XS": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 146.23,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Burner": 1,
+			"Advanced Ionic Chamber XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Safe Space Engine XS": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 146.23,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Burner": 1,
+			"Advanced Ionic Chamber XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Rare Freight Space Engine XS": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 74.87,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Burner": 1,
+			"Rare Ionic Chamber XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Maneuver Space Engine XS": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 146.23,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Burner": 1,
+			"Rare Ionic Chamber XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Military Space Engine XS": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 146.23,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Burner": 1,
+			"Rare Ionic Chamber XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Safe Space Engine XS": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 146.23,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Burner": 1,
+			"Rare Ionic Chamber XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Basic Space Engine S": {
 		"tier": 1,
 		"type": "Space Engine",
 		"mass": 761.74,
@@ -7473,7 +11246,243 @@
 			"Basic Reinforced Frame S": 1
 		}
 	},
-	"Space Engine M": {
+	"Uncommon Freight Space Engine S": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 609.39,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Burner": 5,
+			"Uncommon Ionic Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Uncommon Maneuver Space Engine S": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 761.74,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Burner": 5,
+			"Uncommon Ionic Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Uncommon Military Space Engine S": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 761.74,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Burner": 5,
+			"Uncommon Ionic Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Uncommon Safe Space Engine S": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 761.74,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Burner": 5,
+			"Uncommon Ionic Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Advanced Freight Space Engine S": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 487.51,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Burner": 5,
+			"Advanced Ionic Chamber S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Maneuver Space Engine S": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 761.74,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Burner": 5,
+			"Advanced Ionic Chamber S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Military Space Engine S": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 761.74,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Burner": 5,
+			"Advanced Ionic Chamber S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Safe Space Engine S": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 761.74,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Burner": 5,
+			"Advanced Ionic Chamber S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Rare Freight Space Engine S": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 390.01,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Burner": 5,
+			"Rare Ionic Chamber S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Maneuver Space Engine S": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 761.74,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Burner": 5,
+			"Rare Ionic Chamber S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Military Space Engine S": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 761.74,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Burner": 5,
+			"Rare Ionic Chamber S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Safe Space Engine S": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 761.74,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Burner": 5,
+			"Rare Ionic Chamber S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Basic Space Engine M": {
 		"tier": 1,
 		"type": "Space Engine",
 		"mass": 4090,
@@ -7492,13 +11501,249 @@
 			"Basic Reinforced Frame M": 1
 		}
 	},
-	"Space Engine L": {
+	"Uncommon Freight Space Engine M": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 3270,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Burner": 25,
+			"Uncommon Ionic Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Uncommon Maneuver Space Engine M": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 4090,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Burner": 25,
+			"Uncommon Ionic Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Uncommon Military Space Engine M": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 4090,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Burner": 25,
+			"Uncommon Ionic Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Uncommon Safe Space Engine M": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 4090,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Burner": 25,
+			"Uncommon Ionic Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Advanced Freight Space Engine M": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 2620,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Burner": 25,
+			"Advanced Ionic Chamber M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Maneuver Space Engine M": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 4090,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Burner": 25,
+			"Advanced Ionic Chamber M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Military Space Engine M": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 4090,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Burner": 25,
+			"Advanced Ionic Chamber M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Safe Space Engine M": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 4090,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Burner": 25,
+			"Advanced Ionic Chamber M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare Freight Space Engine M": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 2100,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Burner": 25,
+			"Rare Ionic Chamber M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Maneuver Space Engine M": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 4090,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Burner": 25,
+			"Rare Ionic Chamber M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Military Space Engine M": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 4090,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Burner": 25,
+			"Rare Ionic Chamber M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Safe Space Engine M": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 4090,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Burner": 25,
+			"Rare Ionic Chamber M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Basic Space Engine L": {
 		"tier": 1,
 		"type": "Space Engine",
 		"mass": 22470,
 		"volume": 3071.4,
 		"outputQuantity": 1,
-		"time": 7200,
+		"time": 7680,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -7511,13 +11756,249 @@
 			"Basic Reinforced Frame L": 1
 		}
 	},
-	"Space Engine XL": {
+	"Uncommon Freight Space Engine L": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 17980,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Burner": 125,
+			"Uncommon Ionic Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Uncommon Maneuver Space Engine L": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 22470,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Burner": 125,
+			"Uncommon Ionic Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Uncommon Military Space Engine L": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 22470,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Burner": 125,
+			"Uncommon Ionic Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Uncommon Safe Space Engine L": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 22470,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Burner": 125,
+			"Uncommon Ionic Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Advanced Freight Space Engine L": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 14380,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Burner": 125,
+			"Advanced Ionic Chamber L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Maneuver Space Engine L": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 22470,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Burner": 125,
+			"Advanced Ionic Chamber L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Military Space Engine L": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 22470,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Burner": 125,
+			"Advanced Ionic Chamber L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Safe Space Engine L": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 22470,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Burner": 125,
+			"Advanced Ionic Chamber L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Rare Freight Space Engine L": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 11510,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Burner": 125,
+			"Rare Ionic Chamber L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Maneuver Space Engine L": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 22470,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Burner": 125,
+			"Rare Ionic Chamber L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Military Space Engine L": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 22470,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Burner": 125,
+			"Rare Ionic Chamber L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Safe Space Engine L": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 22470,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Burner": 125,
+			"Rare Ionic Chamber L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Basic Space Engine XL": {
 		"tier": 1,
 		"type": "Space Engine",
 		"mass": 126240,
 		"volume": 17150,
 		"outputQuantity": 1,
-		"time": 32400,
+		"time": 30720,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -7528,6 +12009,242 @@
 			"Basic Burner": 625,
 			"Basic Ionic Chamber XL": 1,
 			"Basic Reinforced Frame XL": 1
+		}
+	},
+	"Uncommon Freight Space Engine XL": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 100990,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 92160,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 648,
+			"Uncommon Screw": 648,
+			"Uncommon Burner": 625,
+			"Uncommon Ionic Chamber XL": 1,
+			"Uncommon Reinforced Frame XL": 1
+		}
+	},
+	"Uncommon Maneuver Space Engine XL": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 126240,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 92160,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 648,
+			"Uncommon Screw": 648,
+			"Uncommon Burner": 625,
+			"Uncommon Ionic Chamber XL": 1,
+			"Uncommon Reinforced Frame XL": 1
+		}
+	},
+	"Uncommon Military Space Engine XL": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 126240,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 92160,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 648,
+			"Uncommon Screw": 648,
+			"Uncommon Burner": 625,
+			"Uncommon Ionic Chamber XL": 1,
+			"Uncommon Reinforced Frame XL": 1
+		}
+	},
+	"Uncommon Safe Space Engine XL": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 126240,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 92160,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 648,
+			"Uncommon Screw": 648,
+			"Uncommon Burner": 625,
+			"Uncommon Ionic Chamber XL": 1,
+			"Uncommon Reinforced Frame XL": 1
+		}
+	},
+	"Advanced Freight Space Engine XL": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 80790,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 259500,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Uncommon Screw": 1296,
+			"Advanced Burner": 625,
+			"Advanced Ionic Chamber XL": 1,
+			"Advanced Reinforced Frame XL": 1
+		}
+	},
+	"Advanced Maneuver Space Engine XL": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 126240,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 259500,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Uncommon Screw": 1296,
+			"Advanced Burner": 625,
+			"Advanced Ionic Chamber XL": 1,
+			"Advanced Reinforced Frame XL": 1
+		}
+	},
+	"Advanced Military Space Engine XL": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 126240,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 259500,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Uncommon Screw": 1296,
+			"Advanced Burner": 625,
+			"Advanced Ionic Chamber XL": 1,
+			"Advanced Reinforced Frame XL": 1
+		}
+	},
+	"Advanced Safe Space Engine XL": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 126240,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 259500,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Uncommon Screw": 1296,
+			"Advanced Burner": 625,
+			"Advanced Ionic Chamber XL": 1,
+			"Advanced Reinforced Frame XL": 1
+		}
+	},
+	"Rare Freight Space Engine XL": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 64630,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 828000,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Uncommon Screw": 648,
+			"Advanced Screw": 648,
+			"Rare Burner": 625,
+			"Rare Ionic Chamber XL": 1,
+			"Rare Reinforced Frame XL": 1
+		}
+	},
+	"Rare Maneuver Space Engine XL": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 126240,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 828000,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Uncommon Screw": 648,
+			"Advanced Screw": 648,
+			"Rare Burner": 625,
+			"Rare Ionic Chamber XL": 1,
+			"Rare Reinforced Frame XL": 1
+		}
+	},
+	"Rare Military Space Engine XL": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 126240,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 828000,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Uncommon Screw": 648,
+			"Advanced Screw": 648,
+			"Rare Burner": 625,
+			"Rare Ionic Chamber XL": 1,
+			"Rare Reinforced Frame XL": 1
+		}
+	},
+	"Rare Safe Space Engine XL": {
+		"tier": 4,
+		"type": "Space Engine",
+		"mass": 126240,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 828000,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Uncommon Screw": 648,
+			"Advanced Screw": 648,
+			"Rare Burner": 625,
+			"Rare Ionic Chamber XL": 1,
+			"Rare Reinforced Frame XL": 1
 		}
 	},
 	"Hover Engine S": {
@@ -7728,7 +12445,7 @@
 		"mass": 3390,
 		"volume": 628,
 		"outputQuantity": 1,
-		"time": 18000,
+		"time": 17280,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -7823,7 +12540,7 @@
 		"mass": 207.86,
 		"volume": 57.56,
 		"outputQuantity": 1,
-		"time": 1380,
+		"time": 1350,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -7843,7 +12560,7 @@
 		"mass": 49.88,
 		"volume": 13,
 		"outputQuantity": 1,
-		"time": 120,
+		"time": 90,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -7900,7 +12617,7 @@
 		"mass": 8500,
 		"volume": 1981,
 		"outputQuantity": 1,
-		"time": 18000,
+		"time": 17280,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -7919,7 +12636,7 @@
 		"mass": 207.86,
 		"volume": 57.56,
 		"outputQuantity": 1,
-		"time": 1380,
+		"time": 337,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -7937,7 +12654,7 @@
 		"mass": 110.62,
 		"volume": 34.7,
 		"outputQuantity": 1,
-		"time": 360,
+		"time": 337,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -7955,7 +12672,7 @@
 		"mass": 110.62,
 		"volume": 34.7,
 		"outputQuantity": 1,
-		"time": 360,
+		"time": 337,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -7973,7 +12690,7 @@
 		"mass": 110.62,
 		"volume": 34.7,
 		"outputQuantity": 1,
-		"time": 360,
+		"time": 337,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -7991,7 +12708,7 @@
 		"mass": 66460,
 		"volume": 12700,
 		"outputQuantity": 1,
-		"time": 93600,
+		"time": 92160,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8051,7 +12768,7 @@
 		"mass": 7.79,
 		"volume": 4.5,
 		"outputQuantity": 1,
-		"time": 300,
+		"time": 270,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -8088,7 +12805,7 @@
 		"mass": 9.35,
 		"volume": 4.8,
 		"outputQuantity": 1,
-		"time": 300,
+		"time": 270,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -8183,7 +12900,7 @@
 		"mass": 2170,
 		"volume": 486.4,
 		"outputQuantity": 1,
-		"time": 18000,
+		"time": 17280,
 		"skill": "Combat",
 		"byproducts": {},
 		"industries": [
@@ -8202,7 +12919,7 @@
 		"mass": 11320,
 		"volume": 2666.6,
 		"outputQuantity": 1,
-		"time": 68400,
+		"time": 69120,
 		"skill": "Combat",
 		"byproducts": {},
 		"industries": [
@@ -8263,7 +12980,7 @@
 		"mass": 550870,
 		"volume": 86470,
 		"outputQuantity": 1,
-		"time": 1036800,
+		"time": 4147200,
 		"skill": "Piloting",
 		"byproducts": {},
 		"industries": [
@@ -8399,7 +13116,7 @@
 		"mass": 122750,
 		"volume": 16760,
 		"outputQuantity": 1,
-		"time": 93600,
+		"time": 92160,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8419,7 +13136,7 @@
 		"mass": 122750,
 		"volume": 16760,
 		"outputQuantity": 1,
-		"time": 93600,
+		"time": 183600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8439,7 +13156,7 @@
 		"mass": 122750,
 		"volume": 16760,
 		"outputQuantity": 1,
-		"time": 93600,
+		"time": 367200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8459,7 +13176,7 @@
 		"mass": 122750,
 		"volume": 16760,
 		"outputQuantity": 1,
-		"time": 93600,
+		"time": 460800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8479,7 +13196,7 @@
 		"mass": 122750,
 		"volume": 16760,
 		"outputQuantity": 1,
-		"time": 93600,
+		"time": 738000,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8499,7 +13216,43 @@
 		"mass": 13.27,
 		"volume": 5,
 		"outputQuantity": 1,
-		"time": 70,
+		"time": 67,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"NAND Operator": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 13.27,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 67,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"NOR Operator": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 13.27,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 67,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8517,7 +13270,7 @@
 		"mass": 7.47,
 		"volume": 4.5,
 		"outputQuantity": 1,
-		"time": 70,
+		"time": 67,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8535,7 +13288,25 @@
 		"mass": 7.47,
 		"volume": 4.5,
 		"outputQuantity": 1,
-		"time": 70,
+		"time": 67,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"XOR Operator": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 7.47,
+		"volume": 4.5,
+		"outputQuantity": 1,
+		"time": 67,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8553,7 +13324,7 @@
 		"mass": 8.87,
 		"volume": 6.5,
 		"outputQuantity": 1,
-		"time": 120,
+		"time": 90,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8589,7 +13360,7 @@
 		"mass": 9.93,
 		"volume": 5,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 67,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8607,7 +13378,7 @@
 		"mass": 9.93,
 		"volume": 5,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 67,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8625,7 +13396,7 @@
 		"mass": 9.93,
 		"volume": 5,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 67,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8643,7 +13414,7 @@
 		"mass": 9.93,
 		"volume": 5,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 67,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8661,7 +13432,7 @@
 		"mass": 9.93,
 		"volume": 5,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 67,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8673,13 +13444,13 @@
 			"Uncommon Electronics": 1
 		}
 	},
-	"Infra-Red Laser Emitter": {
+	"Infrared Laser Emitter": {
 		"tier": 2,
 		"type": "Electronics",
 		"mass": 9.93,
 		"volume": 5,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 90,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8714,7 +13485,7 @@
 		"mass": 7.47,
 		"volume": 4.5,
 		"outputQuantity": 1,
-		"time": 30,
+		"time": 22,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8768,7 +13539,7 @@
 		"mass": 6636.912,
 		"volume": 1500,
 		"outputQuantity": 1,
-		"time": 21600,
+		"time": 23040,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8848,7 +13619,7 @@
 		"mass": 70.05,
 		"volume": 10.8,
 		"outputQuantity": 1,
-		"time": 240,
+		"time": 90,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -8926,7 +13697,7 @@
 		"mass": 70.05,
 		"volume": 10.8,
 		"outputQuantity": 1,
-		"time": 240,
+		"time": 90,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -9004,7 +13775,7 @@
 		"mass": 70.05,
 		"volume": 10.8,
 		"outputQuantity": 1,
-		"time": 240,
+		"time": 90,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -9096,7 +13867,7 @@
 			"Uncommon Casing XS": 1
 		}
 	},
-	"Small Atmospheric Radar PvP S": {
+	"Atmospheric Radar S": {
 		"tier": 1,
 		"type": "Radar",
 		"mass": 486.72,
@@ -9116,7 +13887,7 @@
 			"Uncommon Standard Frame S": 1
 		}
 	},
-	"Medium Atmospheric Radar PvP M": {
+	"Atmospheric Radar M": {
 		"tier": 2,
 		"type": "Radar",
 		"mass": 1740,
@@ -9136,7 +13907,7 @@
 			"Uncommon Reinforced Frame M": 1
 		}
 	},
-	"Large Atmospheric Radar PvP L": {
+	"Atmospheric Radar L": {
 		"tier": 2,
 		"type": "Radar",
 		"mass": 6640,
@@ -9157,7 +13928,7 @@
 		}
 	},
 	"Space Radar S": {
-		"tier": 1,
+		"tier": 2,
 		"type": "Radar",
 		"mass": 486.72,
 		"volume": 96.56,
@@ -9176,8 +13947,182 @@
 			"Uncommon Standard Frame S": 1
 		}
 	},
+	"Advanced Phased-Array Space Radar S": {
+		"tier": 3,
+		"type": "Radar",
+		"mass": 486.72,
+		"volume": 96.56,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon LED": 6,
+			"Advanced Magnet": 5,
+			"Advanced Antenna S": 1,
+			"Advanced Standard Frame S": 1
+		}
+	},
+	"Advanced Protected Space Radar S": {
+		"tier": 3,
+		"type": "Radar",
+		"mass": 486.72,
+		"volume": 96.56,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon LED": 6,
+			"Advanced Magnet": 5,
+			"Advanced Antenna S": 1,
+			"Advanced Standard Frame S": 1
+		}
+	},
+	"Advanced Quick-Wired Space Radar S": {
+		"tier": 3,
+		"type": "Radar",
+		"mass": 486.72,
+		"volume": 96.56,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon LED": 6,
+			"Advanced Magnet": 5,
+			"Advanced Antenna S": 1,
+			"Advanced Standard Frame S": 1
+		}
+	},
+	"Rare Phased-Array Space Radar S": {
+		"tier": 4,
+		"type": "Radar",
+		"mass": 486.72,
+		"volume": 96.56,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon LED": 3,
+			"Advanced LED": 3,
+			"Rare Magnet": 5,
+			"Rare Antenna S": 1,
+			"Rare Standard Frame S": 1
+		}
+	},
+	"Rare Protected Space Radar S": {
+		"tier": 4,
+		"type": "Radar",
+		"mass": 486.72,
+		"volume": 96.56,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon LED": 3,
+			"Advanced LED": 3,
+			"Rare Magnet": 5,
+			"Rare Antenna S": 1,
+			"Rare Standard Frame S": 1
+		}
+	},
+	"Rare Quick-Wired Space Radar S": {
+		"tier": 4,
+		"type": "Radar",
+		"mass": 486.72,
+		"volume": 96.56,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon LED": 3,
+			"Advanced LED": 3,
+			"Rare Magnet": 5,
+			"Rare Antenna S": 1,
+			"Rare Standard Frame S": 1
+		}
+	},
+	"Exotic Phased-Array Space Radar S": {
+		"tier": 5,
+		"type": "Radar",
+		"mass": 486.72,
+		"volume": 96.56,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced LED": 6,
+			"Exotic Magnet": 5,
+			"Exotic Antenna S": 1,
+			"Exotic Standard Frame S": 1
+		}
+	},
+	"Exotic Protected Space Radar S": {
+		"tier": 5,
+		"type": "Radar",
+		"mass": 486.72,
+		"volume": 96.56,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced LED": 6,
+			"Exotic Magnet": 5,
+			"Exotic Antenna S": 1,
+			"Exotic Standard Frame S": 1
+		}
+	},
+	"Exotic Quick-Wired Space Radar S": {
+		"tier": 5,
+		"type": "Radar",
+		"mass": 486.72,
+		"volume": 96.56,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced LED": 6,
+			"Exotic Magnet": 5,
+			"Exotic Antenna S": 1,
+			"Exotic Standard Frame S": 1
+		}
+	},
 	"Space Radar M": {
-		"tier": 1,
+		"tier": 2,
 		"type": "Radar",
 		"mass": 2350,
 		"volume": 486.36,
@@ -9196,13 +14141,187 @@
 			"Uncommon Standard Frame M": 1
 		}
 	},
+	"Advanced Phased-Array Space Radar M": {
+		"tier": 3,
+		"type": "Radar",
+		"mass": 2350,
+		"volume": 486.36,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon LED": 36,
+			"Advanced Magnet": 25,
+			"Advanced Antenna M": 1,
+			"Advanced Standard Frame M": 1
+		}
+	},
+	"Advanced Protected Space Radar M": {
+		"tier": 3,
+		"type": "Radar",
+		"mass": 2350,
+		"volume": 486.36,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon LED": 36,
+			"Advanced Magnet": 25,
+			"Advanced Antenna M": 1,
+			"Advanced Standard Frame M": 1
+		}
+	},
+	"Advanced Quick-Wired Space Radar M": {
+		"tier": 3,
+		"type": "Radar",
+		"mass": 2350,
+		"volume": 486.36,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon LED": 36,
+			"Advanced Magnet": 25,
+			"Advanced Antenna M": 1,
+			"Advanced Standard Frame M": 1
+		}
+	},
+	"Rare Phased-Array Space Radar M": {
+		"tier": 4,
+		"type": "Radar",
+		"mass": 2350,
+		"volume": 486.36,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon LED": 18,
+			"Advanced LED": 18,
+			"Rare Magnet": 25,
+			"Rare Antenna M": 1,
+			"Rare Standard Frame M": 1
+		}
+	},
+	"Rare Protected Space Radar M": {
+		"tier": 4,
+		"type": "Radar",
+		"mass": 2350,
+		"volume": 486.36,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon LED": 18,
+			"Advanced LED": 18,
+			"Rare Magnet": 25,
+			"Rare Antenna M": 1,
+			"Rare Standard Frame M": 1
+		}
+	},
+	"Rare Quick-Wired Space Radar M": {
+		"tier": 4,
+		"type": "Radar",
+		"mass": 2350,
+		"volume": 486.36,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon LED": 18,
+			"Advanced LED": 18,
+			"Rare Magnet": 25,
+			"Rare Antenna M": 1,
+			"Rare Standard Frame M": 1
+		}
+	},
+	"Exotic Phased-Array Space Radar M": {
+		"tier": 5,
+		"type": "Radar",
+		"mass": 2350,
+		"volume": 486.36,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced LED": 36,
+			"Exotic Magnet": 25,
+			"Exotic Antenna M": 1,
+			"Exotic Standard Frame M": 1
+		}
+	},
+	"Exotic Protected Space Radar M": {
+		"tier": 5,
+		"type": "Radar",
+		"mass": 2350,
+		"volume": 486.36,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced LED": 36,
+			"Exotic Magnet": 25,
+			"Exotic Antenna M": 1,
+			"Exotic Standard Frame M": 1
+		}
+	},
+	"Exotic Quick-Wired Space Radar M": {
+		"tier": 5,
+		"type": "Radar",
+		"mass": 2350,
+		"volume": 486.36,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced LED": 36,
+			"Exotic Magnet": 25,
+			"Exotic Antenna M": 1,
+			"Exotic Standard Frame M": 1
+		}
+	},
 	"Space Radar L": {
-		"tier": 1,
+		"tier": 2,
 		"type": "Radar",
 		"mass": 12490,
 		"volume": 2658.56,
 		"outputQuantity": 1,
-		"time": 5760,
+		"time": 23040,
 		"skill": "Combat",
 		"byproducts": {},
 		"industries": [
@@ -9214,6 +14333,200 @@
 			"Uncommon Processor": 125,
 			"Uncommon Antenna L": 1,
 			"Uncommon Standard Frame L": 1
+		}
+	},
+	"Advanced Phased-Array Space Radar L": {
+		"tier": 3,
+		"type": "Radar",
+		"mass": 12490,
+		"volume": 2658.56,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon LED": 216,
+			"Advanced Magnet": 125,
+			"Advanced Antenna L": 1,
+			"Advanced Standard Frame L": 1
+		}
+	},
+	"Advanced Protected Space Radar L": {
+		"tier": 3,
+		"type": "Radar",
+		"mass": 12490,
+		"volume": 2658.56,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon LED": 216,
+			"Advanced Magnet": 125,
+			"Advanced Antenna L": 1,
+			"Advanced Standard Frame L": 1
+		}
+	},
+	"Advanced Quick-Wired Space Radar L": {
+		"tier": 3,
+		"type": "Radar",
+		"mass": 12490,
+		"volume": 2658.56,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon LED": 216,
+			"Advanced Magnet": 125,
+			"Advanced Antenna L": 1,
+			"Advanced Standard Frame L": 1
+		}
+	},
+	"Rare Phased-Array Space Radar L": {
+		"tier": 4,
+		"type": "Radar",
+		"mass": 12490,
+		"volume": 2658.56,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon LED": 108,
+			"Advanced LED": 108,
+			"Rare Magnet": 125,
+			"Rare Antenna L": 1,
+			"Rare Standard Frame L": 1
+		}
+	},
+	"Rare Protected Space Radar L": {
+		"tier": 4,
+		"type": "Radar",
+		"mass": 12490,
+		"volume": 2658.56,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon LED": 108,
+			"Advanced LED": 108,
+			"Rare Magnet": 125,
+			"Rare Antenna L": 1,
+			"Rare Standard Frame L": 1
+		}
+	},
+	"Rare Quick-Wired Space Radar L": {
+		"tier": 4,
+		"type": "Radar",
+		"mass": 12490,
+		"volume": 2658.56,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon LED": 108,
+			"Advanced LED": 108,
+			"Rare Magnet": 125,
+			"Rare Antenna L": 1,
+			"Rare Standard Frame L": 1
+		}
+	},
+	"Exotic Phased-Array Space Radar L": {
+		"tier": 5,
+		"type": "Radar",
+		"mass": 12490,
+		"volume": 2658.56,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced LED": 216,
+			"Exotic Magnet": 125,
+			"Exotic Antenna L": 1,
+			"Exotic Standard Frame L": 1
+		}
+	},
+	"Exotic Protected Space Radar L": {
+		"tier": 5,
+		"type": "Radar",
+		"mass": 12490,
+		"volume": 2658.56,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced LED": 216,
+			"Exotic Magnet": 125,
+			"Exotic Antenna L": 1,
+			"Exotic Standard Frame L": 1
+		}
+	},
+	"Exotic Quick-Wired Space Radar L": {
+		"tier": 5,
+		"type": "Radar",
+		"mass": 12490,
+		"volume": 2658.56,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced LED": 216,
+			"Exotic Magnet": 125,
+			"Exotic Antenna L": 1,
+			"Exotic Standard Frame L": 1
+		}
+	},
+	"Info Button S": {
+		"tier": 1,
+		"type": "Info Button",
+		"mass": 28,
+		"volume": 27,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic LED": 1,
+			"Uncommon LED": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Antenna XS": 1,
+			"Uncommon Casing XS": 1
 		}
 	},
 	"Screen XS": {
@@ -9282,7 +14595,7 @@
 		"mass": 12810,
 		"volume": 11170,
 		"outputQuantity": 1,
-		"time": 93600,
+		"time": 92160,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -9456,7 +14769,7 @@
 			"Uncommon Casing XS": 1
 		}
 	},
-	"Sign Vertical XS": {
+	"Vertical Sign XS": {
 		"tier": 2,
 		"type": "Screen/Sign",
 		"mass": 18.67,
@@ -9476,7 +14789,7 @@
 			"Uncommon Casing XS": 1
 		}
 	},
-	"Sign Vertical M": {
+	"Vertical Sign M": {
 		"tier": 2,
 		"type": "Screen/Sign",
 		"mass": 18.67,
@@ -9496,7 +14809,7 @@
 			"Uncommon Casing XS": 1
 		}
 	},
-	"Sign Vertical L": {
+	"Vertical Sign L": {
 		"tier": 2,
 		"type": "Screen/Sign",
 		"mass": 18.67,
@@ -9513,27 +14826,6 @@
 			"Uncommon Component": 1,
 			"Uncommon Electronics": 1,
 			"Uncommon Screen XS": 1,
-			"Uncommon Casing XS": 1
-		}
-	},
-	"Sensors S": {
-		"tier": 1,
-		"type": "Surrogate Element",
-		"mass": 28,
-		"volume": 27,
-		"outputQuantity": 1,
-		"time": 360,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Nanopack",
-			"Assembly Line XS"
-		],
-		"input": {
-			"Basic LED": 1,
-			"Uncommon LED": 1,
-			"Uncommon Electronics": 1,
-			"Uncommon Antenna XS": 1,
 			"Uncommon Casing XS": 1
 		}
 	},
@@ -9580,7 +14872,7 @@
 		"mass": 2.52,
 		"volume": 2,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -9669,7 +14961,7 @@
 		"mass": 9.93,
 		"volume": 5,
 		"outputQuantity": 1,
-		"time": 120,
+		"time": 90,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -9681,13 +14973,13 @@
 			"Uncommon Electronics": 1
 		}
 	},
-	"Infra-Red Laser Receiver": {
+	"Infrared Laser Receiver": {
 		"tier": 2,
 		"type": "Sensor",
 		"mass": 9.93,
 		"volume": 5,
 		"outputQuantity": 1,
-		"time": 120,
+		"time": 90,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -9705,7 +14997,7 @@
 		"mass": 7.79,
 		"volume": 4.5,
 		"outputQuantity": 1,
-		"time": 300,
+		"time": 270,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -9722,7 +15014,7 @@
 		"mass": 7.79,
 		"volume": 4.5,
 		"outputQuantity": 1,
-		"time": 300,
+		"time": 270,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -9739,7 +15031,7 @@
 		"mass": 7.79,
 		"volume": 4.5,
 		"outputQuantity": 1,
-		"time": 300,
+		"time": 270,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -9756,7 +15048,7 @@
 		"mass": 7.79,
 		"volume": 4.5,
 		"outputQuantity": 1,
-		"time": 300,
+		"time": 270,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -9773,7 +15065,7 @@
 		"mass": 24.68,
 		"volume": 3.8,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -9792,7 +15084,7 @@
 		"mass": 130.06,
 		"volume": 24,
 		"outputQuantity": 1,
-		"time": 600,
+		"time": 300,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -9847,7 +15139,7 @@
 		"mass": 14.65,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -9866,7 +15158,7 @@
 		"mass": 14.65,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -9885,7 +15177,7 @@
 		"mass": 14.65,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -9904,7 +15196,7 @@
 		"mass": 6.72,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -9923,7 +15215,7 @@
 		"mass": 25.62,
 		"volume": 13,
 		"outputQuantity": 1,
-		"time": 120,
+		"time": 90,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -9942,7 +15234,7 @@
 		"mass": 8.32,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -9961,7 +15253,7 @@
 		"mass": 6.72,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -9980,7 +15272,7 @@
 		"mass": 6.72,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -9993,13 +15285,13 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Cable Model-A S": {
+	"Cable Model A S": {
 		"tier": 1,
 		"type": "Cable",
 		"mass": 14.1,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10012,13 +15304,13 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Cable Model-B S": {
+	"Cable Model B S": {
 		"tier": 1,
 		"type": "Cable",
 		"mass": 14.1,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10031,13 +15323,13 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Cable Model-C S": {
+	"Cable Model C S": {
 		"tier": 1,
 		"type": "Cable",
 		"mass": 14.1,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10050,13 +15342,13 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Cable Model-A M": {
+	"Cable Model A M": {
 		"tier": 1,
 		"type": "Cable",
 		"mass": 14.1,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10069,13 +15361,13 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Cable Model-B M": {
+	"Cable Model B M": {
 		"tier": 1,
 		"type": "Cable",
 		"mass": 14.1,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10088,13 +15380,13 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Cable Model-C M": {
+	"Cable Model C M": {
 		"tier": 1,
 		"type": "Cable",
 		"mass": 14.1,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10107,13 +15399,13 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Corner Cable Model-A": {
+	"Corner Cable Model A": {
 		"tier": 1,
 		"type": "Cable",
 		"mass": 14.1,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10126,13 +15418,13 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Corner Cable Model-B": {
+	"Corner Cable Model B": {
 		"tier": 1,
 		"type": "Cable",
 		"mass": 14.1,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10145,13 +15437,13 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Corner Cable Model-C": {
+	"Corner Cable Model C": {
 		"tier": 1,
 		"type": "Cable",
 		"mass": 14.1,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10170,7 +15462,7 @@
 		"mass": 8.32,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10189,7 +15481,7 @@
 		"mass": 22.33,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10208,7 +15500,7 @@
 		"mass": 5.92,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10283,7 +15575,7 @@
 		"mass": 6.72,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10321,7 +15613,26 @@
 		"mass": 6.72,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Polycarbonate Plastic": 1,
+			"Basic Fixation": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Trash Can": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 6.72,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10359,7 +15670,7 @@
 		"mass": 2.52,
 		"volume": 2,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10377,7 +15688,7 @@
 		"mass": 5.54,
 		"volume": 5,
 		"outputQuantity": 1,
-		"time": 2040,
+		"time": 2025,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10396,7 +15707,7 @@
 		"mass": 5.54,
 		"volume": 5,
 		"outputQuantity": 1,
-		"time": 2040,
+		"time": 2025,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10415,7 +15726,7 @@
 		"mass": 5.54,
 		"volume": 5,
 		"outputQuantity": 1,
-		"time": 2040,
+		"time": 2025,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10434,7 +15745,7 @@
 		"mass": 1.72,
 		"volume": 2,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10452,7 +15763,7 @@
 		"mass": 2.78,
 		"volume": 2,
 		"outputQuantity": 1,
-		"time": 6060,
+		"time": 6075,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10469,7 +15780,7 @@
 		"mass": 2.52,
 		"volume": 2,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10544,7 +15855,7 @@
 		"mass": 8.32,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10563,7 +15874,7 @@
 		"mass": 8.32,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10582,7 +15893,7 @@
 		"mass": 8.32,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10615,12 +15926,12 @@
 		}
 	},
 	"Spaceship Hologram S": {
-		"tier": 2,
+		"tier": 1,
 		"type": "Hologram",
 		"mass": 112.72,
 		"volume": 9,
 		"outputQuantity": 1,
-		"time": 120,
+		"time": 90,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10639,7 +15950,7 @@
 		"mass": 15.98,
 		"volume": 13,
 		"outputQuantity": 1,
-		"time": 300,
+		"time": 270,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10653,12 +15964,12 @@
 		}
 	},
 	"Spaceship Hologram L": {
-		"tier": 2,
+		"tier": 3,
 		"type": "Hologram",
 		"mass": 14.02,
 		"volume": 12.5,
 		"outputQuantity": 1,
-		"time": 840,
+		"time": 810,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10666,8 +15977,8 @@
 		],
 		"input": {
 			"Uncommon Component": 1,
-			"Uncommon Optics": 1,
-			"Uncommon Casing XS": 1
+			"Advanced Optics": 1,
+			"Advanced Casing XS": 1
 		}
 	},
 	"Planet Hologram": {
@@ -10676,7 +15987,7 @@
 		"mass": 13.39,
 		"volume": 12.5,
 		"outputQuantity": 1,
-		"time": 120,
+		"time": 90,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10708,42 +16019,232 @@
 			"Basic Casing S": 1
 		}
 	},
-	"Steel Column": {
+	"Canopy Metal Corner S": {
 		"tier": 1,
 		"type": "Hull",
-		"mass": 13.37,
-		"volume": 4,
+		"mass": 136.61,
+		"volume": 24,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 900,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
-			"Nanopack",
-			"Assembly Line XS"
+			"Assembly Line S"
 		],
 		"input": {
-			"Steel": 1,
-			"Basic Fixation": 1,
-			"Basic Standard Frame XS": 1
+			"Duralumin": 7,
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Reinforced Frame S": 1
 		}
 	},
-	"Steel Panel": {
+	"Canopy Metal Corner M": {
 		"tier": 1,
 		"type": "Hull",
-		"mass": 13.37,
-		"volume": 4,
+		"mass": 889.1,
+		"volume": 159,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 3600,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
-			"Nanopack",
-			"Assembly Line XS"
+			"Assembly Line M"
 		],
 		"input": {
-			"Steel": 1,
-			"Basic Fixation": 1,
-			"Basic Standard Frame XS": 1
+			"Duralumin": 49,
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Canopy Metal Corner L": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 5920,
+		"volume": 1074,
+		"outputQuantity": 1,
+		"time": 14400,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Duralumin": 343,
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Canopy Metal Flat S": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 136.61,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 900,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Duralumin": 7,
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Canopy Metal Flat M": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 889.1,
+		"volume": 159,
+		"outputQuantity": 1,
+		"time": 3600,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Duralumin": 49,
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Canopy Metal Flat L": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 5920,
+		"volume": 1074,
+		"outputQuantity": 1,
+		"time": 14400,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Duralumin": 343,
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Canopy Metal Tilted S": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 136.61,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 900,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Duralumin": 7,
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Canopy Metal Tilted M": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 889.1,
+		"volume": 159,
+		"outputQuantity": 1,
+		"time": 3600,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Duralumin": 49,
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Canopy Metal Tilted L": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 5920,
+		"volume": 1074,
+		"outputQuantity": 1,
+		"time": 14400,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Duralumin": 343,
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Canopy Metal Triangle S": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 136.61,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 900,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Duralumin": 7,
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Canopy Metal Triangle M": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 889.1,
+		"volume": 159,
+		"outputQuantity": 1,
+		"time": 3600,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Duralumin": 49,
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Canopy Metal Triangle L": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 5920,
+		"volume": 1074,
+		"outputQuantity": 1,
+		"time": 14400,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Duralumin": 343,
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Reinforced Frame L": 1
 		}
 	},
 	"Hull Decorative Element A": {
@@ -10752,7 +16253,7 @@
 		"mass": 14.65,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10771,7 +16272,7 @@
 		"mass": 14.65,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10790,7 +16291,7 @@
 		"mass": 14.65,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10800,6 +16301,44 @@
 		"input": {
 			"Steel": 1,
 			"Basic Pipe": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Steel Column": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 13.37,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 75,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Steel": 1,
+			"Basic Fixation": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Steel Panel": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 13.37,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 75,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Steel": 1,
+			"Basic Fixation": 1,
 			"Basic Standard Frame XS": 1
 		}
 	},
@@ -10936,7 +16475,7 @@
 		"mass": 3.52,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10974,7 +16513,7 @@
 		"mass": 3.52,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -10993,7 +16532,7 @@
 		"mass": 3.52,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11012,7 +16551,7 @@
 		"mass": 3.52,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11031,7 +16570,7 @@
 		"mass": 3.52,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11050,7 +16589,7 @@
 		"mass": 3.52,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11069,7 +16608,7 @@
 		"mass": 3.52,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11088,7 +16627,7 @@
 		"mass": 3.52,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11107,7 +16646,7 @@
 		"mass": 3.52,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11126,7 +16665,7 @@
 		"mass": 902.04,
 		"volume": 180.6,
 		"outputQuantity": 1,
-		"time": 50400,
+		"time": 48600,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11336,7 +16875,7 @@
 		"mass": 94.64,
 		"volume": 48,
 		"outputQuantity": 1,
-		"time": 300,
+		"time": 600,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11355,7 +16894,7 @@
 		"mass": 189.28,
 		"volume": 96,
 		"outputQuantity": 1,
-		"time": 300,
+		"time": 1200,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11374,7 +16913,7 @@
 		"mass": 378.56,
 		"volume": 192,
 		"outputQuantity": 1,
-		"time": 300,
+		"time": 2400,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11412,7 +16951,7 @@
 		"mass": 94.32,
 		"volume": 48,
 		"outputQuantity": 1,
-		"time": 900,
+		"time": 1800,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11431,7 +16970,7 @@
 		"mass": 188.64,
 		"volume": 96,
 		"outputQuantity": 1,
-		"time": 900,
+		"time": 3600,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11450,7 +16989,7 @@
 		"mass": 377.28,
 		"volume": 192,
 		"outputQuantity": 1,
-		"time": 900,
+		"time": 7200,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11469,7 +17008,7 @@
 		"mass": 5.02,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11488,7 +17027,7 @@
 		"mass": 20.08,
 		"volume": 16,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 300,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11526,7 +17065,7 @@
 		"mass": 5090,
 		"volume": 2544,
 		"outputQuantity": 1,
-		"time": 1200,
+		"time": 19200,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11538,13 +17077,241 @@
 			"Basic Standard Frame M": 16
 		}
 	},
+	"Canopy Windshield Corner S": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 2.5,
+		"volume": 3,
+		"outputQuantity": 1,
+		"time": 900,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Glass": 7,
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Canopy Windshield Corner M": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 10,
+		"volume": 12,
+		"outputQuantity": 1,
+		"time": 3600,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Glass": 49,
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Canopy Windshield Corner L": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 40,
+		"volume": 48,
+		"outputQuantity": 1,
+		"time": 14400,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Glass": 343,
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Canopy Windshield Flat S": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 2.5,
+		"volume": 3,
+		"outputQuantity": 1,
+		"time": 900,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Glass": 7,
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Canopy Windshield Flat M": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 10,
+		"volume": 12,
+		"outputQuantity": 1,
+		"time": 3600,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Glass": 49,
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Canopy Windshield Flat L": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 40,
+		"volume": 48,
+		"outputQuantity": 1,
+		"time": 14400,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Glass": 343,
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Canopy Windshield Tilted S": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 2.5,
+		"volume": 3,
+		"outputQuantity": 1,
+		"time": 900,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Glass": 7,
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Canopy Windshield Tilted M": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 10,
+		"volume": 12,
+		"outputQuantity": 1,
+		"time": 3600,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Glass": 49,
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Canopy Windshield Tilted L": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 40,
+		"volume": 48,
+		"outputQuantity": 1,
+		"time": 14400,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Glass": 343,
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Canopy Windshield Triangle S": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 2.5,
+		"volume": 3,
+		"outputQuantity": 1,
+		"time": 900,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Glass": 7,
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Canopy Windshield Triangle M": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 10,
+		"volume": 12,
+		"outputQuantity": 1,
+		"time": 3600,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Glass": 49,
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Canopy Windshield Triangle L": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 40,
+		"volume": 48,
+		"outputQuantity": 1,
+		"time": 14400,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Glass": 343,
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
 	"Vertical Wing": {
 		"tier": 1,
 		"type": "Winglets",
 		"mass": 20.3,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11557,13 +17324,13 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Wing Tip S": {
+	"Wingtip S": {
 		"tier": 1,
 		"type": "Winglets",
 		"mass": 20.3,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11576,13 +17343,13 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Wing Tip M": {
+	"Wingtip M": {
 		"tier": 1,
 		"type": "Winglets",
 		"mass": 20.3,
 		"volume": 4,
 		"outputQuantity": 1,
-		"time": 60,
+		"time": 75,
 		"skill": "Furniture/Appliance",
 		"byproducts": {},
 		"industries": [
@@ -11595,7 +17362,7 @@
 			"Basic Standard Frame XS": 1
 		}
 	},
-	"Wing Tip L": {
+	"Wingtip L": {
 		"tier": 1,
 		"type": "Winglets",
 		"mass": 127.75,
@@ -11619,8 +17386,8 @@
 		"type": "Scrap",
 		"mass": 2.7,
 		"volume": 1,
-		"outputQuantity": 50,
-		"time": 3,
+		"outputQuantity": 3000,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -11628,7 +17395,7 @@
 			"Recycler M"
 		],
 		"input": {
-			"Aluminium Pure": 50
+			"Pure Aluminium": 3000
 		}
 	},
 	"Carbon Scrap": {
@@ -11636,7 +17403,7 @@
 		"type": "Scrap",
 		"mass": 2.27,
 		"volume": 1,
-		"outputQuantity": 50,
+		"outputQuantity": 3000,
 		"time": 3,
 		"skill": "Systems",
 		"byproducts": {},
@@ -11645,7 +17412,7 @@
 			"Recycler M"
 		],
 		"input": {
-			"Carbon Pure": 50
+			"Pure Carbon": 3000
 		}
 	},
 	"Silicon Scrap": {
@@ -11653,7 +17420,7 @@
 		"type": "Scrap",
 		"mass": 2.33,
 		"volume": 1,
-		"outputQuantity": 50,
+		"outputQuantity": 3000,
 		"time": 3,
 		"skill": "Systems",
 		"byproducts": {},
@@ -11662,7 +17429,7 @@
 			"Recycler M"
 		],
 		"input": {
-			"Silicon Pure": 50
+			"Pure Silicon": 3000
 		}
 	},
 	"Iron Scrap": {
@@ -11670,7 +17437,7 @@
 		"type": "Scrap",
 		"mass": 7.85,
 		"volume": 1,
-		"outputQuantity": 50,
+		"outputQuantity": 3000,
 		"time": 3,
 		"skill": "Systems",
 		"byproducts": {},
@@ -11679,7 +17446,7 @@
 			"Recycler M"
 		],
 		"input": {
-			"Iron Pure": 50
+			"Pure Iron": 3000
 		}
 	},
 	"Calcium Scrap": {
@@ -11687,7 +17454,7 @@
 		"type": "Scrap",
 		"mass": 1.55,
 		"volume": 1,
-		"outputQuantity": 50,
+		"outputQuantity": 750,
 		"time": 12,
 		"skill": "Systems",
 		"byproducts": {},
@@ -11695,7 +17462,7 @@
 			"Recycler M"
 		],
 		"input": {
-			"Calcium Pure": 50
+			"Pure Calcium": 750
 		}
 	},
 	"Chromium Scrap": {
@@ -11703,7 +17470,7 @@
 		"type": "Scrap",
 		"mass": 7.19,
 		"volume": 1,
-		"outputQuantity": 50,
+		"outputQuantity": 750,
 		"time": 12,
 		"skill": "Systems",
 		"byproducts": {},
@@ -11711,7 +17478,7 @@
 			"Recycler M"
 		],
 		"input": {
-			"Chromium Pure": 50
+			"Pure Chromium": 750
 		}
 	},
 	"Copper Scrap": {
@@ -11719,7 +17486,7 @@
 		"type": "Scrap",
 		"mass": 8.96,
 		"volume": 1,
-		"outputQuantity": 50,
+		"outputQuantity": 750,
 		"time": 12,
 		"skill": "Systems",
 		"byproducts": {},
@@ -11727,7 +17494,7 @@
 			"Recycler M"
 		],
 		"input": {
-			"Copper Pure": 50
+			"Pure Copper": 750
 		}
 	},
 	"Sodium Scrap": {
@@ -11735,7 +17502,7 @@
 		"type": "Scrap",
 		"mass": 0.97,
 		"volume": 1,
-		"outputQuantity": 50,
+		"outputQuantity": 750,
 		"time": 12,
 		"skill": "Systems",
 		"byproducts": {},
@@ -11743,7 +17510,7 @@
 			"Recycler M"
 		],
 		"input": {
-			"Sodium Pure": 50
+			"Pure Sodium": 750
 		}
 	},
 	"Lithium Scrap": {
@@ -11751,15 +17518,15 @@
 		"type": "Scrap",
 		"mass": 0.53,
 		"volume": 1,
-		"outputQuantity": 50,
-		"time": 48,
+		"outputQuantity": 150,
+		"time": 144,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Recycler M"
 		],
 		"input": {
-			"Lithium Pure": 50
+			"Pure Lithium": 150
 		}
 	},
 	"Nickel Scrap": {
@@ -11767,15 +17534,15 @@
 		"type": "Scrap",
 		"mass": 8.91,
 		"volume": 1,
-		"outputQuantity": 50,
-		"time": 48,
+		"outputQuantity": 150,
+		"time": 144,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Recycler M"
 		],
 		"input": {
-			"Nickel Pure": 50
+			"Pure Nickel": 150
 		}
 	},
 	"Silver Scrap": {
@@ -11783,15 +17550,15 @@
 		"type": "Scrap",
 		"mass": 10.49,
 		"volume": 1,
-		"outputQuantity": 50,
-		"time": 48,
+		"outputQuantity": 150,
+		"time": 144,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Recycler M"
 		],
 		"input": {
-			"Silver Pure": 50
+			"Pure Silver": 150
 		}
 	},
 	"Sulfur Scrap": {
@@ -11799,15 +17566,15 @@
 		"type": "Scrap",
 		"mass": 1.82,
 		"volume": 1,
-		"outputQuantity": 50,
-		"time": 48,
+		"outputQuantity": 150,
+		"time": 144,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Recycler M"
 		],
 		"input": {
-			"Sulfur Pure": 50
+			"Pure Sulfur": 150
 		}
 	},
 	"Cobalt Scrap": {
@@ -11816,14 +17583,14 @@
 		"mass": 8.9,
 		"volume": 1,
 		"outputQuantity": 50,
-		"time": 180,
+		"time": 192,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Recycler M"
 		],
 		"input": {
-			"Cobalt Pure": 50
+			"Pure Cobalt": 50
 		}
 	},
 	"Fluorine Scrap": {
@@ -11832,14 +17599,14 @@
 		"mass": 1.7,
 		"volume": 1,
 		"outputQuantity": 50,
-		"time": 180,
+		"time": 192,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Recycler M"
 		],
 		"input": {
-			"Fluorine Pure": 50
+			"Pure Fluorine": 50
 		}
 	},
 	"Gold Scrap": {
@@ -11848,14 +17615,14 @@
 		"mass": 19.3,
 		"volume": 1,
 		"outputQuantity": 50,
-		"time": 180,
+		"time": 192,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Recycler M"
 		],
 		"input": {
-			"Gold Pure": 50
+			"Pure Gold": 50
 		}
 	},
 	"Scandium Scrap": {
@@ -11864,14 +17631,78 @@
 		"mass": 2.98,
 		"volume": 1,
 		"outputQuantity": 50,
-		"time": 180,
+		"time": 192,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Recycler M"
 		],
 		"input": {
-			"Scandium Pure": 50
+			"Pure Scandium": 50
+		}
+	},
+	"Manganese Scrap": {
+		"tier": 5,
+		"type": "Scrap",
+		"mass": 3.76,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 768,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Pure Manganese": 50
+		}
+	},
+	"Niobium Scrap": {
+		"tier": 5,
+		"type": "Scrap",
+		"mass": 5.38,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 768,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Pure Niobium": 50
+		}
+	},
+	"Titanium Scrap": {
+		"tier": 5,
+		"type": "Scrap",
+		"mass": 4.55,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 768,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Pure Titanium": 50
+		}
+	},
+	"Vanadium Scrap": {
+		"tier": 5,
+		"type": "Scrap",
+		"mass": 6.95,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 768,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Pure Vanadium": 50
 		}
 	},
 	"Iron Honeycomb": {
@@ -11879,8 +17710,8 @@
 		"type": "Pure Honeycomb",
 		"mass": 78.5,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 5,
+		"outputQuantity": 180,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -11888,16 +17719,16 @@
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Iron Pure": 100
+			"Pure Iron": 1800
 		}
 	},
 	"Aluminium Honeycomb": {
 		"tier": 1,
 		"type": "Pure Honeycomb",
 		"mass": 27,
-		"volume": 5,
-		"outputQuantity": 10,
-		"time": 5,
+		"volume": 10,
+		"outputQuantity": 180,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -11905,7 +17736,7 @@
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Aluminium Pure": 100
+			"Pure Aluminium": 1800
 		}
 	},
 	"Carbon Honeycomb": {
@@ -11913,8 +17744,8 @@
 		"type": "Pure Honeycomb",
 		"mass": 22.7,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 5,
+		"outputQuantity": 180,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -11922,7 +17753,7 @@
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Iron Pure": 100
+			"Pure Iron": 1800
 		}
 	},
 	"Silicon Honeycomb": {
@@ -11930,8 +17761,8 @@
 		"type": "Pure Honeycomb",
 		"mass": 23.3,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 5,
+		"outputQuantity": 180,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -11939,7 +17770,7 @@
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Silicon Pure": 100
+			"Pure Silicon": 1800
 		}
 	},
 	"Copper Honeycomb": {
@@ -11947,15 +17778,15 @@
 		"type": "Pure Honeycomb",
 		"mass": 89.6,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 15,
+		"outputQuantity": 60,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Copper Pure": 100
+			"Pure Copper": 600
 		}
 	},
 	"Chromium Honeycomb": {
@@ -11963,15 +17794,15 @@
 		"type": "Pure Honeycomb",
 		"mass": 71.9,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 15,
+		"outputQuantity": 60,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Chromium Pure": 100
+			"Pure Chromium": 600
 		}
 	},
 	"Calcium Honeycomb": {
@@ -11979,15 +17810,15 @@
 		"type": "Pure Honeycomb",
 		"mass": 15.5,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 15,
+		"outputQuantity": 60,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Calcium Pure": 100
+			"Pure Calcium": 600
 		}
 	},
 	"Sodium Honeycomb": {
@@ -11995,15 +17826,15 @@
 		"type": "Pure Honeycomb",
 		"mass": 9.7,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 15,
+		"outputQuantity": 60,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Sodium Pure": 100
+			"Pure Sodium": 600
 		}
 	},
 	"Lithium Honeycomb": {
@@ -12011,15 +17842,15 @@
 		"type": "Pure Honeycomb",
 		"mass": 5.3,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 45,
+		"outputQuantity": 20,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Lithium Pure": 100
+			"Pure Lithium": 200
 		}
 	},
 	"Nickel Honeycomb": {
@@ -12027,15 +17858,15 @@
 		"type": "Pure Honeycomb",
 		"mass": 89.1,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 45,
+		"outputQuantity": 20,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Nickel Pure": 100
+			"Pure Nickel": 200
 		}
 	},
 	"Silver Honeycomb": {
@@ -12043,15 +17874,15 @@
 		"type": "Pure Honeycomb",
 		"mass": 104.9,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 45,
+		"outputQuantity": 20,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Silver Pure": 100
+			"Pure Silver": 200
 		}
 	},
 	"Sulfur Honeycomb": {
@@ -12059,15 +17890,15 @@
 		"type": "Pure Honeycomb",
 		"mass": 18.19,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 45,
+		"outputQuantity": 20,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Sulfur Pure": 100
+			"Pure Sulfur": 200
 		}
 	},
 	"Gold Honeycomb": {
@@ -12076,14 +17907,14 @@
 		"mass": 193,
 		"volume": 10,
 		"outputQuantity": 10,
-		"time": 120,
+		"time": 270,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Gold Pure": 100
+			"Pure Gold": 100
 		}
 	},
 	"Cobalt Honeycomb": {
@@ -12092,14 +17923,14 @@
 		"mass": 89,
 		"volume": 10,
 		"outputQuantity": 10,
-		"time": 120,
+		"time": 270,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Cobalt Pure": 100
+			"Pure Cobalt": 100
 		}
 	},
 	"Fluorine Honeycomb": {
@@ -12108,14 +17939,14 @@
 		"mass": 16.96,
 		"volume": 10,
 		"outputQuantity": 10,
-		"time": 120,
+		"time": 270,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Fluorine Pure": 100
+			"Pure Fluorine": 100
 		}
 	},
 	"Scandium Honeycomb": {
@@ -12124,14 +17955,14 @@
 		"mass": 29.85,
 		"volume": 10,
 		"outputQuantity": 10,
-		"time": 120,
+		"time": 270,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Scandium Pure": 100
+			"Pure Scandium": 100
 		}
 	},
 	"Manganese Honeycomb": {
@@ -12140,14 +17971,14 @@
 		"mass": 72.1,
 		"volume": 10,
 		"outputQuantity": 10,
-		"time": 420,
+		"time": 810,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Manganese Pure": 100
+			"Pure Manganese": 100
 		}
 	},
 	"Niobium Honeycomb": {
@@ -12156,14 +17987,14 @@
 		"mass": 85.7,
 		"volume": 10,
 		"outputQuantity": 10,
-		"time": 420,
+		"time": 810,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Niobium Pure": 100
+			"Pure Niobium": 100
 		}
 	},
 	"Titanium Honeycomb": {
@@ -12172,14 +18003,14 @@
 		"mass": 45.1,
 		"volume": 10,
 		"outputQuantity": 10,
-		"time": 420,
+		"time": 810,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Titanium Pure": 100
+			"Pure Titanium": 100
 		}
 	},
 	"Vanadium Honeycomb": {
@@ -12188,14 +18019,14 @@
 		"mass": 60,
 		"volume": 10,
 		"outputQuantity": 10,
-		"time": 420,
+		"time": 810,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Vanadium Pure": 100
+			"Pure Vanadium": 100
 		}
 	},
 	"Plastic Honeycomb": {
@@ -12203,8 +18034,8 @@
 		"type": "Product Honeycomb",
 		"mass": 27.57,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 20,
+		"outputQuantity": 180,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12212,7 +18043,7 @@
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Polycarbonate Plastic": 100
+			"Polycarbonate Plastic": 1800
 		}
 	},
 	"Wood Honeycomb": {
@@ -12220,8 +18051,8 @@
 		"type": "Product Honeycomb",
 		"mass": 27.19,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 10,
+		"outputQuantity": 180,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12229,7 +18060,7 @@
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Wood": 100
+			"Wood": 1800
 		}
 	},
 	"Concrete Honeycomb": {
@@ -12237,8 +18068,8 @@
 		"type": "Product Honeycomb",
 		"mass": 27.57,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 20,
+		"outputQuantity": 180,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12246,16 +18077,16 @@
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Concrete": 100
+			"Concrete": 1800
 		}
 	},
-	"Carbonfiber Honeycomb": {
-		"tier": 2,
+	"Carbon Fiber Honeycomb": {
+		"tier": 1,
 		"type": "Product Honeycomb",
 		"mass": 27.38,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 20,
+		"outputQuantity": 180,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12263,7 +18094,7 @@
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Carbon Fiber": 100
+			"Carbon Fiber": 1800
 		}
 	},
 	"Brick Honeycomb": {
@@ -12271,8 +18102,8 @@
 		"type": "Product Honeycomb",
 		"mass": 27.57,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 10,
+		"outputQuantity": 180,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12280,16 +18111,16 @@
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Brick": 100
+			"Brick": 1800
 		}
 	},
 	"Steel Honeycomb": {
-		"tier": 2,
+		"tier": 1,
 		"type": "Product Honeycomb",
 		"mass": 115.14,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 20,
+		"outputQuantity": 180,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12297,7 +18128,24 @@
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Steel": 100
+			"Steel": 1800
+		}
+	},
+	"Silumin Honeycomb": {
+		"tier": 1,
+		"type": "Product Honeycomb",
+		"mass": 30,
+		"volume": 10,
+		"outputQuantity": 180,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Silumin": 1800
 		}
 	},
 	"Marble Honeycomb": {
@@ -12305,15 +18153,47 @@
 		"type": "Product Honeycomb",
 		"mass": 129.4,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 30,
+		"outputQuantity": 60,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Honeycomb Refinery M"
 		],
 		"input": {
-			"Marble": 100
+			"Marble": 600
+		}
+	},
+	"Duralumin Honeycomb": {
+		"tier": 2,
+		"type": "Product Honeycomb",
+		"mass": 28,
+		"volume": 10,
+		"outputQuantity": 60,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Duralumin": 600
+		}
+	},
+	"Stainless Steel Honeycomb": {
+		"tier": 2,
+		"type": "Product Honeycomb",
+		"mass": 77.5,
+		"volume": 10,
+		"outputQuantity": 60,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Stainless Steel": 600
 		}
 	},
 	"Luminescent White Glass": {
@@ -12321,16 +18201,112 @@
 		"type": "Product Honeycomb",
 		"mass": 26,
 		"volume": 10,
-		"outputQuantity": 10,
-		"time": 15,
+		"outputQuantity": 60,
+		"time": 180,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Glass Furnace M"
 		],
 		"input": {
-			"Advanced Glass": 100,
-			"Uncommon LED": 10
+			"Advanced Glass": 600,
+			"Uncommon LED": 60
+		}
+	},
+	"Al-Li Honeycomb": {
+		"tier": 3,
+		"type": "Product Honeycomb",
+		"mass": 25,
+		"volume": 10,
+		"outputQuantity": 20,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Al-Li Alloy": 200
+		}
+	},
+	"Inconel Honeycomb": {
+		"tier": 3,
+		"type": "Product Honeycomb",
+		"mass": 84.97,
+		"volume": 10,
+		"outputQuantity": 20,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Inconel": 200
+		}
+	},
+	"Maraging Steel Honeycomb": {
+		"tier": 4,
+		"type": "Product Honeycomb",
+		"mass": 82.3,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 270,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Maraging Steel": 100
+		}
+	},
+	"Sc-Al Honeycomb": {
+		"tier": 4,
+		"type": "Product Honeycomb",
+		"mass": 28.5,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 270,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Sc-Al Alloy": 100
+		}
+	},
+	"Grade 5 Titanium Honeycomb": {
+		"tier": 5,
+		"type": "Product Honeycomb",
+		"mass": 44.3,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 810,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Grade 5 Titanium Alloy": 100
+		}
+	},
+	"Mangalloy Honeycomb": {
+		"tier": 5,
+		"type": "Product Honeycomb",
+		"mass": 78.33,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 810,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Mangalloy": 100
 		}
 	},
 	"Resurrection Node": {
@@ -12339,7 +18315,7 @@
 		"mass": 728.43,
 		"volume": 203.33,
 		"outputQuantity": 1,
-		"time": 5400,
+		"time": 1440,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12354,27 +18330,26 @@
 		}
 	},
 	"Virtual Scaffolding Projector": {
-		"tier": 4,
+		"tier": 1,
 		"type": "Virtual Projector",
 		"mass": 167.11,
 		"volume": 122.4,
 		"outputQuantity": 1,
-		"time": 14400,
+		"time": 480,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line S"
 		],
 		"input": {
-			"Uncommon Component": 3,
-			"Advanced Component": 3,
-			"Rare Optics": 5,
-			"Rare Laser Chamber S": 1,
-			"Rare Casing S": 1
+			"Basic Component": 6,
+			"Basic Optics": 5,
+			"Basic Laser Chamber S": 1,
+			"Basic Casing S": 1
 		}
 	},
 	"Cannon XS": {
-		"tier": 1,
+		"tier": 3,
 		"type": "Cannon",
 		"mass": 190.1,
 		"volume": 34.2,
@@ -12392,8 +18367,240 @@
 			"Advanced Reinforced Frame XS": 1
 		}
 	},
+	"Advanced Agile Cannon XS": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 190.1,
+		"volume": 34.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Electronics": 1,
+			"Advanced Firing System XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Defense Cannon XS": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 190.1,
+		"volume": 34.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Electronics": 1,
+			"Advanced Firing System XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Heavy Cannon XS": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 190.1,
+		"volume": 34.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Electronics": 1,
+			"Advanced Firing System XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Precision Cannon XS": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 190.1,
+		"volume": 34.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Electronics": 1,
+			"Advanced Firing System XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Rare Agile Cannon XS": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 190.1,
+		"volume": 34.2,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Electronics": 1,
+			"Rare Firing System XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Defense Cannon XS": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 190.1,
+		"volume": 34.2,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Electronics": 1,
+			"Rare Firing System XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Heavy Cannon XS": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 190.1,
+		"volume": 34.2,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Electronics": 1,
+			"Rare Firing System XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Precision Cannon XS": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 190.1,
+		"volume": 34.2,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Electronics": 1,
+			"Rare Firing System XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Agile Cannon XS": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 190.1,
+		"volume": 34.2,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Screw": 1,
+			"Exotic Electronics": 1,
+			"Exotic Firing System XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Defense Cannon XS": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 190.1,
+		"volume": 34.2,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Screw": 1,
+			"Exotic Electronics": 1,
+			"Exotic Firing System XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Heavy Cannon XS": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 190.1,
+		"volume": 34.2,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Screw": 1,
+			"Exotic Electronics": 1,
+			"Exotic Firing System XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Precision Cannon XS": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 190.1,
+		"volume": 34.2,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Screw": 1,
+			"Exotic Electronics": 1,
+			"Exotic Firing System XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
 	"Cannon S": {
-		"tier": 2,
+		"tier": 3,
 		"type": "Cannon",
 		"mass": 517.52,
 		"volume": 95.4,
@@ -12411,13 +18618,245 @@
 			"Advanced Reinforced Frame S": 1
 		}
 	},
+	"Advanced Agile Cannon S": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Electronics": 5,
+			"Advanced Firing System S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Defense Cannon S": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Electronics": 5,
+			"Advanced Firing System S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Heavy Cannon S": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Electronics": 5,
+			"Advanced Firing System S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Precision Cannon S": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Electronics": 5,
+			"Advanced Firing System S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Rare Agile Cannon S": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Electronics": 5,
+			"Rare Firing System S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Defense Cannon S": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Electronics": 5,
+			"Rare Firing System S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Heavy Cannon S": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Electronics": 5,
+			"Rare Firing System S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Precision Cannon S": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Electronics": 5,
+			"Rare Firing System S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Exotic Agile Cannon S": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Screw": 6,
+			"Exotic Electronics": 5,
+			"Exotic Firing System S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
+	"Exotic Defense Cannon S": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Screw": 6,
+			"Exotic Electronics": 5,
+			"Exotic Firing System S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
+	"Exotic Heavy Cannon S": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Screw": 6,
+			"Exotic Electronics": 5,
+			"Exotic Firing System S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
+	"Exotic Precision Cannon S": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Screw": 6,
+			"Exotic Electronics": 5,
+			"Exotic Firing System S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
 	"Cannon M": {
 		"tier": 3,
 		"type": "Cannon",
 		"mass": 2670,
 		"volume": 478,
 		"outputQuantity": 1,
-		"time": 18000,
+		"time": 17280,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12430,13 +18869,245 @@
 			"Advanced Reinforced Frame M": 1
 		}
 	},
-	"Cannon L": {
+	"Advanced Agile Cannon M": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 2670,
+		"volume": 478,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Electronics": 25,
+			"Advanced Firing System M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Defense Cannon M": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 2670,
+		"volume": 478,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Electronics": 25,
+			"Advanced Firing System M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Heavy Cannon M": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 2670,
+		"volume": 478,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Electronics": 25,
+			"Advanced Firing System M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Precision Cannon M": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 2670,
+		"volume": 478,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Electronics": 25,
+			"Advanced Firing System M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare Agile Cannon M": {
 		"tier": 4,
+		"type": "Cannon",
+		"mass": 2670,
+		"volume": 478,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Electronics": 25,
+			"Rare Firing System M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Defense Cannon M": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 2670,
+		"volume": 478,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Electronics": 25,
+			"Rare Firing System M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Heavy Cannon M": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 2670,
+		"volume": 478,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Electronics": 25,
+			"Rare Firing System M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Precision Cannon M": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 2670,
+		"volume": 478,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Electronics": 25,
+			"Rare Firing System M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Exotic Agile Cannon M": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 2670,
+		"volume": 478,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Screw": 36,
+			"Exotic Electronics": 25,
+			"Exotic Firing System M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Exotic Defense Cannon M": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 2670,
+		"volume": 478,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Screw": 36,
+			"Exotic Electronics": 25,
+			"Exotic Firing System M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Exotic Heavy Cannon M": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 2670,
+		"volume": 478,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Screw": 36,
+			"Exotic Electronics": 25,
+			"Exotic Firing System M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Exotic Precision Cannon M": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 2670,
+		"volume": 478,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Screw": 36,
+			"Exotic Electronics": 25,
+			"Exotic Firing System M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Cannon L": {
+		"tier": 3,
 		"type": "Cannon",
 		"mass": 15240,
 		"volume": 2614.2,
 		"outputQuantity": 1,
-		"time": 68400,
+		"time": 69120,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12449,8 +19120,240 @@
 			"Advanced Reinforced Frame L": 1
 		}
 	},
+	"Advanced Agile Cannon L": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 15240,
+		"volume": 2614.2,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Electronics": 125,
+			"Advanced Firing System L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Defense Cannon L": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 15240,
+		"volume": 2614.2,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Electronics": 125,
+			"Advanced Firing System L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Heavy Cannon L": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 15240,
+		"volume": 2614.2,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Electronics": 125,
+			"Advanced Firing System L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Precision Cannon L": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 15240,
+		"volume": 2614.2,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Electronics": 125,
+			"Advanced Firing System L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Rare Agile Cannon L": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 15240,
+		"volume": 2614.2,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Electronics": 125,
+			"Rare Firing System L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Defense Cannon L": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 15240,
+		"volume": 2614.2,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Electronics": 125,
+			"Rare Firing System L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Heavy Cannon L": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 15240,
+		"volume": 2614.2,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Electronics": 125,
+			"Rare Firing System L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Precision Cannon L": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 15240,
+		"volume": 2614.2,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Electronics": 125,
+			"Rare Firing System L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Exotic Agile Cannon L": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 15240,
+		"volume": 2614.2,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Screw": 216,
+			"Exotic Electronics": 125,
+			"Exotic Firing System L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
+	"Exotic Defense Cannon L": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 15240,
+		"volume": 2614.2,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Screw": 216,
+			"Exotic Electronics": 125,
+			"Exotic Firing System L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
+	"Exotic Heavy Cannon L": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 15240,
+		"volume": 2614.2,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Screw": 216,
+			"Exotic Electronics": 125,
+			"Exotic Firing System L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
+	"Exotic Precision Cannon L": {
+		"tier": 5,
+		"type": "Cannon",
+		"mass": 15240,
+		"volume": 2614.2,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Screw": 216,
+			"Exotic Electronics": 125,
+			"Exotic Firing System L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
 	"Laser XS": {
-		"tier": 1,
+		"tier": 3,
 		"type": "Laser",
 		"mass": 118.55,
 		"volume": 39.2,
@@ -12468,8 +19371,240 @@
 			"Advanced Reinforced Frame XS": 1
 		}
 	},
+	"Advanced Agile Laser XS": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Power System": 1,
+			"Advanced Laser Chamber XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Defense Laser XS": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Power System": 1,
+			"Advanced Laser Chamber XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Heavy Laser XS": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Power System": 1,
+			"Advanced Laser Chamber XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Precision Laser XS": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Power System": 1,
+			"Advanced Laser Chamber XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Rare Agile Laser XS": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Connector": 1,
+			"Rare Power System": 1,
+			"Rare Laser Chamber XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Defense Laser XS": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Connector": 1,
+			"Rare Power System": 1,
+			"Rare Laser Chamber XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Heavy Laser XS": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Connector": 1,
+			"Rare Power System": 1,
+			"Rare Laser Chamber XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Precision Laser XS": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Connector": 1,
+			"Rare Power System": 1,
+			"Rare Laser Chamber XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Agile Laser XS": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Connector": 1,
+			"Exotic Power System": 1,
+			"Exotic Laser Chamber XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Defense Laser XS": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Connector": 1,
+			"Exotic Power System": 1,
+			"Exotic Laser Chamber XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Heavy Laser XS": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Connector": 1,
+			"Exotic Power System": 1,
+			"Exotic Laser Chamber XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Precision Laser XS": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Connector": 1,
+			"Exotic Power System": 1,
+			"Exotic Laser Chamber XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
 	"Laser S": {
-		"tier": 2,
+		"tier": 3,
 		"type": "Laser",
 		"mass": 508.26,
 		"volume": 120.2,
@@ -12487,13 +19622,245 @@
 			"Advanced Reinforced Frame S": 1
 		}
 	},
+	"Advanced Agile Laser S": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 508.26,
+		"volume": 120.2,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 6,
+			"Advanced Power System": 5,
+			"Advanced Laser Chamber S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Defense Laser S": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 508.26,
+		"volume": 120.2,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 6,
+			"Advanced Power System": 5,
+			"Advanced Laser Chamber S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Heavy Laser S": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 508.26,
+		"volume": 120.2,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 6,
+			"Advanced Power System": 5,
+			"Advanced Laser Chamber S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Precision Laser S": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 508.26,
+		"volume": 120.2,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 6,
+			"Advanced Power System": 5,
+			"Advanced Laser Chamber S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Rare Agile Laser S": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 3,
+			"Advanced Connector": 3,
+			"Rare Power System": 5,
+			"Rare Laser Chamber S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Defense Laser S": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 3,
+			"Advanced Connector": 3,
+			"Rare Power System": 5,
+			"Rare Laser Chamber S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Heavy Laser S": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 3,
+			"Advanced Connector": 3,
+			"Rare Power System": 5,
+			"Rare Laser Chamber S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Precision Laser S": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 3,
+			"Advanced Connector": 3,
+			"Rare Power System": 5,
+			"Rare Laser Chamber S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Exotic Agile Laser S": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Connector": 6,
+			"Exotic Power System": 5,
+			"Exotic Laser Chamber S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
+	"Exotic Defense Laser S": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Connector": 6,
+			"Exotic Power System": 5,
+			"Exotic Laser Chamber S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
+	"Exotic Heavy Laser S": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Connector": 6,
+			"Exotic Power System": 5,
+			"Exotic Laser Chamber S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
+	"Exotic Precision Laser S": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Connector": 6,
+			"Exotic Power System": 5,
+			"Exotic Laser Chamber S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
 	"Laser M": {
 		"tier": 3,
 		"type": "Laser",
 		"mass": 2690,
 		"volume": 600.8,
 		"outputQuantity": 1,
-		"time": 18000,
+		"time": 17280,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12506,13 +19873,245 @@
 			"Advanced Reinforced Frame M": 1
 		}
 	},
-	"Laser L": {
+	"Advanced Agile Laser M": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 2690,
+		"volume": 600.8,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 36,
+			"Advanced Power System": 25,
+			"Advanced Laser Chamber M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Defense Laser M": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 2690,
+		"volume": 600.8,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 36,
+			"Advanced Power System": 25,
+			"Advanced Laser Chamber M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Heavy Laser M": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 2690,
+		"volume": 600.8,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 36,
+			"Advanced Power System": 25,
+			"Advanced Laser Chamber M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Precision Laser M": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 2690,
+		"volume": 600.8,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 36,
+			"Advanced Power System": 25,
+			"Advanced Laser Chamber M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare Agile Laser M": {
 		"tier": 4,
+		"type": "Laser",
+		"mass": 2690,
+		"volume": 600.8,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 18,
+			"Advanced Connector": 18,
+			"Rare Power System": 25,
+			"Rare Laser Chamber M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Defense Laser M": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 2690,
+		"volume": 600.8,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 18,
+			"Advanced Connector": 18,
+			"Rare Power System": 25,
+			"Rare Laser Chamber M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Heavy Laser M": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 2690,
+		"volume": 600.8,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 18,
+			"Advanced Connector": 18,
+			"Rare Power System": 25,
+			"Rare Laser Chamber M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Precision Laser M": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 2690,
+		"volume": 600.8,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 18,
+			"Advanced Connector": 18,
+			"Rare Power System": 25,
+			"Rare Laser Chamber M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Exotic Agile Laser M": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 2690,
+		"volume": 600.8,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Connector": 36,
+			"Exotic Power System": 25,
+			"Exotic Laser Chamber M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Exotic Defense Laser M": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 2690,
+		"volume": 600.8,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Connector": 36,
+			"Exotic Power System": 25,
+			"Exotic Laser Chamber M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Exotic Heavy Laser M": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 2690,
+		"volume": 600.8,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Connector": 36,
+			"Exotic Power System": 25,
+			"Exotic Laser Chamber M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Exotic Precision Laser M": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 2690,
+		"volume": 600.8,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Connector": 36,
+			"Exotic Power System": 25,
+			"Exotic Laser Chamber M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Laser L": {
+		"tier": 3,
 		"type": "Laser",
 		"mass": 14770,
 		"volume": 3221,
 		"outputQuantity": 1,
-		"time": 68400,
+		"time": 69120,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12525,8 +20124,240 @@
 			"Advanced Reinforced Frame L": 1
 		}
 	},
+	"Advanced Agile Laser L": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 14770,
+		"volume": 3221,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 216,
+			"Advanced Power System": 125,
+			"Advanced Laser Chamber L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Defense Laser L": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 14770,
+		"volume": 3221,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 216,
+			"Advanced Power System": 125,
+			"Advanced Laser Chamber L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Heavy Laser L": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 14770,
+		"volume": 3221,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 216,
+			"Advanced Power System": 125,
+			"Advanced Laser Chamber L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Precision Laser L": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 14770,
+		"volume": 3221,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 216,
+			"Advanced Power System": 125,
+			"Advanced Laser Chamber L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Rare Agile Laser L": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 14770,
+		"volume": 3221,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 108,
+			"Advanced Connector": 108,
+			"Rare Power System": 125,
+			"Rare Laser Chamber L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Defense Laser L": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 14770,
+		"volume": 3221,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 108,
+			"Advanced Connector": 108,
+			"Rare Power System": 125,
+			"Rare Laser Chamber L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Heavy Laser L": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 14770,
+		"volume": 3221,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 108,
+			"Advanced Connector": 108,
+			"Rare Power System": 125,
+			"Rare Laser Chamber L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Precision Laser L": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 14770,
+		"volume": 3221,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 108,
+			"Advanced Connector": 108,
+			"Rare Power System": 125,
+			"Rare Laser Chamber L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Exotic Agile Laser L": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 14770,
+		"volume": 3221,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Connector": 216,
+			"Exotic Power System": 125,
+			"Exotic Laser Chamber L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
+	"Exotic Defense Laser L": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 14770,
+		"volume": 3221,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Connector": 216,
+			"Exotic Power System": 125,
+			"Exotic Laser Chamber L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
+	"Exotic Heavy Laser L": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 14770,
+		"volume": 3221,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Connector": 216,
+			"Exotic Power System": 125,
+			"Exotic Laser Chamber L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
+	"Exotic Precision Laser L": {
+		"tier": 5,
+		"type": "Laser",
+		"mass": 14770,
+		"volume": 3221,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Connector": 216,
+			"Exotic Power System": 125,
+			"Exotic Laser Chamber L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
 	"Missile XS": {
-		"tier": 1,
+		"tier": 3,
 		"type": "Missile",
 		"mass": 207.67,
 		"volume": 40.2,
@@ -12544,8 +20375,240 @@
 			"Advanced Reinforced Frame XS": 1
 		}
 	},
+	"Advanced Agile Missile XS": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 207.67,
+		"volume": 40.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Hydraulics": 1,
+			"Advanced Missile Silo XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Defense Missile XS": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 207.67,
+		"volume": 40.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Hydraulics": 1,
+			"Advanced Missile Silo XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Heavy Missile XS": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 207.67,
+		"volume": 40.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Hydraulics": 1,
+			"Advanced Missile Silo XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Precision Missile XS": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 207.67,
+		"volume": 40.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Hydraulics": 1,
+			"Advanced Missile Silo XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Rare Agile Missile XS": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 207.67,
+		"volume": 40.2,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Hydraulics": 1,
+			"Rare Missile Silo XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Defense Missile XS": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 207.67,
+		"volume": 40.2,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Hydraulics": 1,
+			"Rare Missile Silo XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Heavy Missile XS": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 207.67,
+		"volume": 40.2,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Hydraulics": 1,
+			"Rare Missile Silo XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Precision Missile XS": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 207.67,
+		"volume": 40.2,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Screw": 1,
+			"Rare Hydraulics": 1,
+			"Rare Missile Silo XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Agile Missile XS": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 207.67,
+		"volume": 40.2,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Screw": 1,
+			"Exotic Hydraulics": 1,
+			"Exotic Missile Silo XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Defense Missile XS": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 207.67,
+		"volume": 40.2,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Screw": 1,
+			"Exotic Hydraulics": 1,
+			"Exotic Missile Silo XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Heavy Missile XS": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 207.67,
+		"volume": 40.2,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Screw": 1,
+			"Exotic Hydraulics": 1,
+			"Exotic Missile Silo XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Precision Missile XS": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 207.67,
+		"volume": 40.2,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Screw": 1,
+			"Exotic Hydraulics": 1,
+			"Exotic Missile Silo XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
 	"Missile S": {
-		"tier": 2,
+		"tier": 3,
 		"type": "Missile",
 		"mass": 593.35,
 		"volume": 125.4,
@@ -12563,13 +20626,245 @@
 			"Advanced Reinforced Frame S": 1
 		}
 	},
+	"Advanced Agile Missile S": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 593.35,
+		"volume": 125.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Hydraulics": 5,
+			"Advanced Missile Silo S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Defense Missile S": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 593.35,
+		"volume": 125.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Hydraulics": 5,
+			"Advanced Missile Silo S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Heavy Missile S": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 593.35,
+		"volume": 125.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Hydraulics": 5,
+			"Advanced Missile Silo S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Precision Missile S": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 593.35,
+		"volume": 125.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Hydraulics": 5,
+			"Advanced Missile Silo S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Rare Agile Missile S": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 593.35,
+		"volume": 125.4,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Hydraulics": 5,
+			"Rare Missile Silo S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Defense Missile S": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 593.35,
+		"volume": 125.4,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Hydraulics": 5,
+			"Rare Missile Silo S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Heavy Missile S": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 593.35,
+		"volume": 125.4,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Hydraulics": 5,
+			"Rare Missile Silo S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Precision Missile S": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 593.35,
+		"volume": 125.4,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 3,
+			"Advanced Screw": 3,
+			"Rare Hydraulics": 5,
+			"Rare Missile Silo S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Exotic Agile Missile S": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 593.35,
+		"volume": 125.4,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Screw": 6,
+			"Exotic Hydraulics": 5,
+			"Exotic Missile Silo S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
+	"Exotic Defense Missile S": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 593.35,
+		"volume": 125.4,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Screw": 6,
+			"Exotic Hydraulics": 5,
+			"Exotic Missile Silo S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
+	"Exotic Heavy Missile S": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 593.35,
+		"volume": 125.4,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Screw": 6,
+			"Exotic Hydraulics": 5,
+			"Exotic Missile Silo S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
+	"Exotic Precision Missile S": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 593.35,
+		"volume": 125.4,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Screw": 6,
+			"Exotic Hydraulics": 5,
+			"Exotic Missile Silo S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
 	"Missile M": {
 		"tier": 3,
 		"type": "Missile",
 		"mass": 2970,
 		"volume": 628,
 		"outputQuantity": 1,
-		"time": 18000,
+		"time": 17280,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12582,13 +20877,245 @@
 			"Advanced Reinforced Frame M": 1
 		}
 	},
-	"Missile L": {
+	"Advanced Agile Missile M": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 2970,
+		"volume": 628,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Hydraulics": 25,
+			"Advanced Missile Silo M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Defense Missile M": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 2970,
+		"volume": 628,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Hydraulics": 25,
+			"Advanced Missile Silo M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Heavy Missile M": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 2970,
+		"volume": 628,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Hydraulics": 25,
+			"Advanced Missile Silo M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Precision Missile M": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 2970,
+		"volume": 628,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Hydraulics": 25,
+			"Advanced Missile Silo M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare Agile Missile M": {
 		"tier": 4,
+		"type": "Missile",
+		"mass": 2970,
+		"volume": 628,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Hydraulics": 25,
+			"Rare Missile Silo M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Defense Missile M": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 2970,
+		"volume": 628,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Hydraulics": 25,
+			"Rare Missile Silo M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Heavy Missile M": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 2970,
+		"volume": 628,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Hydraulics": 25,
+			"Rare Missile Silo M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Precision Missile M": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 2970,
+		"volume": 628,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 18,
+			"Advanced Screw": 18,
+			"Rare Hydraulics": 25,
+			"Rare Missile Silo M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Exotic Agile Missile M": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 2970,
+		"volume": 628,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Screw": 36,
+			"Exotic Hydraulics": 25,
+			"Exotic Missile Silo M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Exotic Defense Missile M": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 2970,
+		"volume": 628,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Screw": 36,
+			"Exotic Hydraulics": 25,
+			"Exotic Missile Silo M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Exotic Heavy Missile M": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 2970,
+		"volume": 628,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Screw": 36,
+			"Exotic Hydraulics": 25,
+			"Exotic Missile Silo M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Exotic Precision Missile M": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 2970,
+		"volume": 628,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Screw": 36,
+			"Exotic Hydraulics": 25,
+			"Exotic Missile Silo M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Missile L": {
+		"tier": 3,
 		"type": "Missile",
 		"mass": 16130,
 		"volume": 3364.2,
 		"outputQuantity": 1,
-		"time": 68400,
+		"time": 69120,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12601,8 +21128,240 @@
 			"Advanced Reinforced Frame L": 1
 		}
 	},
+	"Advanced Agile Missile L": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 16130,
+		"volume": 3364.2,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Hydraulics": 125,
+			"Advanced Missile Silo L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Defense Missile L": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 16130,
+		"volume": 3364.2,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Hydraulics": 125,
+			"Advanced Missile Silo L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Heavy Missile L": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 16130,
+		"volume": 3364.2,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Hydraulics": 125,
+			"Advanced Missile Silo L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Precision Missile L": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 16130,
+		"volume": 3364.2,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Hydraulics": 125,
+			"Advanced Missile Silo L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Rare Agile Missile L": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 16130,
+		"volume": 3364.2,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Hydraulics": 125,
+			"Rare Missile Silo L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Defense Missile L": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 16130,
+		"volume": 3364.2,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Hydraulics": 125,
+			"Rare Missile Silo L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Heavy Missile L": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 16130,
+		"volume": 3364.2,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Hydraulics": 125,
+			"Rare Missile Silo L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Precision Missile L": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 16130,
+		"volume": 3364.2,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 108,
+			"Advanced Screw": 108,
+			"Rare Hydraulics": 125,
+			"Rare Missile Silo L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Exotic Agile Missile L": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 16130,
+		"volume": 3364.2,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Screw": 216,
+			"Exotic Hydraulics": 125,
+			"Exotic Missile Silo L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
+	"Exotic Defense Missile L": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 16130,
+		"volume": 3364.2,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Screw": 216,
+			"Exotic Hydraulics": 125,
+			"Exotic Missile Silo L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
+	"Exotic Heavy Missile L": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 16130,
+		"volume": 3364.2,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Screw": 216,
+			"Exotic Hydraulics": 125,
+			"Exotic Missile Silo L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
+	"Exotic Precision Missile L": {
+		"tier": 5,
+		"type": "Missile",
+		"mass": 16130,
+		"volume": 3364.2,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Screw": 216,
+			"Exotic Hydraulics": 125,
+			"Exotic Missile Silo L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
 	"Railgun XS": {
-		"tier": 1,
+		"tier": 3,
 		"type": "Railgun",
 		"mass": 232.02,
 		"volume": 33.66,
@@ -12620,8 +21379,240 @@
 			"Advanced Reinforced Frame XS": 1
 		}
 	},
+	"Advanced Agile Railgun XS": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 232.02,
+		"volume": 33.66,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Optics": 1,
+			"Advanced Magnetic Rail XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Defense Railgun XS": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 232.02,
+		"volume": 33.66,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Optics": 1,
+			"Advanced Magnetic Rail XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Heavy Railgun XS": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 232.02,
+		"volume": 33.66,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Optics": 1,
+			"Advanced Magnetic Rail XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Precision Railgun XS": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 232.02,
+		"volume": 33.66,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Optics": 1,
+			"Advanced Magnetic Rail XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Rare Agile Railgun XS": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 232.02,
+		"volume": 33.66,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Connector": 1,
+			"Rare Optics": 1,
+			"Rare Magnetic Rail XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Defense Railgun XS": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 232.02,
+		"volume": 33.66,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Connector": 1,
+			"Rare Optics": 1,
+			"Rare Magnetic Rail XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Heavy Railgun XS": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 232.02,
+		"volume": 33.66,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Connector": 1,
+			"Rare Optics": 1,
+			"Rare Magnetic Rail XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Rare Precision Railgun XS": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 232.02,
+		"volume": 33.66,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Connector": 1,
+			"Rare Optics": 1,
+			"Rare Magnetic Rail XS": 1,
+			"Rare Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Agile Railgun XS": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 232.02,
+		"volume": 33.66,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Connector": 1,
+			"Exotic Optics": 1,
+			"Exotic Magnetic Rail XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Defense Railgun XS": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 232.02,
+		"volume": 33.66,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Connector": 1,
+			"Exotic Optics": 1,
+			"Exotic Magnetic Rail XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Heavy Railgun XS": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 232.02,
+		"volume": 33.66,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Connector": 1,
+			"Exotic Optics": 1,
+			"Exotic Magnetic Rail XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
+	"Exotic Precision Railgun XS": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 232.02,
+		"volume": 33.66,
+		"outputQuantity": 1,
+		"time": 9720,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Connector": 1,
+			"Exotic Optics": 1,
+			"Exotic Magnetic Rail XS": 1,
+			"Exotic Reinforced Frame XS": 1
+		}
+	},
 	"Railgun S": {
-		"tier": 2,
+		"tier": 3,
 		"type": "Railgun",
 		"mass": 517.52,
 		"volume": 95.4,
@@ -12639,13 +21630,245 @@
 			"Advanced Reinforced Frame S": 1
 		}
 	},
+	"Advanced Agile Railgun S": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 6,
+			"Advanced Optics": 5,
+			"Advanced Magnetic Rail S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Defense Railgun S": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 6,
+			"Advanced Optics": 5,
+			"Advanced Magnetic Rail S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Heavy Railgun S": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 6,
+			"Advanced Optics": 5,
+			"Advanced Magnetic Rail S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Precision Railgun S": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 6,
+			"Advanced Optics": 5,
+			"Advanced Magnetic Rail S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Rare Agile Railgun S": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 3,
+			"Advanced Connector": 3,
+			"Rare Optics": 5,
+			"Rare Magnetic Rail S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Defense Railgun S": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 3,
+			"Advanced Connector": 3,
+			"Rare Optics": 5,
+			"Rare Magnetic Rail S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Heavy Railgun S": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 3,
+			"Advanced Connector": 3,
+			"Rare Optics": 5,
+			"Rare Magnetic Rail S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Rare Precision Railgun S": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 3,
+			"Advanced Connector": 3,
+			"Rare Optics": 5,
+			"Rare Magnetic Rail S": 1,
+			"Rare Reinforced Frame S": 1
+		}
+	},
+	"Exotic Agile Railgun S": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Connector": 6,
+			"Exotic Optics": 5,
+			"Exotic Magnetic Rail S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
+	"Exotic Defense Railgun S": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Connector": 6,
+			"Exotic Optics": 5,
+			"Exotic Magnetic Rail S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
+	"Exotic Heavy Railgun S": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Connector": 6,
+			"Exotic Optics": 5,
+			"Exotic Magnetic Rail S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
+	"Exotic Precision Railgun S": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 38880,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Connector": 6,
+			"Exotic Optics": 5,
+			"Exotic Magnetic Rail S": 1,
+			"Exotic Reinforced Frame S": 1
+		}
+	},
 	"Railgun M": {
 		"tier": 3,
 		"type": "Railgun",
 		"mass": 3010,
 		"volume": 565.89,
 		"outputQuantity": 1,
-		"time": 18000,
+		"time": 17280,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12658,13 +21881,245 @@
 			"Advanced Reinforced Frame M": 1
 		}
 	},
-	"Railgun L": {
+	"Advanced Agile Railgun M": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 3010,
+		"volume": 565.89,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 36,
+			"Advanced Optics": 25,
+			"Advanced Magnetic Rail M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Defense Railgun M": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 3010,
+		"volume": 565.89,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 36,
+			"Advanced Optics": 25,
+			"Advanced Magnetic Rail M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Heavy Railgun M": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 3010,
+		"volume": 565.89,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 36,
+			"Advanced Optics": 25,
+			"Advanced Magnetic Rail M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Advanced Precision Railgun M": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 3010,
+		"volume": 565.89,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 36,
+			"Advanced Optics": 25,
+			"Advanced Magnetic Rail M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Rare Agile Railgun M": {
 		"tier": 4,
+		"type": "Railgun",
+		"mass": 3010,
+		"volume": 565.89,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 18,
+			"Advanced Connector": 18,
+			"Rare Optics": 25,
+			"Rare Magnetic Rail M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Defense Railgun M": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 3010,
+		"volume": 565.89,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 18,
+			"Advanced Connector": 18,
+			"Rare Optics": 25,
+			"Rare Magnetic Rail M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Heavy Railgun M": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 3010,
+		"volume": 565.89,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 18,
+			"Advanced Connector": 18,
+			"Rare Optics": 25,
+			"Rare Magnetic Rail M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Rare Precision Railgun M": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 3010,
+		"volume": 565.89,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 18,
+			"Advanced Connector": 18,
+			"Rare Optics": 25,
+			"Rare Magnetic Rail M": 1,
+			"Rare Reinforced Frame M": 1
+		}
+	},
+	"Exotic Agile Railgun M": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 3010,
+		"volume": 565.89,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Connector": 36,
+			"Exotic Optics": 25,
+			"Exotic Magnetic Rail M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Exotic Defense Railgun M": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 3010,
+		"volume": 565.89,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Connector": 36,
+			"Exotic Optics": 25,
+			"Exotic Magnetic Rail M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Exotic Heavy Railgun M": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 3010,
+		"volume": 565.89,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Connector": 36,
+			"Exotic Optics": 25,
+			"Exotic Magnetic Rail M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Exotic Precision Railgun M": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 3010,
+		"volume": 565.89,
+		"outputQuantity": 1,
+		"time": 155520,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Connector": 36,
+			"Exotic Optics": 25,
+			"Exotic Magnetic Rail M": 1,
+			"Exotic Reinforced Frame M": 1
+		}
+	},
+	"Railgun L": {
+		"tier": 3,
 		"type": "Railgun",
 		"mass": 16720,
 		"volume": 3054.89,
 		"outputQuantity": 1,
-		"time": 68400,
+		"time": 69120,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12677,13 +22132,245 @@
 			"Advanced Reinforced Frame L": 1
 		}
 	},
+	"Advanced Agile Railgun L": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 16720,
+		"volume": 3054.89,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 216,
+			"Advanced Optics": 125,
+			"Advanced Magnetic Rail L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Defense Railgun L": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 16720,
+		"volume": 3054.89,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 216,
+			"Advanced Optics": 125,
+			"Advanced Magnetic Rail L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Heavy Railgun L": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 16720,
+		"volume": 3054.89,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 216,
+			"Advanced Optics": 125,
+			"Advanced Magnetic Rail L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Precision Railgun L": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 16720,
+		"volume": 3054.89,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 216,
+			"Advanced Optics": 125,
+			"Advanced Magnetic Rail L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Rare Agile Railgun L": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 16720,
+		"volume": 3054.89,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 108,
+			"Advanced Connector": 108,
+			"Rare Optics": 125,
+			"Rare Magnetic Rail L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Defense Railgun L": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 16720,
+		"volume": 3054.89,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 108,
+			"Advanced Connector": 108,
+			"Rare Optics": 125,
+			"Rare Magnetic Rail L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Heavy Railgun L": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 16720,
+		"volume": 3054.89,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 108,
+			"Advanced Connector": 108,
+			"Rare Optics": 125,
+			"Rare Magnetic Rail L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Rare Precision Railgun L": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 16720,
+		"volume": 3054.89,
+		"outputQuantity": 1,
+		"time": 208800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 108,
+			"Advanced Connector": 108,
+			"Rare Optics": 125,
+			"Rare Magnetic Rail L": 1,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Exotic Agile Railgun L": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 16720,
+		"volume": 3054.89,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Connector": 216,
+			"Exotic Optics": 125,
+			"Exotic Magnetic Rail L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
+	"Exotic Defense Railgun L": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 16720,
+		"volume": 3054.89,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Connector": 216,
+			"Exotic Optics": 125,
+			"Exotic Magnetic Rail L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
+	"Exotic Heavy Railgun L": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 16720,
+		"volume": 3054.89,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Connector": 216,
+			"Exotic Optics": 125,
+			"Exotic Magnetic Rail L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
+	"Exotic Precision Railgun L": {
+		"tier": 5,
+		"type": "Railgun",
+		"mass": 16720,
+		"volume": 3054.89,
+		"outputQuantity": 1,
+		"time": 622800,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Connector": 216,
+			"Exotic Optics": 125,
+			"Exotic Magnetic Rail L": 1,
+			"Exotic Reinforced Frame L": 1
+		}
+	},
 	"Cannon Agile Kinetic Ammo XS": {
 		"tier": 3,
 		"type": "Advanced Ammo",
 		"mass": 1.61,
 		"volume": 1,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12702,7 +22389,7 @@
 		"mass": 1.59,
 		"volume": 1,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12721,7 +22408,7 @@
 		"mass": 1.73,
 		"volume": 1,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12740,7 +22427,7 @@
 		"mass": 1.54,
 		"volume": 1,
 		"outputQuantity": 40,
-		"time": 180,
+		"time": 200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12758,7 +22445,7 @@
 		"mass": 1.54,
 		"volume": 1,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12777,7 +22464,7 @@
 		"mass": 1.07,
 		"volume": 1,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12796,7 +22483,7 @@
 		"mass": 1.05,
 		"volume": 1,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12815,7 +22502,7 @@
 		"mass": 1.19,
 		"volume": 1,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12834,7 +22521,7 @@
 		"mass": 1.08,
 		"volume": 1,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12853,7 +22540,7 @@
 		"mass": 1.01,
 		"volume": 1,
 		"outputQuantity": 40,
-		"time": 180,
+		"time": 200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12871,7 +22558,7 @@
 		"mass": 4.1,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12890,7 +22577,7 @@
 		"mass": 4.07,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12909,7 +22596,7 @@
 		"mass": 4.34,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12928,7 +22615,7 @@
 		"mass": 3.98,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12946,7 +22633,7 @@
 		"mass": 4.11,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12965,7 +22652,7 @@
 		"mass": 3.2,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -12984,7 +22671,7 @@
 		"mass": 2.99,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13003,7 +22690,7 @@
 		"mass": 3.28,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13022,7 +22709,7 @@
 		"mass": 3.2,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13041,7 +22728,7 @@
 		"mass": 2.93,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13059,7 +22746,7 @@
 		"mass": 14.73,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13078,7 +22765,7 @@
 		"mass": 14.66,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13097,7 +22784,7 @@
 		"mass": 15.21,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13116,7 +22803,7 @@
 		"mass": 14.66,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13134,7 +22821,7 @@
 		"mass": 14.76,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13153,7 +22840,7 @@
 		"mass": 12.57,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13172,7 +22859,7 @@
 		"mass": 12.5,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13191,7 +22878,7 @@
 		"mass": 13.05,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13210,7 +22897,7 @@
 		"mass": 12.6,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13229,7 +22916,7 @@
 		"mass": 12.55,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13247,7 +22934,7 @@
 		"mass": 75.56,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13266,7 +22953,7 @@
 		"mass": 75.42,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13285,7 +22972,7 @@
 		"mass": 76.52,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13304,7 +22991,7 @@
 		"mass": 76.58,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13322,7 +23009,7 @@
 		"mass": 75.61,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13341,7 +23028,7 @@
 		"mass": 71.24,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13360,7 +23047,7 @@
 		"mass": 71.1,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13379,7 +23066,7 @@
 		"mass": 72.2,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13398,7 +23085,7 @@
 		"mass": 71.29,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13417,7 +23104,7 @@
 		"mass": 72.37,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13435,7 +23122,7 @@
 		"mass": 31.56,
 		"volume": 2,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13454,7 +23141,7 @@
 		"mass": 1.54,
 		"volume": 2,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13473,7 +23160,7 @@
 		"mass": 1.46,
 		"volume": 2,
 		"outputQuantity": 40,
-		"time": 180,
+		"time": 200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13491,7 +23178,7 @@
 		"mass": 1.68,
 		"volume": 2,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13510,7 +23197,7 @@
 		"mass": 1.56,
 		"volume": 2,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13529,7 +23216,7 @@
 		"mass": 0.67,
 		"volume": 2,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13548,7 +23235,7 @@
 		"mass": 0.65,
 		"volume": 2,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13567,7 +23254,7 @@
 		"mass": 0.79,
 		"volume": 2,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13586,7 +23273,7 @@
 		"mass": 0.67,
 		"volume": 2,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13605,7 +23292,7 @@
 		"mass": 0.6,
 		"volume": 2,
 		"outputQuantity": 40,
-		"time": 180,
+		"time": 200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13623,7 +23310,7 @@
 		"mass": 3.21,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13642,7 +23329,7 @@
 		"mass": 3.18,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13661,7 +23348,7 @@
 		"mass": 3.03,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13679,7 +23366,7 @@
 		"mass": 3.45,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13698,7 +23385,7 @@
 		"mass": 3.23,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13717,7 +23404,7 @@
 		"mass": 1.44,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13736,7 +23423,7 @@
 		"mass": 1.4,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13755,7 +23442,7 @@
 		"mass": 1.68,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13774,7 +23461,7 @@
 		"mass": 1.45,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13793,7 +23480,7 @@
 		"mass": 1.31,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13811,7 +23498,7 @@
 		"mass": 7.19,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13830,7 +23517,7 @@
 		"mass": 7.12,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13849,7 +23536,7 @@
 		"mass": 6.78,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13867,7 +23554,7 @@
 		"mass": 7.67,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13886,7 +23573,7 @@
 		"mass": 7.22,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13905,7 +23592,7 @@
 		"mass": 3.64,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13924,7 +23611,7 @@
 		"mass": 3.56,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13943,7 +23630,7 @@
 		"mass": 3.56,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13962,7 +23649,7 @@
 		"mass": 4.12,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13981,7 +23668,7 @@
 		"mass": 3.34,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -13999,7 +23686,7 @@
 		"mass": 19.77,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14018,7 +23705,7 @@
 		"mass": 19.62,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14037,7 +23724,7 @@
 		"mass": 18.7,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14055,7 +23742,7 @@
 		"mass": 20.73,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14074,7 +23761,7 @@
 		"mass": 19.81,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14093,7 +23780,7 @@
 		"mass": 12.65,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14112,7 +23799,7 @@
 		"mass": 12.51,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14131,7 +23818,7 @@
 		"mass": 13.61,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14150,7 +23837,7 @@
 		"mass": 12.7,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14169,7 +23856,7 @@
 		"mass": 11.81,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14187,14 +23874,14 @@
 		"mass": 0.94,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line XS"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 1,
+			"Advanced Antimatter Capsule": 1,
 			"Uncommon Processor": 1,
 			"Al-Li Alloy": 1,
 			"Uncommon Standard Frame XS": 1
@@ -14206,14 +23893,14 @@
 		"mass": 0.87,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 180,
+		"time": 200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line XS"
 		],
 		"input": {
-			"Uncommon Anti-Matter Capsule": 1,
+			"Uncommon Antimatter Capsule": 1,
 			"Basic Processor": 1,
 			"Basic Standard Frame XS": 1
 		}
@@ -14224,14 +23911,14 @@
 		"mass": 0.92,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line XS"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 1,
+			"Advanced Antimatter Capsule": 1,
 			"Uncommon Processor": 1,
 			"Polysulfide Plastic": 1,
 			"Uncommon Standard Frame XS": 1
@@ -14243,14 +23930,14 @@
 		"mass": 1.06,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line XS"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 1,
+			"Advanced Antimatter Capsule": 1,
 			"Uncommon Processor": 1,
 			"Inconel": 1,
 			"Uncommon Standard Frame XS": 1
@@ -14262,14 +23949,14 @@
 		"mass": 0.95,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line XS"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 1,
+			"Advanced Antimatter Capsule": 1,
 			"Uncommon Processor": 1,
 			"Ag-Li Reinforced Glass": 1,
 			"Uncommon Standard Frame XS": 1
@@ -14281,7 +23968,7 @@
 		"mass": 1.37,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14300,7 +23987,7 @@
 		"mass": 1.35,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14319,7 +24006,7 @@
 		"mass": 1.49,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14338,7 +24025,7 @@
 		"mass": 1.29,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 180,
+		"time": 200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14356,7 +24043,7 @@
 		"mass": 1.38,
 		"volume": 5,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14375,14 +24062,14 @@
 		"mass": 2.16,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line S"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 2,
+			"Advanced Antimatter Capsule": 2,
 			"Uncommon Processor": 2,
 			"Al-Li Alloy": 2,
 			"Uncommon Standard Frame XS": 2
@@ -14394,14 +24081,14 @@
 		"mass": 2.16,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line S"
 		],
 		"input": {
-			"Uncommon Anti-Matter Capsule": 2,
+			"Uncommon Antimatter Capsule": 2,
 			"Basic Processor": 2,
 			"Basic Standard Frame XS": 2
 		}
@@ -14412,14 +24099,14 @@
 		"mass": 2.12,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line S"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 2,
+			"Advanced Antimatter Capsule": 2,
 			"Uncommon Processor": 2,
 			"Polysulfide Plastic": 2,
 			"Uncommon Standard Frame XS": 2
@@ -14431,14 +24118,14 @@
 		"mass": 2.4,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line S"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 2,
+			"Advanced Antimatter Capsule": 2,
 			"Uncommon Processor": 2,
 			"Inconel": 2,
 			"Uncommon Standard Frame XS": 2
@@ -14450,14 +24137,14 @@
 		"mass": 2.17,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line S"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 2,
+			"Advanced Antimatter Capsule": 2,
 			"Uncommon Processor": 2,
 			"Ag-Li Reinforced Glass": 2,
 			"Uncommon Standard Frame XS": 2
@@ -14469,7 +24156,7 @@
 		"mass": 3.02,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14488,7 +24175,7 @@
 		"mass": 2.99,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14507,7 +24194,7 @@
 		"mass": 3.26,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14526,7 +24213,7 @@
 		"mass": 2.87,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14544,7 +24231,7 @@
 		"mass": 3.03,
 		"volume": 25,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14563,14 +24250,14 @@
 		"mass": 6.41,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line M"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 4,
+			"Advanced Antimatter Capsule": 4,
 			"Uncommon Processor": 4,
 			"Al-Li Alloy": 4,
 			"Uncommon Standard Frame S": 1
@@ -14582,14 +24269,14 @@
 		"mass": 6.24,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line M"
 		],
 		"input": {
-			"Uncommon Anti-Matter Capsule": 4,
+			"Uncommon Antimatter Capsule": 4,
 			"Basic Processor": 4,
 			"Basic Standard Frame S": 1
 		}
@@ -14600,14 +24287,14 @@
 		"mass": 6.33,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line M"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 4,
+			"Advanced Antimatter Capsule": 4,
 			"Uncommon Processor": 4,
 			"Polysulfide Plastic": 4,
 			"Uncommon Standard Frame S": 1
@@ -14619,14 +24306,14 @@
 		"mass": 6.89,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line M"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 4,
+			"Advanced Antimatter Capsule": 4,
 			"Uncommon Processor": 4,
 			"Inconel": 4,
 			"Uncommon Standard Frame S": 1
@@ -14638,14 +24325,14 @@
 		"mass": 6.43,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line M"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 4,
+			"Advanced Antimatter Capsule": 4,
 			"Uncommon Processor": 4,
 			"Ag-Li Reinforced Glass": 4,
 			"Uncommon Standard Frame S": 1
@@ -14657,7 +24344,7 @@
 		"mass": 8.13,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14676,7 +24363,7 @@
 		"mass": 8.06,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14695,7 +24382,7 @@
 		"mass": 8.61,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14714,7 +24401,7 @@
 		"mass": 7.92,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14732,7 +24419,7 @@
 		"mass": 8.15,
 		"volume": 125,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14751,14 +24438,14 @@
 		"mass": 27.54,
 		"volume": 625,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line L"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 8,
+			"Advanced Antimatter Capsule": 8,
 			"Uncommon Processor": 8,
 			"Al-Li Alloy": 8,
 			"Uncommon Standard Frame S": 2
@@ -14770,14 +24457,14 @@
 		"mass": 27.9,
 		"volume": 625,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line L"
 		],
 		"input": {
-			"Uncommon Anti-Matter Capsule": 8,
+			"Uncommon Antimatter Capsule": 8,
 			"Basic Processor": 8,
 			"Basic Standard Frame S": 2
 		}
@@ -14788,14 +24475,14 @@
 		"mass": 6.33,
 		"volume": 625,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line L"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 8,
+			"Advanced Antimatter Capsule": 8,
 			"Uncommon Processor": 8,
 			"Polysulfide Plastic": 8,
 			"Uncommon Standard Frame S": 2
@@ -14807,14 +24494,14 @@
 		"mass": 27.4,
 		"volume": 625,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line L"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 8,
+			"Advanced Antimatter Capsule": 8,
 			"Uncommon Processor": 8,
 			"Inconel": 8,
 			"Uncommon Standard Frame S": 2
@@ -14826,14 +24513,14 @@
 		"mass": 27.59,
 		"volume": 625,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line L"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 8,
+			"Advanced Antimatter Capsule": 8,
 			"Uncommon Processor": 8,
 			"Ag-Li Reinforced Glass": 8,
 			"Uncommon Standard Frame S": 2
@@ -14845,7 +24532,7 @@
 		"mass": 30.99,
 		"volume": 625,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14864,7 +24551,7 @@
 		"mass": 30.84,
 		"volume": 625,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14883,7 +24570,7 @@
 		"mass": 31.95,
 		"volume": 625,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14902,7 +24589,7 @@
 		"mass": 31.26,
 		"volume": 625,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14920,7 +24607,7 @@
 		"mass": 31.04,
 		"volume": 625,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -14939,14 +24626,14 @@
 		"mass": 2.04,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line XS"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 1,
+			"Advanced Antimatter Capsule": 1,
 			"Uncommon Magnet": 1,
 			"Al-Li Alloy": 1,
 			"Uncommon Reinforced Frame XS": 1
@@ -14958,14 +24645,14 @@
 		"mass": 2.01,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 180,
+		"time": 200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line XS"
 		],
 		"input": {
-			"Uncommon Anti-Matter Capsule": 1,
+			"Uncommon Antimatter Capsule": 1,
 			"Basic Magnet": 1,
 			"Basic Reinforced Frame XS": 1
 		}
@@ -14976,14 +24663,14 @@
 		"mass": 2.02,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line XS"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 1,
+			"Advanced Antimatter Capsule": 1,
 			"Uncommon Magnet": 1,
 			"Polysulfide Plastic": 1,
 			"Uncommon Reinforced Frame XS": 1
@@ -14995,14 +24682,14 @@
 		"mass": 2.16,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line XS"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 1,
+			"Advanced Antimatter Capsule": 1,
 			"Uncommon Magnet": 1,
 			"Inconel": 2,
 			"Uncommon Reinforced Frame XS": 1
@@ -15014,14 +24701,14 @@
 		"mass": 2.05,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line XS"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 1,
+			"Advanced Antimatter Capsule": 1,
 			"Uncommon Magnet": 1,
 			"Ag-Li Reinforced Glass": 1,
 			"Uncommon Reinforced Frame XS": 1
@@ -15033,7 +24720,7 @@
 		"mass": 2.77,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15052,7 +24739,7 @@
 		"mass": 2.8,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15071,7 +24758,7 @@
 		"mass": 6.43,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 180,
+		"time": 200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15089,7 +24776,7 @@
 		"mass": 2.94,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15108,7 +24795,7 @@
 		"mass": 2.83,
 		"volume": 10,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15127,14 +24814,14 @@
 		"mass": 4.96,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line S"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 2,
+			"Advanced Antimatter Capsule": 2,
 			"Uncommon Magnet": 2,
 			"Al-Li Alloy": 2,
 			"Uncommon Reinforced Frame XS": 2
@@ -15146,14 +24833,14 @@
 		"mass": 4.92,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line S"
 		],
 		"input": {
-			"Uncommon Anti-Matter Capsule": 2,
+			"Uncommon Antimatter Capsule": 2,
 			"Basic Magnet": 2,
 			"Basic Reinforced Frame XS": 2
 		}
@@ -15164,14 +24851,14 @@
 		"mass": 4.93,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line S"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 2,
+			"Advanced Antimatter Capsule": 2,
 			"Uncommon Magnet": 2,
 			"Polysulfide Plastic": 2,
 			"Uncommon Reinforced Frame XS": 2
@@ -15183,14 +24870,14 @@
 		"mass": 5.2,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line S"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 2,
+			"Advanced Antimatter Capsule": 2,
 			"Uncommon Magnet": 2,
 			"Inconel": 2,
 			"Uncommon Reinforced Frame XS": 2
@@ -15202,14 +24889,14 @@
 		"mass": 4.97,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line S"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 2,
+			"Advanced Antimatter Capsule": 2,
 			"Uncommon Magnet": 2,
 			"Ag-Li Reinforced Glass": 2,
 			"Uncommon Reinforced Frame XS": 2
@@ -15221,7 +24908,7 @@
 		"mass": 6.52,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15240,7 +24927,7 @@
 		"mass": 6.49,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15259,7 +24946,7 @@
 		"mass": 6.43,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 420,
+		"time": 400,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15277,7 +24964,7 @@
 		"mass": 6.76,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15296,7 +24983,7 @@
 		"mass": 6.53,
 		"volume": 50,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15315,14 +25002,14 @@
 		"mass": 16.45,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line M"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 4,
+			"Advanced Antimatter Capsule": 4,
 			"Uncommon Magnet": 4,
 			"Al-Li Alloy": 4,
 			"Uncommon Reinforced Frame S": 1
@@ -15334,14 +25021,14 @@
 		"mass": 16.54,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line M"
 		],
 		"input": {
-			"Uncommon Anti-Matter Capsule": 4,
+			"Uncommon Antimatter Capsule": 4,
 			"Basic Magnet": 4,
 			"Basic Reinforced Frame S": 1
 		}
@@ -15352,14 +25039,14 @@
 		"mass": 16.38,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line M"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 4,
+			"Advanced Antimatter Capsule": 4,
 			"Uncommon Magnet": 4,
 			"Polysulfide Plastic": 4,
 			"Uncommon Reinforced Frame S": 1
@@ -15371,14 +25058,14 @@
 		"mass": 16.93,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line M"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 4,
+			"Advanced Antimatter Capsule": 4,
 			"Uncommon Magnet": 4,
 			"Inconel": 4,
 			"Uncommon Reinforced Frame S": 1
@@ -15390,14 +25077,14 @@
 		"mass": 16.48,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line M"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 4,
+			"Advanced Antimatter Capsule": 4,
 			"Uncommon Magnet": 4,
 			"Ag-Li Reinforced Glass": 4,
 			"Uncommon Reinforced Frame S": 1
@@ -15409,7 +25096,7 @@
 		"mass": 19.58,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15428,7 +25115,7 @@
 		"mass": 19.5,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15447,7 +25134,7 @@
 		"mass": 19.56,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 780,
+		"time": 800,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15465,7 +25152,7 @@
 		"mass": 20.06,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15484,7 +25171,7 @@
 		"mass": 19.6,
 		"volume": 250,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15503,14 +25190,14 @@
 		"mass": 79,
 		"volume": 1250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line L"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 8,
+			"Advanced Antimatter Capsule": 8,
 			"Uncommon Magnet": 8,
 			"Al-Li Alloy": 8,
 			"Uncommon Reinforced Frame S": 2
@@ -15522,14 +25209,14 @@
 		"mass": 80.35,
 		"volume": 1250,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line L"
 		],
 		"input": {
-			"Uncommon Anti-Matter Capsule": 8,
+			"Uncommon Antimatter Capsule": 8,
 			"Basic Magnet": 8,
 			"Basic Reinforced Frame S": 2
 		}
@@ -15540,14 +25227,14 @@
 		"mass": 78.86,
 		"volume": 1250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line L"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 8,
+			"Advanced Antimatter Capsule": 8,
 			"Uncommon Magnet": 8,
 			"Polysulfide Plastic": 8,
 			"Uncommon Reinforced Frame S": 2
@@ -15559,14 +25246,14 @@
 		"mass": 79.96,
 		"volume": 1250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line L"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 8,
+			"Advanced Antimatter Capsule": 8,
 			"Uncommon Magnet": 8,
 			"Inconel": 8,
 			"Uncommon Reinforced Frame S": 2
@@ -15578,14 +25265,14 @@
 		"mass": 79.05,
 		"volume": 1250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
 			"Assembly Line L"
 		],
 		"input": {
-			"Advanced Anti-Matter Capsule": 8,
+			"Advanced Antimatter Capsule": 8,
 			"Uncommon Magnet": 8,
 			"Ag-Li Reinforced Glass": 8,
 			"Uncommon Reinforced Frame S": 2
@@ -15597,7 +25284,7 @@
 		"mass": 85.24,
 		"volume": 1250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15616,7 +25303,7 @@
 		"mass": 85.1,
 		"volume": 1250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15635,7 +25322,7 @@
 		"mass": 86.4,
 		"volume": 1250,
 		"outputQuantity": 40,
-		"time": 1620,
+		"time": 1600,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15653,7 +25340,7 @@
 		"mass": 86.2,
 		"volume": 1250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15672,7 +25359,7 @@
 		"mass": 85.29,
 		"volume": 1250,
 		"outputQuantity": 40,
-		"time": 3180,
+		"time": 3200,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15699,11 +25386,11 @@
 		],
 		"input": {
 			"Advanced Quantum Alignment Unit": 1,
-			"Advanced Anti-Matter Core Unit": 1
+			"Advanced Antimatter Core Unit": 1
 		}
 	},
 	"Warp Drive L": {
-		"tier": 1,
+		"tier": 3,
 		"type": "Warp Drive Unit",
 		"mass": 31360,
 		"volume": 75,
@@ -15718,7 +25405,7 @@
 			"Uncommon Screw": 216,
 			"Advanced Magnet": 125,
 			"Advanced Ionic Chamber L": 1,
-			"Advanced Anti-Matter Core Unit": 64,
+			"Advanced Antimatter Core Unit": 64,
 			"Advanced Reinforced Frame L": 1
 		}
 	},
@@ -15748,7 +25435,7 @@
 		"mass": 229.09,
 		"volume": 64,
 		"outputQuantity": 1,
-		"time": 360,
+		"time": 300,
 		"skill": "Systems",
 		"byproducts": {},
 		"industries": [
@@ -15759,6 +25446,26 @@
 			"Silumin": 7,
 			"Basic Fixation": 6,
 			"Basic Reinforced Frame S": 1
+		}
+	},
+	"Interior door": {
+		"tier": 1,
+		"type": "Door/Gate",
+		"mass": 4200,
+		"volume": 546.4,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Power System": 25,
+			"Basic Electric Engine": 1,
+			"Basic Reinforced Frame M": 1
 		}
 	},
 	"Fuel Intake XS": {
@@ -15775,804 +25482,8 @@
 			"Assembly Line XS"
 		],
 		"input": {
-			"Silumin": 2,
+			"Silumin": 1,
 			"Basic Fixation": 1
-		}
-	},
-	"Freight Atmospheric Engine XS": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 101.88,
-		"volume": 22.6,
-		"outputQuantity": 1,
-		"time": 360,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line XS"
-		],
-		"input": {
-			"Basic Screw": 1,
-			"Uncommon Screw": 1,
-			"Uncommon Injector": 1,
-			"Uncommon Combustion Chamber XS": 1,
-			"Uncommon Reinforced Frame XS": 1
-		}
-	},
-	"Safe Atmospheric Engine XS": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 101.88,
-		"volume": 22.6,
-		"outputQuantity": 1,
-		"time": 360,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line XS"
-		],
-		"input": {
-			"Basic Screw": 1,
-			"Uncommon Screw": 1,
-			"Uncommon Injector": 1,
-			"Uncommon Combustion Chamber XS": 1,
-			"Uncommon Reinforced Frame XS": 1
-		}
-	},
-	"Maneuver Atmospheric Engine XS": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 101.88,
-		"volume": 22.6,
-		"outputQuantity": 1,
-		"time": 360,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line XS"
-		],
-		"input": {
-			"Basic Screw": 1,
-			"Uncommon Screw": 1,
-			"Uncommon Injector": 1,
-			"Uncommon Combustion Chamber XS": 1,
-			"Uncommon Reinforced Frame XS": 1
-		}
-	},
-	"Military Atmospheric Engine XS": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 101.88,
-		"volume": 22.6,
-		"outputQuantity": 1,
-		"time": 360,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line XS"
-		],
-		"input": {
-			"Basic Screw": 1,
-			"Uncommon Screw": 1,
-			"Uncommon Injector": 1,
-			"Uncommon Combustion Chamber XS": 1,
-			"Uncommon Reinforced Frame XS": 1
-		}
-	},
-	"Freight Atmospheric Engine S": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 539.99,
-		"volume": 116.6,
-		"outputQuantity": 1,
-		"time": 1440,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line S"
-		],
-		"input": {
-			"Basic Screw": 3,
-			"Uncommon Screw": 3,
-			"Uncommon Injector": 5,
-			"Uncommon Combustion Chamber S": 1,
-			"Uncommon Reinforced Frame S": 1
-		}
-	},
-	"Maneuver Atmospheric Engine S": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 539.99,
-		"volume": 116.6,
-		"outputQuantity": 1,
-		"time": 1440,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line S"
-		],
-		"input": {
-			"Basic Screw": 3,
-			"Uncommon Screw": 3,
-			"Uncommon Injector": 5,
-			"Uncommon Combustion Chamber S": 1,
-			"Uncommon Reinforced Frame S": 1
-		}
-	},
-	"Military Atmospheric Engine S": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 539.99,
-		"volume": 116.6,
-		"outputQuantity": 1,
-		"time": 1440,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line S"
-		],
-		"input": {
-			"Basic Screw": 3,
-			"Uncommon Screw": 3,
-			"Uncommon Injector": 5,
-			"Uncommon Combustion Chamber S": 1,
-			"Uncommon Reinforced Frame S": 1
-		}
-	},
-	"Safe Atmospheric Engine S": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 539.99,
-		"volume": 116.6,
-		"outputQuantity": 1,
-		"time": 1440,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line S"
-		],
-		"input": {
-			"Basic Screw": 3,
-			"Uncommon Screw": 3,
-			"Uncommon Injector": 5,
-			"Uncommon Combustion Chamber S": 1,
-			"Uncommon Reinforced Frame S": 1
-		}
-	},
-	"Freight Atmospheric Engine M": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 2980,
-		"volume": 619.2,
-		"outputQuantity": 1,
-		"time": 5760,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line M"
-		],
-		"input": {
-			"Basic Screw": 18,
-			"Uncommon Screw": 18,
-			"Uncommon Injector": 25,
-			"Uncommon Combustion Chamber M": 1,
-			"Uncommon Reinforced Frame M": 1
-		}
-	},
-	"Maneuver Atmospheric Engine M": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 2980,
-		"volume": 619.2,
-		"outputQuantity": 1,
-		"time": 5760,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line M"
-		],
-		"input": {
-			"Basic Screw": 18,
-			"Uncommon Screw": 18,
-			"Uncommon Injector": 25,
-			"Uncommon Combustion Chamber M": 1,
-			"Uncommon Reinforced Frame M": 1
-		}
-	},
-	"Military Atmospheric Engine M": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 2980,
-		"volume": 619.2,
-		"outputQuantity": 1,
-		"time": 5760,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line M"
-		],
-		"input": {
-			"Basic Screw": 18,
-			"Uncommon Screw": 18,
-			"Uncommon Injector": 25,
-			"Uncommon Combustion Chamber M": 1,
-			"Uncommon Reinforced Frame M": 1
-		}
-	},
-	"Safe Atmospheric Engine M": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 2980,
-		"volume": 619.2,
-		"outputQuantity": 1,
-		"time": 5760,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line M"
-		],
-		"input": {
-			"Basic Screw": 18,
-			"Uncommon Screw": 18,
-			"Uncommon Injector": 25,
-			"Uncommon Combustion Chamber M": 1,
-			"Uncommon Reinforced Frame M": 1
-		}
-	},
-	"Freight Atmospheric Engine L": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 16930,
-		"volume": 3355.4,
-		"outputQuantity": 1,
-		"time": 23040,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line L"
-		],
-		"input": {
-			"Basic Screw": 108,
-			"Uncommon Screw": 108,
-			"Uncommon Injector": 125,
-			"Uncommon Combustion Chamber L": 1,
-			"Uncommon Reinforced Frame L": 1
-		}
-	},
-	"Maneuver Atmospheric Engine L": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 16930,
-		"volume": 3355.4,
-		"outputQuantity": 1,
-		"time": 23040,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line L"
-		],
-		"input": {
-			"Basic Screw": 108,
-			"Uncommon Screw": 108,
-			"Uncommon Injector": 125,
-			"Uncommon Combustion Chamber L": 1,
-			"Uncommon Reinforced Frame L": 1
-		}
-	},
-	"Military Atmospheric Engine L": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 16930,
-		"volume": 3355.4,
-		"outputQuantity": 1,
-		"time": 23040,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line L"
-		],
-		"input": {
-			"Basic Screw": 108,
-			"Uncommon Screw": 108,
-			"Uncommon Injector": 125,
-			"Uncommon Combustion Chamber L": 1,
-			"Uncommon Reinforced Frame L": 1
-		}
-	},
-	"Safe Atmospheric Engine L": {
-		"tier": 2,
-		"type": "Atmospheric Engine",
-		"mass": 16930,
-		"volume": 3355.4,
-		"outputQuantity": 1,
-		"time": 23040,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line L"
-		],
-		"input": {
-			"Basic Screw": 108,
-			"Uncommon Screw": 108,
-			"Uncommon Injector": 125,
-			"Uncommon Combustion Chamber L": 1,
-			"Uncommon Reinforced Frame L": 1
-		}
-	},
-	"Freight Space Engine XS": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 146.23,
-		"volume": 20.33,
-		"outputQuantity": 1,
-		"time": 360,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line XS"
-		],
-		"input": {
-			"Basic Screw": 1,
-			"Uncommon Screw": 1,
-			"Uncommon Burner": 1,
-			"Uncommon Ionic Chamber XS": 1,
-			"Uncommon Reinforced Frame XS": 1
-		}
-	},
-	"Maneuver Space Engine XS": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 146.23,
-		"volume": 20.33,
-		"outputQuantity": 1,
-		"time": 360,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line XS"
-		],
-		"input": {
-			"Basic Screw": 1,
-			"Uncommon Screw": 1,
-			"Uncommon Burner": 1,
-			"Uncommon Ionic Chamber XS": 1,
-			"Uncommon Reinforced Frame XS": 1
-		}
-	},
-	"Military Space Engine XS": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 146.23,
-		"volume": 20.33,
-		"outputQuantity": 1,
-		"time": 360,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line XS"
-		],
-		"input": {
-			"Basic Screw": 1,
-			"Uncommon Screw": 1,
-			"Uncommon Burner": 1,
-			"Uncommon Ionic Chamber XS": 1,
-			"Uncommon Reinforced Frame XS": 1
-		}
-	},
-	"Safe Space Engine XS": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 146.23,
-		"volume": 20.33,
-		"outputQuantity": 1,
-		"time": 360,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line XS"
-		],
-		"input": {
-			"Basic Screw": 1,
-			"Uncommon Screw": 1,
-			"Uncommon Burner": 1,
-			"Uncommon Ionic Chamber XS": 1,
-			"Uncommon Reinforced Frame XS": 1
-		}
-	},
-	"Freight Space Engine S": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 761.74,
-		"volume": 105.24,
-		"outputQuantity": 1,
-		"time": 1440,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line S"
-		],
-		"input": {
-			"Basic Screw": 3,
-			"Uncommon Screw": 3,
-			"Uncommon Burner": 5,
-			"Uncommon Ionic Chamber S": 1,
-			"Uncommon Reinforced Frame S": 1
-		}
-	},
-	"Maneuver Space Engine S": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 761.74,
-		"volume": 105.24,
-		"outputQuantity": 1,
-		"time": 1440,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line S"
-		],
-		"input": {
-			"Basic Screw": 3,
-			"Uncommon Screw": 3,
-			"Uncommon Burner": 5,
-			"Uncommon Ionic Chamber S": 1,
-			"Uncommon Reinforced Frame S": 1
-		}
-	},
-	"Military Space Engine S": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 761.74,
-		"volume": 105.24,
-		"outputQuantity": 1,
-		"time": 1440,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line S"
-		],
-		"input": {
-			"Basic Screw": 3,
-			"Uncommon Screw": 3,
-			"Uncommon Burner": 5,
-			"Uncommon Ionic Chamber S": 1,
-			"Uncommon Reinforced Frame S": 1
-		}
-	},
-	"Safe Space Engine S": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 761.74,
-		"volume": 105.24,
-		"outputQuantity": 1,
-		"time": 1440,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line S"
-		],
-		"input": {
-			"Basic Screw": 3,
-			"Uncommon Screw": 3,
-			"Uncommon Burner": 5,
-			"Uncommon Ionic Chamber S": 1,
-			"Uncommon Reinforced Frame S": 1
-		}
-	},
-	"Freight Space Engine M": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 4090,
-		"volume": 562.4,
-		"outputQuantity": 1,
-		"time": 5760,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line M"
-		],
-		"input": {
-			"Basic Screw": 18,
-			"Uncommon Screw": 18,
-			"Uncommon Burner": 25,
-			"Uncommon Ionic Chamber M": 1,
-			"Uncommon Reinforced Frame M": 1
-		}
-	},
-	"Maneuver Space Engine M": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 4090,
-		"volume": 562.4,
-		"outputQuantity": 1,
-		"time": 5760,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line M"
-		],
-		"input": {
-			"Basic Screw": 18,
-			"Uncommon Screw": 18,
-			"Uncommon Burner": 25,
-			"Uncommon Ionic Chamber M": 1,
-			"Uncommon Reinforced Frame M": 1
-		}
-	},
-	"Military Space Engine M": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 4090,
-		"volume": 562.4,
-		"outputQuantity": 1,
-		"time": 5760,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line M"
-		],
-		"input": {
-			"Basic Screw": 18,
-			"Uncommon Screw": 18,
-			"Uncommon Burner": 25,
-			"Uncommon Ionic Chamber M": 1,
-			"Uncommon Reinforced Frame M": 1
-		}
-	},
-	"Safe Space Engine M": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 4090,
-		"volume": 562.4,
-		"outputQuantity": 1,
-		"time": 5760,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line M"
-		],
-		"input": {
-			"Basic Screw": 18,
-			"Uncommon Screw": 18,
-			"Uncommon Burner": 25,
-			"Uncommon Ionic Chamber M": 1,
-			"Uncommon Reinforced Frame M": 1
-		}
-	},
-	"Freight Space Engine L": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 22470,
-		"volume": 3071.4,
-		"outputQuantity": 1,
-		"time": 23040,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line L"
-		],
-		"input": {
-			"Basic Screw": 108,
-			"Uncommon Screw": 108,
-			"Uncommon Burner": 125,
-			"Uncommon Ionic Chamber L": 1,
-			"Uncommon Reinforced Frame L": 1
-		}
-	},
-	"Maneuver Space Engine L": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 22470,
-		"volume": 3071.4,
-		"outputQuantity": 1,
-		"time": 23040,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line L"
-		],
-		"input": {
-			"Basic Screw": 108,
-			"Uncommon Screw": 108,
-			"Uncommon Burner": 125,
-			"Uncommon Ionic Chamber L": 1,
-			"Uncommon Reinforced Frame L": 1
-		}
-	},
-	"Military Space Engine L": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 22470,
-		"volume": 3071.4,
-		"outputQuantity": 1,
-		"time": 23040,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line L"
-		],
-		"input": {
-			"Basic Screw": 108,
-			"Uncommon Screw": 108,
-			"Uncommon Burner": 125,
-			"Uncommon Ionic Chamber L": 1,
-			"Uncommon Reinforced Frame L": 1
-		}
-	},
-	"Safe Space Engine L": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 22470,
-		"volume": 3071.4,
-		"outputQuantity": 1,
-		"time": 23040,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line L"
-		],
-		"input": {
-			"Basic Screw": 108,
-			"Uncommon Screw": 108,
-			"Uncommon Burner": 125,
-			"Uncommon Ionic Chamber L": 1,
-			"Uncommon Reinforced Frame L": 1
-		}
-	},
-	"Freight Space Engine XL": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 126240,
-		"volume": 17150,
-		"outputQuantity": 1,
-		"time": 92160,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line XL"
-		],
-		"input": {
-			"Basic Screw": 648,
-			"Uncommon Screw": 648,
-			"Uncommon Burner": 625,
-			"Uncommon Ionic Chamber XL": 1,
-			"Uncommon Reinforced Frame XL": 1
-		}
-	},
-	"Maneuver Space Engine XL": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 126240,
-		"volume": 17150,
-		"outputQuantity": 1,
-		"time": 92160,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line XL"
-		],
-		"input": {
-			"Basic Screw": 648,
-			"Uncommon Screw": 648,
-			"Uncommon Burner": 625,
-			"Uncommon Ionic Chamber XL": 1,
-			"Uncommon Reinforced Frame XL": 1
-		}
-	},
-	"Military Space Engine XL": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 126240,
-		"volume": 17150,
-		"outputQuantity": 1,
-		"time": 92160,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line XL"
-		],
-		"input": {
-			"Basic Screw": 648,
-			"Uncommon Screw": 648,
-			"Uncommon Burner": 625,
-			"Uncommon Ionic Chamber XL": 1,
-			"Uncommon Reinforced Frame XL": 1
-		}
-	},
-	"Safe Space Engine XL": {
-		"tier": 2,
-		"type": "Space Engine",
-		"mass": 126240,
-		"volume": 17150,
-		"outputQuantity": 1,
-		"time": 92160,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line XL"
-		],
-		"input": {
-			"Basic Screw": 648,
-			"Uncommon Screw": 648,
-			"Uncommon Burner": 625,
-			"Uncommon Ionic Chamber XL": 1,
-			"Uncommon Reinforced Frame XL": 1
-		}
-	},
-	"Advanced Space Engine XS": {
-		"tier": 3,
-		"type": "Space Engine",
-		"mass": 146.23,
-		"volume": 20.33,
-		"outputQuantity": 1,
-		"time": 1080,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line XS"
-		],
-		"input": {
-			"Uncommon Screw": 1,
-			"Advanced Burner": 1,
-			"Advanced Ionic Chamber XS": 1,
-			"Advanced Reinforced Frame XS": 1
-		}
-	},
-	"Advanced Space Engine S": {
-		"tier": 3,
-		"type": "Space Engine",
-		"mass": 761.74,
-		"volume": 105.24,
-		"outputQuantity": 1,
-		"time": 4320,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line S"
-		],
-		"input": {
-			"Uncommon Screw": 6,
-			"Advanced Burner": 5,
-			"Advanced Ionic Chamber S": 1,
-			"Advanced Reinforced Frame S": 1
-		}
-	},
-	"Advanced Space Engine M": {
-		"tier": 3,
-		"type": "Space Engine",
-		"mass": 4090,
-		"volume": 562.4,
-		"outputQuantity": 1,
-		"time": 69120,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line L"
-		],
-		"input": {
-			"Uncommon Screw": 216,
-			"Advanced Burner": 125,
-			"Advanced Ionic Chamber L": 1,
-			"Advanced Reinforced Frame L": 1
-		}
-	},
-	"Advanced Space Engine XL": {
-		"tier": 3,
-		"type": "Space Engine",
-		"mass": 126240,
-		"volume": 17150,
-		"outputQuantity": 1,
-		"time": 259500,
-		"skill": "Systems",
-		"byproducts": {},
-		"industries": [
-			"Assembly Line XL"
-		],
-		"input": {
-			"Uncommon Screw": 1296,
-			"Advanced Burner": 625,
-			"Advanced Ionic Chamber XL": 1,
-			"Advanced Reinforced Frame XL": 1
 		}
 	},
 	"Repair Unit": {
@@ -16591,7 +25502,7 @@
 			"Uncommon Component": 216,
 			"Advanced Hydraulics": 125,
 			"Advanced Magnetic Rail L": 1,
-			"Advanced Anti-Matter Core Unit": 64,
+			"Advanced Antimatter Core Unit": 64,
 			"Advanced Reinforced Frame L": 1
 		}
 	},

--- a/data/recipes.json
+++ b/data/recipes.json
@@ -1,14621 +1,16656 @@
 {
-  "Bauxite":{ 
-    "tier": 1,
-    "type": "Ore",
-    "mass": 1.28,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Coal":{ 
-    "tier": 1,
-    "type": "Ore",
-    "mass": 1.35,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Quartz":{ 
-    "tier": 1,
-    "type": "Ore",
-    "mass": 2.65,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Hematite":{ 
-    "tier": 1,
-    "type": "Ore",
-    "mass": 5.04,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Chromite":{ 
-    "tier": 2,
-    "type": "Ore",
-    "mass": 7.19,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Malachite":{ 
-    "tier": 2,
-    "type": "Ore",
-    "mass": 4,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Limestone":{ 
-    "tier": 2,
-    "type": "Ore",
-    "mass": 0.968,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Natron":{ 
-    "tier": 2,
-    "type": "Ore",
-    "mass": 1.55,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Petalite":{ 
-    "tier": 3,
-    "type": "Ore",
-    "mass": 2.41,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Garnierite":{ 
-    "tier": 3,
-    "type": "Ore",
-    "mass": 2.6,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Acanthite":{ 
-    "tier": 3,
-    "type": "Ore",
-    "mass": 7.2,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Pyrite":{ 
-    "tier": 3,
-    "type": "Ore",
-    "mass": 5.01,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Cobaltite":{ 
-    "tier": 4,
-    "type": "Ore",
-    "mass": 6.33,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Cryolite":{ 
-    "tier": 4,
-    "type": "Ore",
-    "mass": 2.95,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Kolbeckite":{ 
-    "tier": 4,
-    "type": "Ore",
-    "mass": 2.37,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Gold Nuggets":{ 
-    "tier": 4,
-    "type": "Ore",
-    "mass": 19.3,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Rhodonite":{ 
-    "tier": 5,
-    "type": "Ore",
-    "mass": 3.76,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Columbite":{ 
-    "tier": 5,
-    "type": "Ore",
-    "mass": 5.38,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Illmenite":{ 
-    "tier": 5,
-    "type": "Ore",
-    "mass": 4.55,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Vanadinite":{ 
-    "tier": 5,
-    "type": "Ore",
-    "mass": 6.95,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Thoramine":{ 
-    "tier": 5,
-    "type": "Ore",
-    "mass": 21.3,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 0,
-    "skill": "",
-    "byproducts": {},
-    "industries": [],
-    "input": {}
-  },
-  "Oxygen Pure":{ 
-    "tier": 1,
-    "type": "Pure",
-    "mass": 1,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 100,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Recycler M"],
-    "input": {}
-  },
-  "Hydrogen Pure":{ 
-    "tier": 1,
-    "type": "Pure",
-    "mass": 0.07,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 100,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Recycler M"],
-    "input": {}
-  },
-  "Aluminium Pure":{ 
-    "tier": 1,
-    "type": "Pure",
-    "mass": 2.7,
-    "volume": 1,
-    "outputQuantity": 405,
-    "time": 225,
-    "skill": "",
-    "byproducts": {"Hydrogen Pure":135},
-    "industries": ["Nanopack","Refiner M"],
-    "input": {
-      "Bauxite": 585
-    }
-  },
-  "Carbon Pure":{ 
-    "tier": 1,
-    "type": "Pure",
-    "mass": 2.27,
-    "volume": 1,
-    "outputQuantity": 405,
-    "time": 225,
-    "skill": "",
-    "byproducts": {"Oxygen Pure":67.5,"Hydrogen Pure":67.5},
-    "industries": ["Nanopack","Refiner M"],
-    "input": {
-      "Coal": 585
-    }
-  },
-  "Silicon Pure":{ 
-    "tier": 1,
-    "type": "Pure",
-    "mass": 2.33,
-    "volume": 1,
-    "outputQuantity": 405,
-    "time": 225,
-    "skill": "",
-    "byproducts": {"Oxygen Pure":135},
-    "industries": ["Nanopack","Refiner M"],
-    "input": {
-      "Quartz": 585
-    }
-  },
-  "Iron Pure":{ 
-    "tier": 1,
-    "type": "Pure",
-    "mass": 7.85,
-    "volume": 1,
-    "outputQuantity": 405,
-    "time": 225,
-    "skill": "",
-    "byproducts": {"Oxygen Pure":135},
-    "industries": ["Nanopack","Refiner M"],
-    "input": {
-      "Hematite": 585
-    }
-  },
-  "Calcium Pure":{ 
-    "tier": 2,
-    "type": "Pure",
-    "mass": 1.55,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 120,
-    "skill": "",
-    "byproducts": {"Oxygen Pure":7.5, "Carbon Pure":7.5},
-    "industries": ["Refiner M"],
-    "input": {
-      "Limestone": 65
-    }
-  },
-  "Chromium Pure":{ 
-    "tier": 2,
-    "type": "Pure",
-    "mass": 7.19,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 120,
-    "skill": "",
-    "byproducts": {"Oxygen Pure":7.5,"Iron Pure":7.5},
-    "industries": ["Refiner M"],
-    "input": {
-      "Chromite": 65
-    }
-  },
-  "Copper Pure":{ 
-    "tier": 2,
-    "type": "Pure",
-    "mass": 8.96,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 120,
-    "skill": "",
-    "byproducts": {"Hydrogen Pure":7.5,"Carbon Pure":7.5},
-    "industries": ["Refiner M"],
-    "input": {
-      "Malachite": 65
-    }
-  },
-  "Sodium Pure":{ 
-    "tier": 2,
-    "type": "Pure",
-    "mass": 0.97,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 120,
-    "skill": "",
-    "byproducts": {"Hydrogen Pure":7.5,"Carbon Pure":7.5},
-    "industries": ["Refiner M"],
-    "input": {
-      "Natron": 65
-    }
-  },
-  "Lithium Pure":{ 
-    "tier": 3,
-    "type": "Pure",
-    "mass": 0.53,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 600,
-    "skill": "",
-    "byproducts": {"Silicon Pure":7.5,"Aluminium Pure":7.5},
-    "industries": ["Refiner M"],
-    "input": {
-      "Petalite": 65
-    }
-  },
-  "Nickel Pure":{ 
-    "tier": 3,
-    "type": "Pure",
-    "mass": 8.91,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 600,
-    "skill": "",
-    "byproducts": {"Oxygen Pure":7.5,"Silicon Pure":7.5},
-    "industries": ["Refiner M"],
-    "input": {
-      "Garnierite": 65
-    }
-  },
-  "Silver Pure":{ 
-    "tier": 3,
-    "type": "Pure",
-    "mass": 10.49,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 600,
-    "skill": "",
-    "byproducts": {"Sulfur Pure":15},
-    "industries": ["Refiner M"],
-    "input": {
-      "Acanthite": 65
-    }
-  },
-  "Sulfur Pure":{ 
-    "tier": 3,
-    "type": "Pure",
-    "mass": 1.82,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 600,
-    "skill": "",
-    "byproducts": {"Iron Pure":15},
-    "industries": ["Refiner M"],
-    "input": {
-      "Pyrite": 65
-    }
-  },
-  "Cobalt Pure":{ 
-    "tier": 4,
-    "type": "Pure",
-    "mass": 8.9,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 3120,
-    "skill": "",
-    "byproducts": {"Sulfur Pure":15},
-    "industries": ["Refiner M"],
-    "input": {
-      "Cobaltite": 65
-    }
-  },
-  "Fluorine Pure":{ 
-    "tier": 4,
-    "type": "Pure",
-    "mass": 1.7,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 3120,
-    "skill": "",
-    "byproducts": {"Sodium Pure":7.5, "Aluminium Pure":7.5},
-    "industries": ["Refiner M"],
-    "input": {
-      "Cryolite": 65
-    }
-  },
-  "Gold Pure":{ 
-    "tier": 4,
-    "type": "Pure",
-    "mass": 19.3,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 3120,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Refiner M"],
-    "input": {
-      "Gold Nuggets": 65
-    }
-  },
-  "Scandium Pure":{ 
-    "tier": 4,
-    "type": "Pure",
-    "mass": 2.98,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 3120,
-    "skill": "",
-    "byproducts": {"Oxygen Pure":7.5,"Hydrogen Pure":7.5},
-    "industries": ["Refiner M"],
-    "input": {
-      "Kolbeckite": 65
-    }
-  },
-  "Manganese Pure":{ 
-    "tier": 5,
-    "type": "Pure",
-    "mass": 7.21,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 14400,
-    "skill": "",
-    "byproducts": {"Calcium Pure":5,"Silicon Pure":5,"Oxygen Pure":5},
-    "industries": ["Refiner M"],
-    "input": {
-      "Rhodonite": 65
-    }
-  },
-  "Niobium Pure":{ 
-    "tier": 5,
-    "type": "Pure",
-    "mass": 8.57,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 14400,
-    "skill": "",
-    "byproducts": {"Iron Pure":5,"Manganese Pure":5,"Oxygen Pure":5},
-    "industries": ["Refiner M"],
-    "input": {
-      "Columbite": 65
-    }
-  },
-  "Titanium Pure":{ 
-    "tier": 5,
-    "type": "Pure",
-    "mass": 4.51,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 14400,
-    "skill": "",
-    "byproducts": {"Iron Pure":7.5,"Oxygen Pure":7.5},
-    "industries": ["Refiner M"],
-    "input": {
-      "Illmenite": 65
-    }
-  },
-  "Vanadium Pure":{ 
-    "tier": 5,
-    "type": "Pure",
-    "mass": 6,
-    "volume": 1,
-    "outputQuantity": 45,
-    "time": 14400,
-    "skill": "",
-    "byproducts": {"Oxygen Pure":15},
-    "industries": ["Refiner M"],
-    "input": {
-      "Vanadinite": 65
-    }
-  },
-  "Catalyst 3":{ 
-    "tier": 3,
-    "type": "Catalyst",
-    "mass": 649.39,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 2500,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Chemical Industry M"],
-    "input": {
-	  "Hydrogen Pure": 300,
-      "Iron Pure": 200,
-      "Sodium Pure": 100,
-      "Sulfur Pure": 50
-    }
-  },
-  "Catalyst 4":{ 
-    "tier": 4,
-    "type": "Catalyst",
-    "mass": 606.65,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 12480,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Chemical Industry M"],
-    "input": {
-	  "Hydrogen Pure": 300,
-      "Iron Pure": 500,
-      "Sodium Pure": 200,
-      "Sulfur Pure": 100,
-      "Fluorine Pure": 50
-    }
-  },
-  "Catalyst 5":{ 
-    "tier": 5,
-    "type": "Catalyst",
-    "mass": 657.68,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 62520,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Chemical Industry M"],
-    "input": {
-	  "Hydrogen Pure": 300,
-      "Iron Pure": 1000,
-      "Sodium Pure": 500,
-      "Sulfur Pure": 200,
-      "Fluorine Pure": 100,
-      "Manganese Pure": 50
-    }
-  },
-  "Nitron Fuel":{ 
-    "tier": 1,
-    "type": "Fuel",
-    "mass": 4,
-    "volume": 1,
-    "outputQuantity": 100,
-    "time": 20,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Chemical Industry M"],
-    "input": {
-      "Silicon Pure": 20,
-      "Carbon Pure": 20,
-      "Oxygen Pure": 40,
-      "Hydrogen Pure": 20
-    }
-  },
-  "Kergon-X1 Fuel":{ 
-    "tier": 1,
-    "type": "Fuel",
-    "mass": 6,
-    "volume": 1,
-    "outputQuantity": 100,
-    "time": 40,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Chemical Industry M"],
-    "input": {
-      "Sodium Pure": 40,
-      "Oxygen Pure": 30,
-      "Hydrogen Pure": 30
-    }
-  },
-  "Kergon-X2 Fuel":{ 
-    "tier": 1,
-    "type": "Fuel",
-    "mass": 6,
-    "volume": 1,
-    "outputQuantity": 100,
-    "time": 40,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Chemical Industry M"],
-    "input": {
-      "Calcium Pure": 40,
-      "Oxygen Pure": 25,
-      "Hydrogen Pure": 35
-    }
-  },
-  "Kergon-X3 Fuel":{ 
-    "tier": 1,
-    "type": "Fuel",
-    "mass": 6,
-    "volume": 1,
-    "outputQuantity": 100,
-    "time": 40,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Chemical Industry M"],
-    "input": {
-      "Chromium Pure": 40,
-      "Oxygen Pure": 35,
-      "Hydrogen Pure": 25
-    }
-  },
-  "Kergon-X4 Fuel":{ 
-    "tier": 1,
-    "type": "Fuel",
-    "mass": 6,
-    "volume": 1,
-    "outputQuantity": 100,
-    "time": 40,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Chemical Industry M"],
-    "input": {
-      "Copper Pure": 40,
-      "Oxygen Pure": 30,
-      "Hydrogen Pure": 30
-    }
-  },
-  "Xeron Fuel":{ 
-    "tier": 2,
-    "type": "Fuel",
-    "mass": 0.8,
-    "volume": 1,
-    "outputQuantity": 100,
-    "time": 60,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Chemical Industry M"],
-    "input": {
-      "Chromium Pure": 10,
-      "Sodium Pure": 10,
-      "Hydrogen Pure": 60,
-      "Oxygen Pure": 20
-    }
-  },
-  "Al-Fe Alloy":{ 
-    "tier": 1,
-    "type": "Product",
-    "mass": 7.5,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 150,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Smelter M"],
-    "input": {
-      "Aluminium Pure": 100,
-      "Iron Pure": 50
-    }
-  },
-  "Al-Li Alloy":{ 
-    "tier": 3,
-    "type": "Product",
-    "mass": 2.5,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 3780,
-    "skill": "",
-    "byproducts": {"Catalyst 3":1},
-    "industries": ["Smelter M"],
-    "input": {
-      "Lithium Pure": 100,
-      "Aluminium Pure": 50,
-      "Catalyst 3": 1
-    }
-  },
-  "Calcium Reinforced Copper":{ 
-    "tier": 2,
-    "type": "Product",
-    "mass": 8.1,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 750,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Smelter M"],
-    "input": {
-      "Copper Pure": 100,
-      "Calcium Pure": 50
-    }
-  },
-  "Cu-Ag Alloy":{ 
-    "tier": 3,
-    "type": "Product",
-    "mass": 9.2,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 3780,
-    "skill": "",
-    "byproducts": {"Catalyst 3":1},
-    "industries": ["Smelter M"],
-    "input": {
-      "Silver Pure": 100,
-      "Copper Pure": 50,
-      "Catalyst 3": 1
-    }
-  },
-  "Duralumin":{ 
-    "tier": 2,
-    "type": "Product",
-    "mass": 2.8,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 750,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Smelter M"],
-    "input": {
-      "Copper Pure": 100,
-      "Aluminium Pure": 50
-    }
-  },
-  "Grade 5 Titanium Alloy":{ 
-    "tier": 5,
-    "type": "Product",
-    "mass": 4.43,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 93780,
-    "skill": "",
-    "byproducts": {"Catalyst 5":1},
-    "industries": ["Smelter M"],
-    "input": {
-      "Titanium Pure": 100,
-      "Vanadium Pure": 50,
-      "Aluminium Pure": 50,
-      "Catalyst 5": 1
-    }
-  },
-  "Inconel":{ 
-    "tier": 3,
-    "type": "Product",
-    "mass": 8.5,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 3780,
-    "skill": "",
-    "byproducts": {"Catalyst 3":1},
-    "industries": ["Smelter M"],
-    "input": {
-      "Nickel Pure": 100,
-      "Chromium Pure": 50,
-      "Iron Pure": 50,
-      "Catalyst 3": 1
-    }
-  },
-  "Mangalloy":{ 
-    "tier": 5,
-    "type": "Product",
-    "mass": 7.83,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 93780,
-    "skill": "",
-    "byproducts": {"Catalyst 5":1},
-    "industries": ["Smelter M"],
-    "input": {
-      "Manganese Pure": 100,
-      "Niobium Pure": 50,
-      "Iron Pure": 50,
-      "Catalyst 5": 1
-    }
-  },
-  "Maraging Steel":{ 
-    "tier": 4,
-    "type": "Product",
-    "mass": 8.23,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 18780,
-    "skill": "",
-    "byproducts": {"Catalyst 4":1},
-    "industries": ["Smelter M"],
-    "input": {
-      "Cobalt Pure": 100,
-      "Nickel Pure": 50,
-      "Iron Pure": 50,
-      "Catalyst 4": 1
-    }
-  },
-  "Red Gold":{ 
-    "tier": 4,
-    "type": "Product",
-    "mass": 14.13,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 18780,
-    "skill": "",
-    "byproducts": {"Catalyst 4":1},
-    "industries": ["Smelter M"],
-    "input": {
-      "Gold Pure": 100,
-      "Copper Pure": 50,
-      "Catalyst 4": 1
-    }
-  },
-  "Sc-Al Alloy":{ 
-    "tier": 4,
-    "type": "Product",
-    "mass": 2.85,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 18780,
-    "skill": "",
-    "byproducts": {"Catalyst 4":1},
-    "industries": ["Smelter M"],
-    "input": {
-      "Scandium Pure": 100,
-      "Aluminium Pure": 50,
-      "Lithium Pure": 50,
-      "Catalyst 4": 1
-    }
-  },
-  "Stainless Steel":{ 
-    "tier":2,
-    "type": "Product",
-    "mass": 7.75,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 750,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Smelter M"],
-    "input": {
-      "Chromium Pure": 100,
-      "Iron Pure": 50,
-      "Carbon Pure": 50
-    }
-  },
-  "Ti-Nb Supraconductor":{ 
-    "tier": 5,
-    "type": "Product",
-    "mass": 10.1,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 93780,
-    "skill": "",
-    "byproducts": {"Catalyst 5":1},
-    "industries": ["Smelter M"],
-    "input": {
-      "Niobium Pure": 100,
-      "Titanium Pure": 50,
-      "Catalyst 5": 1
-    }
-  },
-  "Biological Matter":{ 
-    "tier": 1,
-    "type": "Product",
-    "mass": 1,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 150,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Chemical Industry M"],
-    "input": {
-      "Carbon Pure": 100,
-      "Oxygen Pure": 50,
-      "Hydrogen Pure": 50
-    }
-  },
-  "Brick":{ 
-    "tier": 1,
-    "type": "Product",
-    "mass": 1.92,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 150,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Smelter M"],
-    "input": {
-      "Silicon Pure": 50,
-      "Aluminium Pure": 50,
-	    "Oxygen Pure": 50
-    }
-  },
-  "Marble":{ 
-    "tier": 2,
-    "type": "Product",
-    "mass": 2.7,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 750,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Refiner M"],
-    "input": {
-      "Calcium Pure": 50,
-      "Carbon Pure": 50,
-      "Oxygen Pure": 50
-    }
-  },
-  "Concrete":{ 
-    "tier": 2,
-    "type": "Product",
-    "mass": 2.41,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 750,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Refiner M"],
-    "input": {
-      "Calcium Pure": 5,
-      "Carbon Pure": 37.5,
-      "Silicon Pure": 37.5
-    }
-  },
-  "Carbon Fiber":{ 
-    "tier": 1,
-    "type": "Product",
-    "mass": 1.5,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 150,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 50,
-      "Carbon Pure": 50
-    }
-  },
-  "Glass":{ 
-    "tier": 1,
-    "type": "Product",
-    "mass": 2.5,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 150,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Glass Furnace M"],
-    "input": {
-      "Silicon Pure": 100,
-      "Oxygen Pure": 50
-    }
-  },
-  "Advanced Glass":{ 
-    "tier": 2,
-    "type": "Product",
-    "mass": 2.6,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 750,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Sodium Pure": 100,
-      "Calcium Pure": 50,
-      "Silicon Pure": 50,
-      "Oxygen Pure": 50
-    }
-  },
-  "Ag-Li Reinforced Glass":{ 
-    "tier": 3,
-    "type": "Product",
-    "mass": 2.8,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 3750,
-    "skill": "",
-    "byproducts": {"Catalyst 3":1},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Silver Pure": 100,
-      "Lithium Pure": 50,
-      "Silicon Pure": 50,
-      "Oxygen Pure": 50,
-      "Catalyst 3": 1
-    }
-  },
-  "Gold Coated Glass":{ 
-    "tier": 4,
-    "type": "Product",
-    "mass": 3,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 18780,
-    "skill": "",
-    "byproducts": {"Catalyst 4":1},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Gold Pure": 100,
-      "Silicon Pure": 50,
-      "Sodium Pure": 50,
-      "Oxygen Pure": 50,
-      "Catalyst 4": 1
-    }
-  },
-  "Manganese Reinforced Glass":{ 
-    "tier": 5,
-    "type": "Product",
-    "mass": 2.9,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 93780,
-    "skill": "",
-    "byproducts": {"Catalyst 5":1},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Manganese Pure": 100,
-      "Calcium Pure": 50,
-      "Silicon Pure": 50,
-      "Oxygen Pure": 50,
-      "Catalyst 5": 1
-    }
-  },
-  "Polycarbonate Plastic":{ 
-    "tier": 1,
-    "type": "Product",
-    "mass": 1.4,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 150,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Chemical Industry M"],
-    "input": {
-      "Carbon Pure": 100,
-      "Hydrogen Pure": 50
-    }
-  },
-  "Polycalcite Plastic":{ 
-    "tier": 2,
-    "type": "Product",
-    "mass": 1.5,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 750,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Chemical Industry M"],
-    "input": {
-      "Calcium Pure": 100,
-      "Carbon Pure": 50,
-      "Hydrogen Pure": 50
-    }
-  },
-  "Polysulfide Plastic":{ 
-    "tier": 3,	
-    "type": "Product",
-    "mass": 1.6,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 3750,
-    "skill": "",
-    "byproducts": {"Catalyst 3":1},
-    "industries": ["Chemical Industry M"],
-    "input": {
-      "Sulfur Pure": 100,
-      "Carbon Pure": 50,
-      "Hydrogen Pure": 50,
-      "Catalyst 3": 1
-    }
-  },
-  "Fluoropolymer":{ 
-    "tier": 4,
-    "type": "Product",
-    "mass": 1.65,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 18780,
-    "skill": "",
-    "byproducts": {"Catalyst 4":1},
-    "industries": ["Chemical Industry M"],
-    "input": {
-      "Fluorine Pure": 100,
-      "Carbon Pure": 50,
-      "Hydrogen Pure": 50,
-      "Catalyst 4": 1
-    }
-  },
-  "Vanamer":{ 
-    "tier": 5,
-    "type": "Product",
-    "mass": 1.57,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 93780,
-    "skill": "",
-    "byproducts": {"Catalyst 5":1},
-    "industries": ["Chemical Industry M"],
-    "input": {
-      "Vanadium Pure": 100,
-      "Sulfur Pure": 50,
-      "Carbon Pure": 50,
-      "Hydrogen Pure": 50,
-      "Catalyst 5": 1
-    }
-  },
-  "Silumin":{ 
-    "tier": 1,
-    "type": "Product",
-    "mass": 3,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 150,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Smelter M"],
-    "input": {
-      "Aluminium Pure": 100,
-      "Silicon Pure": 50
-    }
-  },
-  "Steel":{ 
-    "tier": 1,
-    "type": "Product",
-    "mass": 8.05,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 150,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Smelter M"],
-    "input": {
-      "Iron Pure": 100,
-      "Carbon Pure": 50
-    }
-  },
-  "Wood":{ 
-    "tier": 1,
-    "type": "Product",
-    "mass": 0.6,
-    "volume": 1,
-    "outputQuantity": 75,
-    "time": 150,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Refiner M"],
-    "input": {
-      "Carbon Pure": 50,
-      "Oxygen Pure": 50
-    }
-  },
-  "Basic Component":{ 
-    "tier": 1,
-    "type": "Intermediary Part",
-    "mass": 2.25,
-    "volume": 0.5,
-    "outputQuantity": 20,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 20
-    }
-  },
-  "Uncommon Component":{ 
-    "tier": 2,
-    "type": "Intermediary Part",
-    "mass": 2.34,
-    "volume": 0.5,
-    "outputQuantity": 10,
-    "time": 480,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 5,
-      "Calcium Reinforced Copper": 5
-    }
-  },
-  "Advanced Component":{ 
-    "tier": 3,
-    "type": "Intermediary Part",
-    "mass": 2.51,
-    "volume": 0.5,
-    "outputQuantity": 10,
-    "time": 1920,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 3,
-      "Calcium Reinforced Copper": 3,
-      "Cu-Ag Alloy": 4
-    }
-  },
-  "Basic Connector":{ 
-    "tier": 1,
-    "type": "Intermediary Part",
-    "mass": 3.75,
-    "volume": 0.8,
-    "outputQuantity": 20,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 20
-    }
-  },
-  "Uncommon Connector":{ 
-    "tier": 2,
-    "type": "Intermediary Part",
-    "mass": 3.9,
-    "volume": 0.8,
-    "outputQuantity": 10,
-    "time": 480,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 5,
-      "Calcium Reinforced Copper": 5
-    }
-  },
-  "Advanced Connector":{ 
-    "tier": 3,
-    "type": "Intermediary Part",
-    "mass": 4.18,
-    "volume": 0.8,
-    "outputQuantity": 10,
-    "time": 1920,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 3,
-      "Calcium Reinforced Copper": 3,
-      "Cu-Ag Alloy": 4
-    }
-  },
-  "Basic Fixation":{ 
-    "tier": 1,
-    "type": "Intermediary Part",
-    "mass": 1.12,
-    "volume": 1,
-    "outputQuantity": 10,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 10
-    }
-  },
-  "Uncommon Fixation":{ 
-    "tier": 2,
-    "type": "Intermediary Part",
-    "mass": 1.16,
-    "volume": 1,
-    "outputQuantity": 10,
-    "time": 120,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 5,
-      "Polycalcite Plastic": 5
-    }
-  },
-  "Advanced Fixation":{ 
-    "tier":3,
-    "type": "Intermediary Part",
-    "mass": 1.21,
-    "volume": 1,
-    "outputQuantity": 10,
-    "time": 1920,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 5,
-      "Polycalcite Plastic": 5,
-      "Polysulfide Plastic": 5
-    }
-  },
-  "Basic LED":{ 
-    "tier": 1,
-    "type": "Intermediary Part",
-    "mass": 1.25,
-    "volume": 1,
-    "outputQuantity": 10,
-    "time": 120,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Glass Furnace M"],
-    "input": {
-      "Glass": 10
-    }
-  },
-  "Uncommon LED":{ 
-    "tier": 2,
-    "type": "Intermediary Part",
-    "mass": 1.27,
-    "volume": 1,
-    "outputQuantity": 10,
-    "time": 480,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Glass": 5,
-      "Advanced Glass": 5
-    }
-  },
-  "Advanced LED":{ 
-    "tier": 3,
-    "type": "Intermediary Part",
-    "mass": 1.32,
-    "volume": 1,
-    "outputQuantity": 10,
-    "time": 1920,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Glass": 3,
-      "Advanced Glass": 3,
-      "Ag-Li Reinforced Glass": 4
-    }
-  },
-  "Basic Pipe":{ 
-    "tier": 1,
-    "type": "Intermediary Part",
-    "mass": 2.4,
-    "volume": 1,
-    "outputQuantity": 20,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 20
-    }
-  },
-  "Uncommon Pipe":{ 
-    "tier": 2,
-    "type": "Intermediary Part",
-    "mass": 2.32,
-    "volume": 1,
-    "outputQuantity": 10,
-    "time": 480,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 5,
-      "Duralumin": 5
-    }
-  },
-  "Advanced Pipe":{ 
-    "tier": 3,
-    "type": "Intermediary Part",
-    "mass": 2.19,
-    "volume": 1,
-    "outputQuantity": 10,
-    "time": 1920,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 3,
-      "Duralumin": 3,
-      "Al-Li Alloy": 4
-    }
-  },
-  "Basic Screw":{ 
-    "tier": 1,
-    "type": "Intermediary Part",
-    "mass": 8.05,
-    "volume": 1,
-    "outputQuantity": 20,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 20
-    }
-  },
-  "Uncommon Screw":{ 
-    "tier": 2,
-    "type": "Intermediary Part",
-    "mass": 7.9,
-    "volume": 1,
-    "outputQuantity": 10,
-    "time": 480,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 5,
-      "Stainless Steel": 5
-    }
-  },
-  "Advanced Screw":{ 
-    "tier": 3,
-    "type": "Intermediary Part",
-    "mass": 8.14,
-    "volume": 1,
-    "outputQuantity": 10,
-    "time": 1920,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 3,
-      "Stainless Steel": 3,
-      "Inconel": 4
-    }
-  },
-  "Basic Anti-Matter Capsule":{ 
-    "tier": 1,
-    "type": "Complex Part",
-    "mass": 24,
-    "volume": 4.6,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Glass Furnace M"],
-    "input": {
-      "Glass": 6,
-      "Basic Connector": 4
-    }
-  },
-  "Uncommon Anti-Matter Capsule":{ 
-    "tier": 2,
-    "type": "Complex Part",
-    "mass": 24.32,
-    "volume": 4.6,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Glass": 2,
-      "Basic Connector": 4,
-      "Advanced Glass": 4
-    }
-  },
-  "Advanced Anti-Matter Capsule":{ 
-    "tier": 3,
-    "type": "Complex Part",
-    "mass": 24.88,
-    "volume": 4.6,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Glass": 2,
-      "Basic Connector": 2,
-      "Advanced Glass": 2,
-      "Uncommon Connector": 2,
-      "Ag-Li Reinforced Glass": 2
-    }
-  },
-  "Rare Anti-Matter Capsule":{ 
-    "tier": 4,
-    "type": "Complex Part",
-    "mass": 25.8,
-    "volume": 4.6,
-    "outputQuantity": 1,
-    "time": 3840,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Basic Connector": 1,
-      "Advanced Glass": 2,
-      "Uncommon Connector": 3,
-      "Ag-Li Reinforced Glass": 2,
-      "Gold Coated Glass": 2
-    }
-  },
-  "Exotic Anti-Matter Capsule":{ 
-    "tier": 5,
-    "type": "Complex Part",
-    "mass": 26.73,
-    "volume": 4.6,
-    "outputQuantity": 1,
-    "time": 15360,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Basic Connector": 1,
-      "Uncommon Connector": 1,
-      "Ag-Li Reinforced Glass": 2,
-      "Advanced Connector": 2,
-      "Gold Coated Glass": 2,
-      "Manganese Reinforced Glass": 2
-    }
-  },
-  "Basic Burner":{ 
-    "tier": 1,
-    "type": "Complex Part",
-    "mass": 50.2,
-    "volume": 10,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 18,
-      "Basic Screw": 12
-    }
-  },
-  "Uncommon Burner":{ 
-    "tier": 2,
-    "type": "Complex Part",
-    "mass":49.4,
-    "volume": 10,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 2,
-      "Basic Screw": 4,
-      "Duralumin": 4
-    }
-  },
-  "Advanced Burner":{ 
-    "tier": 3,
-    "type": "Complex Part",
-    "mass":48.5,
-    "volume": 10,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 2,
-      "Basic Screw": 2,
-      "Duralumin": 2,
-      "Uncommon Screw": 2,
-      "Al-Li Alloy": 2
-    }
-  },
-  "Basic Electronics":{ 
-    "tier": 1,
-    "type": "Complex Part",
-    "mass": 5.22,
-    "volume": 4,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Electronics Industry M"],
-    "input": {
-      "Polycarbonate Plastic": 18,
-      "Basic Component": 12
-    }
-  },
-  "Uncommon Electronics":{ 
-    "tier": 2,
-    "type": "Complex Part",
-    "mass": 5.34,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Polycarbonate Plastic": 2,
-      "Basic Component": 4,
-      "Polycalcite Plastic": 4
-    }
-  },
-  "Advanced Electronics":{ 
-    "tier": 3,
-    "type": "Complex Part",
-    "mass": 5.45,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Polycarbonate Plastic": 2,
-      "Basic Component": 2,
-      "Polycalcite Plastic": 2,
-      "Uncommon Component": 2,
-      "Polysulfide Plastic": 2
-    }
-  },
-  "Rare Electronics":{ 
-    "tier": 4,
-    "type": "Complex Part",
-    "mass": 5.63,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 3840,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Component": 1,
-      "Polycalcite Plastic": 2,
-      "Uncommon Component": 3,
-      "Polysulfide Plastic": 2,
-      "Fluoropolymer": 2
-    }
-  },
-  "Exotic Electronics":{ 
-    "tier": 5,
-    "type": "Complex Part",
-    "mass": 5.77,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 15360,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Polysulfide Plastic": 2,
-      "Advanced Component": 2,
-      "Fluoropolymer": 2,
-      "Vanamer": 2
-    }
-  },
-  "Basic Explosive Module":{ 
-    "tier": 1,
-    "type": "Complex Part",
-    "mass": 18.72,
-    "volume": 4.6,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Chemical Industry M"],
-    "input": {
-      "Polycarbonate Plastic": 6,
-      "Basic Connector": 4
-    }
-  },
-  "Uncommon Explosive Module":{ 
-    "tier": 2,
-    "type": "Complex Part",
-    "mass": 19.04,
-    "volume": 4.6,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Chemical Industry M"],
-    "input": {
-      "Polycarbonate Plastic": 2,
-      "Basic Connector": 4,
-      "Polycalcite Plastic": 4
-    }
-  },
-  "Advanced Explosive Module":{ 
-    "tier": 3,
-    "type": "Complex Part",
-    "mass": 19.04,
-    "volume": 4.6,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Chemical Industry M"],
-    "input": {
-      "Polycarbonate Plastic": 2,
-      "Basic Connector": 2,
-      "Polycalcite Plastic": 2,
-      "Uncommon Connector": 2,
-      "Polysulfide Plastic": 2
-    }
-  },
-  "Basic Hydraulics":{ 
-    "tier": 1,
-    "type": "Complex Part",
-    "mass": 28.95,
-    "volume": 10,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 18,
-      "Basic Pipe": 12
-    }
-  },
-  "Uncommon Hydraulics":{ 
-    "tier": 2,
-    "type": "Complex Part",
-    "mass": 28.35,
-    "volume": 10,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 2,
-      "Basic Pipe": 4,
-      "Stainless Steel": 4
-    }
-  },
-  "Advanced Hydraulics":{ 
-    "tier": 3,
-    "type": "Complex Part",
-    "mass": 29.02,
-    "volume": 10,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 2,
-      "Basic Pipe": 2,
-      "Stainless Steel": 2,
-      "Uncommon Pipe": 2,
-      "Inconel": 2
-    }
-  },
-  "Basic Injector":{ 
-    "tier": 1,
-    "type": "Complex Part",
-    "mass": 20.3,
-    "volume": 10,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 6,
-      "Basic Screw": 4
-    }
-  },
-  "Uncommon Injector":{ 
-    "tier": 2,
-    "type": "Complex Part",
-    "mass": 20.5,
-    "volume": 10,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 2,
-      "Polycalcite Plastic": 4,
-      "Basic Screw": 4
-    }
-  },
-  "Advanced Injector":{ 
-    "tier": 3,
-    "type": "Complex Part",
-    "mass": 20.45,
-    "volume": 10,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 2,
-      "Basic Screw": 2,
-      "Polycalcite Plastic": 2,
-      "Uncommon Screw": 4,
-      "Polysulfide Plastic": 2
-    }
-  },
-  "Basic Magnet":{ 
-    "tier": 1,
-    "type": "Complex Part",
-    "mass": 63.3,
-    "volume": 7.36,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 18,
-      "Basic Connector": 12
-    }
-  },
-  "Uncommon Magnet":{ 
-    "tier": 2,
-    "type": "Complex Part",
-    "mass": 62.1,
-    "volume": 7.36,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 2,
-      "Basic Connector": 4,
-      "Stainless Steel": 4
-    }
-  },
-  "Advanced Magnet":{ 
-    "tier": 3,
-    "type": "Complex Part",
-    "mass": 63.89,
-    "volume": 7.36,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 2,
-      "Basic Connector": 2,
-      "Stainless Steel": 2,
-      "Uncommon Connector": 2,
-      "Inconel": 2
-    }
-  },
-  "Rare Magnet":{ 
-    "tier": 4,
-    "type": "Complex Part",
-    "mass": 64.4,
-    "volume": 7.36,
-    "outputQuantity": 1,
-    "time": 3840,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Connector": 1,
-      "Stainless Steel": 2,
-      "Uncommon Connector": 3,
-      "Inconel": 2,
-      "Maraging Steel": 2
-    }
-  },
-  "Exotic Magnet":{ 
-    "tier": 5,
-    "type": "Complex Part",
-    "mass": 65.13,
-    "volume": 7.36,
-    "outputQuantity": 1,
-    "time": 15360,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Connector": 1,
-      "Uncommon Connector": 1,
-      "Inconel": 2,
-      "Advanced Connector": 2,
-      "Maraging Steel": 2,
-      "Mangalloy": 2
-    }
-  },
-  "Basic Optics":{ 
-    "tier": 1,
-    "type": "Complex Part",
-    "mass": 9.74,
-    "volume": 10,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Glass Furnace M"],
-    "input": {
-      "Glass": 6,
-      "Basic Fixation": 4
-    }
-  },
-  "Uncommon Optics":{ 
-    "tier": 2,
-    "type": "Complex Part",
-    "mass": 9.94,
-    "volume": 10,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Glass": 2,
-      "Basic Fixation": 4,
-      "Advanced Glass": 4
-    }
-  },
-  "Advanced Optics":{ 
-    "tier": 3,
-    "type": "Complex Part",
-    "mass": 10.18,
-    "volume": 10,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Glass": 2,
-      "Basic Fixation": 2,
-      "Advanced Glass": 2,
-      "Uncommon Fixation": 2,
-      "Ag-Li Reinforced Glass": 2
-    }
-  },
-  "Rare Optics":{ 
-    "tier": 4,
-    "type": "Complex Part",
-    "mass": 10.7,
-    "volume": 10,
-    "outputQuantity": 1,
-    "time": 3840,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Basic Fixation": 1,
-      "Advanced Glass": 2,
-      "Uncommon Fixation": 3,
-      "Ag-Li Reinforced Glass": 2,
-      "Gold Coated Glass": 2
-    }
-  },
-  "Basic Power System":{ 
-    "tier": 1,
-    "type": "Complex Part",
-    "mass": 60,
-    "volume": 9.2,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 18,
-      "Basic Connector": 12
-    }
-  },
-  "Uncommon Power System":{ 
-    "tier": 2,
-    "type": "Complex Part",
-    "mass": 62.4,
-    "volume": 9.2,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 2,
-      "Basic Connector": 4,
-      "Calcium Reinforced Copper": 4
-    }
-  },
-  "Advanced Power System":{ 
-    "tier": 3,
-    "type": "Complex Part",
-    "mass": 64.9,
-    "volume": 9.2,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 2,
-      "Basic Connector": 2,
-      "Calcium Reinforced Copper": 2,
-      "Uncommon Connector": 2,
-      "Cu-Ag Alloy": 2
-    }
-  },
-  "Rare Power System":{ 
-    "tier": 4,
-    "type": "Complex Part",
-    "mass": 78.31,
-    "volume": 9.2,
-    "outputQuantity": 1,
-    "time": 3840,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Connector": 1,
-      "Calcium Reinforced Copper": 2,
-      "Uncommon Connector": 3,
-      "Cu-Ag Alloy": 2,
-      "Red Gold": 2
-    }
-  },
-  "Exotic Power System":{ 
-    "tier": 5,
-    "type": "Complex Part",
-    "mass": 82.87,
-    "volume": 9.2,
-    "outputQuantity": 1,
-    "time": 15360,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Connector": 1,
-      "Uncommon Connector": 1,
-      "Cu-Ag Alloy": 2,
-      "Advanced Connector": 2,
-      "Red Gold": 2,
-      "Ti-Nb Supraconductor": 2
-    }
-  },
-  "Basic Processor":{ 
-    "tier": 1,
-    "type": "Complex Part",
-    "mass": 14.84,
-    "volume": 5,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 18,
-      "Basic Fixation": 12
-    }
-  },
-  "Uncommon Processor":{ 
-    "tier": 2,
-    "type": "Complex Part",
-    "mass": 15.56,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 2,
-      "Basic Fixation": 4,
-      "Calcium Reinforced Copper": 4
-    }
-  },
-  "Advanced Processor":{ 
-    "tier": 3,
-    "type": "Complex Part",
-    "mass": 16.25,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 2,
-      "Basic Fixation": 2,
-      "Calcium Reinforced Copper": 2,
-      "Uncommon Fixation": 2,
-      "Cu-Ag Alloy": 2
-    }
-  },
-  "Exotic Processor":{ 
-    "tier": 5,
-    "type": "Complex Part",
-    "mass": 21.47,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 15360,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Fixation": 1,
-      "Uncommon Fixation": 1,
-      "Cu-Ag Alloy": 2,
-      "Advanced Fixation": 2,
-      "Red Gold": 2,
-      "Ti-Nb Supraconductor": 2
-    }
-  },
-  "Basic Quantum Core":{ 
-    "tier": 1,
-    "type": "Complex Part",
-    "mass": 10.72,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 6,
-      "Basic LED": 4
-    }
-  },
-  "Uncommon Quantum Core":{ 
-    "tier": 2,
-    "type": "Complex Part",
-    "mass": 11.04,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 2,
-      "Basic LED": 4,
-      "Polycalcite Plastic": 4
-    }
-  },
-  "Advanced Quantum Core":{ 
-    "tier": 3,
-    "type": "Complex Part",
-    "mass": 11.24,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 2,
-      "Basic LED": 2,
-      "Polycalcite Plastic": 2,
-      "Uncommon LED": 2,
-      "Polysulfide Plastic": 2
-    }
-  },
-  "Rare Quantum Core":{ 
-    "tier": 4,
-    "type": "Complex Part",
-    "mass": 11.66,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 3840,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Basic LED": 1,
-      "Polycalcite Plastic": 2,
-      "Uncommon LED": 3,
-      "Polysulfide Plastic": 2,
-      "Fluoropolymer": 2
-    }
-  },
-  "Exotic Quantum Core":{ 
-    "tier": 5,
-    "type": "Complex Part",
-    "mass": 11.66,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 15360,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Basic LED": 1,
-      "Uncommon LED": 1,
-      "Polysulfide Plastic": 2,
-      "Advanced LED": 2,
-      "Fluoropolymer": 2,
-      "Vanamer": 2
-    }
-  },
-  "Basic Singularity Container":{ 
-    "tier": 1,
-    "type": "Complex Part",
-    "mass": 45.36,
-    "volume": 4,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 18,
-      "Basic Component": 12
-    }
-  },
-  "Uncommon Singularity Container":{ 
-    "tier": 2,
-    "type": "Complex Part",
-    "mass": 44.88,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 2,
-      "Basic Component": 4,
-      "Stainless Steel": 4
-    }
-  },
-  "Advanced Singularity Container":{ 
-    "tier": 3,
-    "type": "Complex Part",
-    "mass": 46.22,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 2,
-      "Basic Component": 2,
-      "Stainless Steel": 2,
-      "Uncommon Component": 2,
-      "Inconel": 2
-    }
-  },
-  "Rare Singularity Container":{ 
-    "tier": 4,
-    "type": "Complex Part",
-    "mass": 46.58,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 3840,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Component": 1,
-      "Stainless Steel": 2,
-      "Uncommon Component": 3,
-      "Inconel": 2,
-      "Maraging Steel": 2
-    }
-  },
-  "Exotic Singularity Container":{ 
-    "tier": 5,
-    "type": "Complex Part",
-    "mass": 46.98,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 15360,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Inconel": 2,
-      "Advanced Component": 2,
-      "Maraging Steel": 2,
-      "Mangalloy": 2
-    }
-  },
-  "Uncommon Solid Warhead":{ 
-    "tier": 2,
-    "type": "Complex Part",
-    "mass": 45.36,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 6,
-      "Basic Pipe": 4,
-      "Stainless Steel": 6
-    }
-  },
-  "Advanced Solid Warhead":{ 
-    "tier": 3,
-    "type": "Complex Part",
-    "mass": 46.43,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 2,
-      "Basic Pipe": 2,
-      "Stainless Steel": 2,
-      "Uncommon Pipe": 2,
-      "Inconel": 2
-    }
-  },
-  "Advanced Anti-Gravity Core":{ 
-    "tier": 3,
-    "type": "Exceptional Part",
-    "mass": 117.05,
-    "volume": 20,
-    "outputQuantity": 1,
-    "time": 3780,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Silumin": 5,
-      "Basic Component": 10,
-      "Basic Singularity Container": 3,
-      "Duralumin": 5,
-      "Uncommon Singularity Container": 1,
-      "Al-Li Alloy": 5,
-      "Advanced Singularity Container": 1
-    }
-  },
-  "Rare Anti-Gravity Core":{ 
-    "tier": 4,
-    "type": "Exceptional Part",
-    "mass": 123.22,
-    "volume": 22.5,
-    "outputQuantity": 1,
-    "time": 18780,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Silumin": 5,
-      "Basic Component": 5,
-      "Basic Singularity Container": 2,
-      "Duralumin": 5,
-      "Uncommon Component": 5,
-      "Uncommon Singularity Container": 1,
-      "Al-Li Alloy": 5,
-      "Advanced Singularity Container": 1,
-      "Sc-Al Alloy": 5,
-      "Rare Singularity Container": 1
-    }
-  },
-  "Exotic Anti-Gravity Core":{ 
-    "tier": 5,
-    "type": "Exceptional Part",
-    "mass": 133.06,
-    "volume": 25,
-    "outputQuantity": 1,
-    "time": 93780,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Silumin": 5,
-      "Basic Singularity Container": 1,
-      "Duralumin": 5,
-      "Uncommon Component": 5,
-      "Uncommon Singularity Container": 1,
-      "Al-Li Alloy": 5,
-      "Advanced Component": 5,
-      "Advanced Singularity Container": 1,
-      "Sc-Al Alloy": 5,
-      "Rare Singularity Container": 1,
-      "Grade 5 Titanium Alloy": 5,
-      "Exotic Singularity Container": 1
-    }
-  },
-  "Advanced Quantum Alignment Unit":{ 
-    "tier": 3,
-    "type": "Exceptional Part",
-    "mass": 35.78,
-    "volume": 25,
-    "outputQuantity": 1,
-    "time": 3780,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Polycarbonate Plastic": 5,
-      "Basic LED": 10,
-      "Basic Quantum Core": 3,
-      "Polycalcite Plastic": 5,
-      "Uncommon Quantum Core": 1,
-      "Polysulfide Plastic": 5,
-      "Advanced Quantum Core": 1
-    }
-  },
-  "Exotic Quantum Alignment Unit":{ 
-    "tier": 5,
-    "type": "Exceptional Part",
-    "mass": 43.24,
-    "volume": 30,
-    "outputQuantity": 1,
-    "time": 93780,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Polycarbonate Plastic": 5,
-      "Basic Quantum Core": 1,
-      "Polycalcite Plastic": 5,
-      "Uncommon LED": 5,
-      "Uncommon Quantum Core": 1,
-      "Polysulfide Plastic": 5,
-      "Advanced LED": 5,
-      "Advanced Quantum Core": 1,
-      "Fluoropolymer": 5,
-      "Rare Quantum Core": 1,
-      "Vanamer": 5,
-      "Exotic Quantum Core": 1
-    }
-  },
-  "Advanced Quantum Barrier":{ 
-    "tier": 3,
-    "type": "Exceptional Part",
-    "mass": 43.38,
-    "volume": 25,
-    "outputQuantity": 1,
-    "time": 3780,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Silumin": 5,
-      "Basic LED": 10,
-      "Basic Quantum Core": 3,
-      "Duralumin": 5,
-      "Uncommon Quantum Core": 1,
-      "Al-Li Alloy": 5,
-      "Advanced Quantum Core": 1
-    }
-  },
-  "Advanced Anti-Matter Core Unit":{ 
-    "tier": 3,
-    "type": "Exceptional Part",
-    "mass": 107.08,
-    "volume": 21.5,
-    "outputQuantity": 1,
-    "time": 3780,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 5,
-      "Basic Component": 10,
-      "Basic Anti-Matter Capsule": 3,
-      "Calcium Reinforced Copper": 5,
-      "Uncommon Anti-Matter Capsule": 1,
-      "Cu-Ag Alloy": 5,
-      "Advanced Anti-Matter Capsule": 1
-    }
-  },
-  "Exotic Anti-Matter Core Unit":{ 
-    "tier": 5,
-    "type": "Exceptional Part",
-    "mass": 158.05,
-    "volume": 26.5,
-    "outputQuantity": 1,
-    "time": 93780,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 5,
-      "Basic Anti-Matter Capsule": 1,
-      "Calcium Reinforced Copper": 5,
-      "Uncommon Component": 5,
-      "Uncommon Anti-Matter Capsule": 1,
-      "Cu-Ag Alloy": 5,
-      "Advanced Component": 5,
-      "Advanced Anti-Matter Capsule": 1,
-      "Red Gold": 5,
-      "Rare Anti-Matter Capsule": 1,
-      "Ti-Nb Supraconductor": 5,
-      "Exotic Anti-Matter Capsule": 1
-    }
-  },
-  "Basic Antenna XS":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 60.44,
-    "volume": 8.96,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 3,
-      "Basic Screw": 3
-    }
-  },
-  "Basic Antenna S":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 314.2,
-    "volume": 46.4,
-    "outputQuantity": 1,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 7,
-      "Basic Screw": 5
-    }
-  },
-  "Uncommon Antenna XS":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 117.16,
-    "volume": 17.12,
-    "outputQuantity": 1,
-    "time": 168,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Screw": 1,
-      "Basic Power System": 1,
-      "Calcium Reinforced Copper": 1,
-      "Uncommon Screw": 1,
-      "Uncommon Power System": 1
-    }
-  },
-  "Uncommon Antenna S":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 379.2,
-    "volume": 54.56,
-    "outputQuantity": 1,
-    "time": 720,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Screw": 2,
-      "Basic Power System": 2,
-      "Calcium Reinforced Copper": 7,
-      "Uncommon Screw": 4,
-      "Uncommon Power System": 4
-    }
-  },
-  "Uncommon Antenna M":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 1770,
-    "volume": 251.36,
-    "outputQuantity": 1,
-    "time": 2160,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Screw": 8,
-      "Basic Power System": 8,
-      "Calcium Reinforced Copper": 49,
-      "Uncommon Screw": 18,
-      "Uncommon Power System": 18
-    }
-  },
-  "Uncommon Antenna L":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 9240,
-    "volume": 1302.56,
-    "outputQuantity": 1,
-    "time": 6480,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Screw": 38,
-      "Basic Power System": 38,
-      "Calcium Reinforced Copper": 343,
-      "Uncommon Screw": 88,
-      "Uncommon Power System": 88
-    }
-  },
-  "Advanced Antenna S":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 389.74,
-    "volume": 54.56,
-    "outputQuantity": 1,
-    "time": 2016,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Screw": 2,
-      "Basic Power System": 2,
-      "Uncommon Screw": 2,
-      "Uncommon Power System": 2,
-      "Cu-Ag Alloy": 7,
-      "Advanced Screw": 2,
-      "Advanced Power System": 2
-    }
-  },
-  "Exotic Antenna M":{ 
-    "tier": 5,
-    "type": "Functional Part",
-    "mass": 2140,
-    "volume": 250.56,
-    "outputQuantity": 1,
-    "time": 138240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Advanced Screw": 25,
-      "Advanced Power System": 8,
-      "Rare Power System": 8,
-      "Ti-Nb Supraconductor": 49,
-      "Exotic Power System": 10
-    }
-  },
-  "Exotic Antenna L":{ 
-    "tier": 5,
-    "type": "Functional Part",
-    "mass": 11250,
-    "volume": 1301.76,
-    "outputQuantity": 1,
-    "time": 414000,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Advanced Screw": 125,
-      "Advanced Power System": 38,
-      "Rare Power System": 38,
-      "Ti-Nb Supraconductor": 343,
-      "Exotic Power System": 50
-    }
-  },
-  "Exotic Antenna XL":{ 
-    "tier": 5,
-    "type": "Functional Part",
-    "mass": 61580,
-    "volume": 7028.16,
-    "outputQuantity": 1,
-    "time": 1245600,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Advanced Screw": 625,
-      "Advanced Power System": 188,
-      "Rare Power System": 188,
-      "Ti-Nb Supraconductor": 2401,
-      "Exotic Power System": 250
-    }
-  },
-  "Basic Chemical Container XS":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 8.13,
-    "volume": 4.8,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 3,
-      "Basic Screw": 3
-    }
-  },
-  "Basic Chemical Container S":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 43.67,
-    "volume": 25.6,
-    "outputQuantity": 1,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 7,
-      "Basic Screw": 5
-    }
-  },
-  "Basic Chemical Container M":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 239.38,
-    "volume": 139.2,
-    "outputQuantity": 1,
-    "time": 540,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 49,
-      "Basic Screw": 25
-    }
-  },
-  "Basic Chemical Container L":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 1340,
-    "volume": 774.4,
-    "outputQuantity": 1,
-    "time": 1620,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 343,
-      "Basic Screw": 125
-    }
-  },
-  "Basic Chemical Container XL":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 7750,
-    "volume": 4420.80,
-    "outputQuantity": 1,
-    "time": 4860,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 2401,
-      "Basic Screw": 625
-    }
-  },
-  "Advanced Chemical Container S":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 48.85,
-    "volume": 29.6,
-    "outputQuantity": 1,
-    "time": 2880,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Screw": 2,
-      "Basic Electronics": 2,
-      "Uncommon Screw": 2,
-      "Uncommon Electronics": 2,
-      "Al-Li Alloy": 7,
-      "Advanced Screw": 2,
-      "Advanced Electronics": 2
-    }
-  },
-  "Advanced Chemical Container M":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 235.25,
-    "volume": 143.2,
-    "outputQuantity": 1,
-    "time": 8640,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Screw": 8,
-      "Basic Electronics": 8,
-      "Uncommon Screw": 8,
-      "Uncommon Electronics": 8,
-      "Al-Li Alloy": 49,
-      "Advanced Screw": 10,
-      "Advanced Electronics": 10
-    }
-  },
-  "Advanced Chemical Container L":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 1270,
-    "volume": 778.4,
-    "outputQuantity": 1,
-    "time": 25920,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Screw": 38,
-      "Basic Electronics": 38,
-      "Uncommon Screw": 38,
-      "Uncommon Electronics": 38,
-      "Al-Li Alloy": 343,
-      "Advanced Screw": 50,
-      "Advanced Electronics": 50
-    }
-  },
-  "Advanced Chemical Container XL":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 7190,
-    "volume": 4424.8,
-    "outputQuantity": 1,
-    "time": 77760,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Screw": 188,
-      "Basic Electronics": 188,
-      "Uncommon Screw": 188,
-      "Uncommon Electronics": 188,
-      "Al-Li Alloy": 2401,
-      "Advanced Screw": 250,
-      "Advanced Electronics": 250
-    }
-  },
-  "Basic Combustion Chamber XS":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 60.65,
-    "volume": 9.6,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 3,
-      "Basic Pipe": 3
-    }
-  },
-  "Basic Combustion Chamber S":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 319.35,
-    "volume": 49.6,
-    "outputQuantity": 1,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 7,
-      "Basic Pipe": 5
-    }
-  },
-  "Basic Combustion Chamber M":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 1710,
-    "volume": 259.2,
-    "outputQuantity": 1,
-    "time": 540,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 49,
-      "Basic Pipe": 25
-    }
-  },
-  "Basic Combustion Chamber L":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 9340,
-    "volume": 1374.4,
-    "outputQuantity": 1,
-    "time": 1620,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 343,
-      "Basic Pipe": 125
-    }
-  },
-  "Uncommon Combustion Chamber XS":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 112.07,
-    "volume": 18.4,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 1,
-      "Basic Burner": 1,
-      "Stainless Steel": 1,
-      "Uncommon Burner": 1,
-      "Uncommon Pipe": 1
-    }
-  },
-  "Uncommon Combustion Chamber S":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 366.33,
-    "volume": 58.4,
-    "outputQuantity": 1,
-    "time": 720,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 2,
-      "Basic Burner": 2,
-      "Stainless Steel": 7,
-      "Uncommon Burner": 4,
-      "Uncommon Pipe": 4
-    }
-  },
-  "Uncommon Combustion Chamber M":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 1730,
-    "volume": 268,
-    "outputQuantity": 1,
-    "time": 2160,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 8,
-      "Basic Burner": 8,
-      "Stainless Steel": 49,
-      "Uncommon Burner": 18,
-      "Uncommon Pipe": 18
-    }
-  },
-  "Uncommon Combustion Chamber L":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 9210,
-    "volume": 1383.2,
-    "outputQuantity": 1,
-    "time": 6480,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 38,
-      "Basic Burner": 38,
-      "Stainless Steel": 343,
-      "Uncommon Burner": 88,
-      "Uncommon Pipe": 88
-    }
-  },
-  "Advanced Combustion Chamber XS":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 163.51,
-    "volume": 27.2,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 1,
-      "Basic Burner": 1,
-      "Uncommon Pipe": 1,
-      "Uncommon Burner": 1,
-      "Inconel": 1,
-      "Advanced Pipe": 1,
-      "Advanced Burner": 1
-    }
-  },
-  "Advanced Combustion Chamber S":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 369.5,
-    "volume": 58.4,
-    "outputQuantity": 1,
-    "time": 2880,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 2,
-      "Basic Burner": 2,
-      "Uncommon Pipe": 2,
-      "Uncommon Burner": 2,
-      "Inconel": 7,
-      "Advanced Pipe": 2,
-      "Advanced Burner": 2
-    }
-  },
-  "Advanced Combustion Chamber M":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 1760,
-    "volume": 268,
-    "outputQuantity": 1,
-    "time": 8640,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 8,
-      "Basic Burner": 8,
-      "Uncommon Pipe": 8,
-      "Uncommon Burner": 8,
-      "Inconel": 49,
-      "Advanced Pipe": 10,
-      "Advanced Burner": 10
-    }
-  },
-  "Basic Control System XS":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 9.25,
-    "volume": 5.2,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Electronics Industry M"],
-    "input": {
-      "Polycarbonate Plastic": 3,
-      "Basic Component": 3
-    }
-  },
-  "Basic Control System S":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 47.63,
-    "volume": 27.6,
-    "outputQuantity": 1,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Electronics Industry M"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Component": 5
-    }
-  },
-  "Basic Control System M":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 247.97,
-    "volume": 149.2,
-    "outputQuantity": 1,
-    "time": 540,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Electronics Industry M"],
-    "input": {
-      "Polycarbonate Plastic": 49,
-      "Basic Component": 25
-    }
-  },
-  "Advanced Control System S":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 59.35,
-    "volume": 32,
-    "outputQuantity": 1,
-    "time": 2880,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Component": 2,
-      "Basic Processor": 2,
-      "Uncommon Component": 2,
-      "Uncommon Processor": 2,
-      "Polysulfide Plastic": 7,
-      "Advanced Component": 2,
-      "Advanced Processor": 2
-    }
-  },
-  "Advanced Control System M":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 272.97,
-    "volume": 153.6,
-    "outputQuantity": 1,
-    "time": 8640,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Component": 8,
-      "Basic Processor": 8,
-      "Uncommon Component": 8,
-      "Uncommon Processor": 8,
-      "Polysulfide Plastic": 49,
-      "Advanced Component": 10,
-      "Advanced Processor": 10
-    }
-  },
-  "Advanced Control System L":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 1410,
-    "volume": 828.8,
-    "outputQuantity": 1,
-    "time": 25920,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Component": 38,
-      "Basic Processor": 38,
-      "Uncommon Component": 38,
-      "Uncommon Processor": 38,
-      "Polysulfide Plastic": 343,
-      "Advanced Component": 50,
-      "Advanced Processor": 50
-    }
-  },
-  "Basic Core System XS":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 4.43,
-    "volume": 4.4,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Polycarbonate Plastic": 3,
-      "Basic Component": 3
-    }
-  },
-  "Basic Core System S":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 23.57,
-    "volume": 23.6,
-    "outputQuantity": 1,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Electronics Industry M"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Component": 5
-    }
-  },
-  "Uncommon Core System S":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 28.08,
-    "volume": 27.2,
-    "outputQuantity": 1,
-    "time": 720,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Component": 2,
-      "Basic Electronics": 2,
-      "Polycalcite Plastic": 7,
-      "Uncommon Component": 4,
-      "Uncommon Electronics": 4
-    }
-  },
-  "Uncommon Core System M":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 135.75,
-    "volume": 132.80,
-    "outputQuantity": 1,
-    "time": 2160,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Component": 8,
-      "Basic Electronics": 8,
-      "Polycalcite Plastic": 49,
-      "Uncommon Component": 18,
-      "Uncommon Electronics": 18
-    }
-  },
-  "Uncommon Core System L":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 737.1,
-    "volume": 728,
-    "outputQuantity": 1,
-    "time": 6480,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Component": 38,
-      "Basic Electronics": 38,
-      "Polycalcite Plastic": 343,
-      "Uncommon Component": 88,
-      "Uncommon Electronics": 88
-    }
-  },
-  "Advanced Core System M":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 139.61,
-    "volume": 132.8,
-    "outputQuantity": 1,
-    "time": 8640,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Component": 8,
-      "Basic Electronics": 8,
-      "Uncommon Component": 8,
-      "Uncommon Electronics": 8,
-      "Polysulfide Plastic": 49,
-      "Advanced Component": 10,
-      "Advanced Electronics": 10
-    }
-  },
-  "Rare Core System L":{ 
-    "tier": 4,
-    "type": "Functional Part",
-    "mass": 783.65,
-    "volume": 728,
-    "outputQuantity": 1,
-    "time": 103680,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Uncommon Component": 38,
-      "Uncommon Electronics": 38,
-      "Advanced Component": 88,
-      "Advanced Electronics": 38,
-      "Fluoropolymer": 343,
-      "Rare Electronics": 50
-    }
-  },
-  "Exotic Core System S":{ 
-    "tier": 5,
-    "type": "Functional Part",
-    "mass": 28.62,
-    "volume": 26.8,
-    "outputQuantity": 1,
-    "time": 46080,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Advanced Component": 5,
-      "Advanced Electronics": 2,
-      "Rare Electronics": 2,
-      "Vanamer": 7,
-      "Exotic Electronics": 2
-    }
-  },
-  "Basic Electric Engine S":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 377.75,
-    "volume": 39.04,
-    "outputQuantity": 1,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 7,
-      "Basic Screw": 5
-    }
-  },
-  "Basic Electric Engine M":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 1930,
-    "volume": 206.4,
-    "outputQuantity": 1,
-    "time": 540,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 49,
-      "Basic Screw": 25
-    }
-  },
-  "Uncommon Electric Engine XL":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 50800,
-    "volume": 6107.49,
-    "outputQuantity": 1,
-    "time": 19440,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Screw": 188,
-      "Basic Magnet": 188,
-      "Duralumin": 2401,
-      "Uncommon Screw": 438,
-      "Uncommon Magnet": 438
-    }
-  },
-  "Basic Firing System XS":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass":60.65,
-    "volume": 9.6,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 3,
-      "Basic Pipe": 3
-    }
-  },
-  "Advanced Firing System XS":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 163.51,
-    "volume": 27.2,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 1,
-      "Basic Burner": 1,
-      "Uncommon Pipe": 1,
-      "Uncommon Burner": 1,
-      "Inconel": 1,
-      "Advanced Pipe": 1,
-      "Advanced Burner": 1
-    }
-  },
-  "Advanced Firing System S":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 369.5,
-    "volume": 58.4,
-    "outputQuantity": 1,
-    "time": 2880,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 2,
-      "Basic Burner": 2,
-      "Uncommon Pipe": 2,
-      "Uncommon Burner": 2,
-      "Inconel": 7,
-      "Advanced Pipe": 2,
-      "Advanced Burner": 2
-    }
-  },
-  "Advanced Firing System M":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 1760,
-    "volume": 268,
-    "outputQuantity": 1,
-    "time": 8640,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 8,
-      "Basic Burner": 8,
-      "Uncommon Pipe": 8,
-      "Uncommon Burner": 8,
-      "Inconel": 49,
-      "Advanced Pipe": 10,
-      "Advanced Burner": 10
-    }
-  },
-  "Advanced Firing System L":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 9410,
-    "volume": 1383.2,
-    "outputQuantity": 1,
-    "time": 25920,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 38,
-      "Basic Burner": 38,
-      "Uncommon Pipe": 38,
-      "Uncommon Burner": 38,
-      "Inconel": 343,
-      "Advanced Pipe": 50,
-      "Advanced Burner": 50
-    }
-  },
-  "Basic Gas Cylinder XS":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 15.68,
-    "volume": 9.6,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 3,
-      "Basic Screw": 3
-    }
-  },
-  "Basic Gas Cylinder S":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 81.38,
-    "volume": 49.6,
-    "outputQuantity": 1,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 7,
-      "Basic Screw": 5
-    }
-  },
-  "Basic Gas Cylinder M":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 427.88,
-    "volume": 259.2,
-    "outputQuantity": 1,
-    "time": 540,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 49,
-      "Basic Screw": 25
-    }
-  },
-  "Basic Ionic Chamber XS":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 75.1,
-    "volume": 7.33,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 3,
-      "Basic Connector": 3
-    }
-  },
-  "Basic Ionic Chamber S":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 391.6,
-    "volume": 38.24,
-    "outputQuantity": 1,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 7,
-      "Basic Connector": 5
-    }
-  },
-  "Basic Ionic Chamber M":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 2070,
-    "volume": 202.4,
-    "outputQuantity": 1,
-    "time": 540,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 49,
-      "Basic Connector": 25
-    }
-  },
-  "Basic Ionic Chamber L":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 1620,
-    "volume": 1090.4,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 343,
-      "Basic Connector": 125
-    }
-  },
-  "Basic Ionic Chamber XL":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 61230,
-    "volume": 6000.8,
-    "outputQuantity": 1,
-    "time": 4860,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 2401,
-      "Basic Connector": 625
-    }
-  },"Uncommon Ionic Chamber XS":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 140.8,
-    "volume": 13.86,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Connector": 1,
-      "Basic Magnet": 1,
-      "Stainless Steel": 1,
-      "Uncommon Connector": 1,
-      "Uncommon Magnet": 1
-    }
-  },
-  "Uncommon Ionic Chamber S":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 452.35,
-    "volume": 44.77,
-    "outputQuantity": 1,
-    "time": 720,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Connector": 2,
-      "Basic Magnet": 2,
-      "Stainless Steel": 7,
-      "Uncommon Connector": 4,
-      "Uncommon Magnet": 4
-    }
-  },
-  "Uncommon Ionic Chamber M":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 2100,
-    "volume": 208.93,
-    "outputQuantity": 1,
-    "time": 2160,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Connector": 8,
-      "Basic Magnet": 8,
-      "Stainless Steel": 49,
-      "Uncommon Connector": 18,
-      "Uncommon Magnet": 18
-    }
-  },
-  "Uncommon Ionic Chamber L":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 11010,
-    "volume": 1096.93,
-    "outputQuantity": 1,
-    "time": 6480,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Connector": 38,
-      "Basic Magnet": 38,
-      "Stainless Steel": 343,
-      "Uncommon Connector": 88,
-      "Uncommon Magnet": 88
-    }
-  },
-  "Uncommon Ionic Chamber XL":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 60120,
-    "volume": 6007.33,
-    "outputQuantity": 1,
-    "time": 19440,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Connector": 188,
-      "Basic Magnet": 188,
-      "Stainless Steel": 2401,
-      "Uncommon Connector": 438,
-      "Uncommon Magnet": 438
-    }
-  },
-  "Advanced Ionic Chamber M":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 8640,
-    "volume": 208.93,
-    "outputQuantity": 1,
-    "time": 7200,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Connector": 8,
-      "Basic Magnet": 8,
-      "Uncommon Connector": 8,
-      "Uncommon Magnet": 8,
-      "Inconel": 49,
-      "Advanced Connector": 10,
-      "Advanced Magnet": 10
-    }
-  },
-  "Advanced Ionic Chamber L":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 11370,
-    "volume": 1096.93,
-    "outputQuantity": 1,
-    "time": 15540,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Connector": 38,
-      "Basic Magnet": 38,
-      "Uncommon Connector": 38,
-      "Uncommon Magnet": 38,
-      "Inconel": 343,
-      "Advanced Connector": 50,
-      "Advanced Magnet": 50
-    }
-  },
-  "Advanced Ionic Chamber XL":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 62430,
-    "volume": 6007.33,
-    "outputQuantity": 1,
-    "time": 15540,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Connector": 188,
-      "Basic Magnet": 188,
-      "Uncommon Connector": 188,
-      "Uncommon Magnet": 188,
-      "Inconel": 2401,
-      "Advanced Connector": 250,
-      "Advanced Magnet": 250
-    }
-  },
-  "Uncommon Laser Chamber XS":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 24.8,
-    "volume": 18.4,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Basic LED": 1,
-      "Basic Optics": 1,
-      "Advanced Glass": 1,
-      "Uncommon LED": 1,
-      "Uncommon Optics": 1
-    }
-  },
-  "Advanced Laser Chamber XS":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 36.51,
-    "volume": 27.2,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Basic LED": 1,
-      "Basic Optics": 1,
-      "Uncommon LED": 1,
-      "Uncommon Optics": 1,
-      "Ag-Li Reinforced Glass": 1,
-      "Advanced LED": 1,
-      "Advanced Optics": 1
-    }
-  },
-  "Advanced Laser Chamber S":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 87.02,
-    "volume": 58.4,
-    "outputQuantity": 1,
-    "time": 2880,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Basic LED": 2,
-      "Basic Optics": 2,
-      "Uncommon LED": 2,
-      "Uncommon Optics": 2,
-      "Ag-Li Reinforced Glass": 7,
-      "Advanced LED": 2,
-      "Advanced Optics": 2
-    }
-  },
-  "Advanced Laser Chamber M":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 429.89,
-    "volume": 268,
-    "outputQuantity": 1,
-    "time": 8640,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Basic LED": 8,
-      "Basic Optics": 8,
-      "Uncommon LED": 8,
-      "Uncommon Optics": 8,
-      "Ag-Li Reinforced Glass": 49,
-      "Advanced LED": 10,
-      "Advanced Optics": 10
-    }
-  },
-  "Advanced Laser Chamber L":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 2380,
-    "volume": 1383.2,
-    "outputQuantity": 1,
-    "time": 25920,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Basic LED": 38,
-      "Basic Optics": 38,
-      "Uncommon LED": 38,
-      "Uncommon Optics": 38,
-      "Ag-Li Reinforced Glass": 343,
-      "Advanced LED": 50,
-      "Advanced Optics": 50
-    }
-  },
-  "Rare Laser Chamber S":{ 
-    "tier": 4,
-    "type": "Functional Part",
-    "mass": 90.49,
-    "volume": 58.4,
-    "outputQuantity": 1,
-    "time": 11520,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Uncommon LED": 2,
-      "Uncommon Optics": 2,
-      "Advanced LED": 2,
-      "Advanced Optics": 2,
-      "Gold Coated Glass": 7,
-      "Rare Optics": 2
-    }
-  },
-  "Uncommon Light XS":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 7.84,
-    "volume": 8.8,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic LED": 1,
-      "Basic Electronics": 1,
-      "Advanced Glass": 1,
-      "Uncommon LED": 1,
-      "Uncommon Electronics": 1
-    }
-  },
-  "Uncommon Light S":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 28.8,
-    "volume": 29.6,
-    "outputQuantity": 1,
-    "time": 720,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic LED": 2,
-      "Basic Electronics": 2,
-      "Advanced Glass": 7,
-      "Uncommon LED": 4,
-      "Uncommon Electronics": 4
-    }
-  },
-  "Advanced Magnetic Rail XS":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 204.7,
-    "volume": 20.86,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 1,
-      "Basic Magnet": 1,
-      "Uncommon Pipe": 1,
-      "Uncommon Magnet": 1,
-      "Inconel": 1,
-      "Advanced Pipe": 1,
-      "Advanced Magnet": 1
-    }
-  },
-  "Advanced Magnetic Rail S":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 451.89,
-    "volume": 45.73,
-    "outputQuantity": 1,
-    "time": 2880,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 2,
-      "Basic Magnet": 2,
-      "Uncommon Pipe": 2,
-      "Uncommon Magnet": 2,
-      "Inconel": 7,
-      "Advanced Pipe": 2,
-      "Advanced Magnet": 2
-    }
-  },
-  "Advanced Magnetic Rail M":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 2120,
-    "volume": 213.09,
-    "outputQuantity": 1,
-    "time": 8640,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 8,
-      "Basic Magnet": 8,
-      "Uncommon Pipe": 8,
-      "Uncommon Magnet": 8,
-      "Inconel": 49,
-      "Advanced Pipe": 10,
-      "Advanced Magnet": 10
-    }
-  },
-  "Advanced Magnetic Rail L":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 11160,
-    "volume": 1117.09,
-    "outputQuantity": 1,
-    "time": 25920,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 38,
-      "Basic Magnet": 38,
-      "Uncommon Pipe": 38,
-      "Uncommon Magnet": 38,
-      "Inconel": 343,
-      "Advanced Pipe": 50,
-      "Advanced Magnet": 50
-    }
-  },
-  "Basic Mechanical Sensor XS":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 35.96,
-    "volume": 7.49,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Electronics Industry M"],
-    "input": {
-      "Al-Fe Alloy": 3,
-      "Basic Fixation": 3
-    }
-  },
-  "Advanced Mechanical Sensor XS":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 100.99,
-    "volume": 20.86,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Fixation": 1,
-      "Basic Magnet": 1,
-      "Uncommon Fixation": 1,
-      "Uncommon Magnet": 1,
-      "Cu-Ag Alloy": 1,
-      "Advanced Fixation": 1,
-      "Advanced Magnet": 1
-    }
-  },
-  "Exotic Mechanical Sensor XS":{ 
-    "tier": 5,
-    "type": "Functional Part",
-    "mass": 102.37,
-    "volume": 19.26,
-    "outputQuantity": 1,
-    "time": 15360,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Advanced Fixation": 1,
-      "Advanced Magnet": 1,
-      "Rare Magnet": 1,
-      "Ti-Nb Supraconductor": 1,
-      "Exotic Magnet": 1
-    }
-  },
-  "Advanced Missile Silo XS":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 157.51,
-    "volume": 27.2,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 1,
-      "Basic Burner": 1,
-      "Uncommon Pipe": 1,
-      "Uncommon Burner": 1,
-      "Al-Li Alloy": 1,
-      "Advanced Pipe": 1,
-      "Advanced Burner": 1
-    }
-  },
-  "Advanced Missile Silo S":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 327.52,
-    "volume": 58.4,
-    "outputQuantity": 1,
-    "time": 2880,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 2,
-      "Basic Burner": 2,
-      "Uncommon Pipe": 2,
-      "Uncommon Burner": 2,
-      "Al-Li Alloy": 7,
-      "Advanced Pipe": 2,
-      "Advanced Burner": 2
-    }
-  },
-  "Advanced Missile Silo M":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 1460,
-    "volume": 268,
-    "outputQuantity": 1,
-    "time": 8640,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 8,
-      "Basic Burner": 8,
-      "Uncommon Pipe": 8,
-      "Uncommon Burner": 8,
-      "Al-Li Alloy": 49,
-      "Advanced Pipe": 10,
-      "Advanced Burner": 10
-    }
-  },
-  "Advanced Missile Silo L":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 7360,
-    "volume": 1383.2,
-    "outputQuantity": 1,
-    "time": 25920,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Basic Pipe": 38,
-      "Basic Burner": 38,
-      "Uncommon Pipe": 38,
-      "Uncommon Burner": 38,
-      "Al-Li Alloy": 343,
-      "Advanced Pipe": 50,
-      "Advanced Burner": 50
-    }
-  },
-  "Basic Mobile Panel XS":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 20,
-    "volume": 9.6,
-    "outputQuantity": 3,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 3,
-      "Basic Screw": 3
-    }
-  },
-  "Basic Mobile Panel S":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 103,
-    "volume": 49.6,
-    "outputQuantity": 1,
-    "time": 180,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 7,
-      "Basic Screw": 5
-    }
-  },
-  "Basic Mobile Panel M":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 536,
-    "volume": 259.2,
-    "outputQuantity": 1,
-    "time": 540,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 49,
-      "Basic Screw": 25
-    }
-  },
-  "Basic Mobile Panel L":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 2830,
-    "volume": 1374.4,
-    "outputQuantity": 1,
-    "time": 1620,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 343,
-      "Basic Screw": 125
-    }
-  },
-  "Basic Mobile Panel XL":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 15160,
-    "volume": 7420.8,
-    "outputQuantity": 1,
-    "time": 4860,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 2401,
-      "Basic Screw": 625
-    }
-  },
-  "Advanced Motherboard M":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 109.19,
-    "volume": 96,
-    "outputQuantity": 1,
-    "time": 8640,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Component": 8,
-      "Basic Processor": 8,
-      "Uncommon Component": 8,
-      "Uncommon Processor": 8,
-      "Polysulfide Plastic": 49,
-      "Advanced Component": 10,
-      "Advanced Processor": 10
-    }
-  },
-  "Uncommon Ore Scanner XL":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 1870,
-    "volume": 2702.9,
-    "outputQuantity": 1,
-    "time": 19440,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Basic Connector": 188,
-      "Basic Electronics": 188,
-      "Polycalcite Plastic": 2401,
-      "Uncommon Connector": 438,
-      "Uncommon Electronics": 438
-    }
-  },
-  "Basic Power Transformer M":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 1020,
-    "volume": 196.4,
-    "outputQuantity": 1,
-    "time": 540,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Electronics Industry M"],
-    "input": {
-      "Steel": 49,
-      "Basic Component": 25
-    }
-  },
-  "Uncommon Power Transformer S":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 221.56,
-    "volume": 43.33,
-    "outputQuantity": 1,
-    "time": 540,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Electronics Industry M"],
-    "input": {
-      "Basic Component": 2,
-	    "Basic Magnet": 2,
-      "Stainless Steel": 7,
-      "Uncommon Component": 4,
-	    "Uncommon Magnet": 4
-    }
-  },
-  "Uncommon Power Transformer M":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 1030,
-    "volume": 202.69,
-    "outputQuantity": 1,
-    "time": 1512,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Electronics Industry M"],
-    "input": {
-      "Basic Component": 8,
-	    "Basic Magnet": 8,
-      "Stainless Steel": 49,
-      "Uncommon Component": 18,
-	    "Uncommon Magnet": 18
-    }
-  },
-  "Rare Power Transformer L":{ 
-    "tier": 4,
-    "type": "Functional Part",
-    "mass": 5570,
-    "volume": 1066.69,
-    "outputQuantity": 1,
-    "time": 103680,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Uncommon Component": 38,
-      "Uncommon Magnet": 38,
-      "Advanced Component": 88,
-      "Advanced Magnet": 38,
-      "Maraging Steel": 343,
-      "Rare Magnet": 50
-    }
-  },
-  "Rare Power Transformer XL":{ 
-    "tier": 4,
-    "type": "Functional Part",
-    "mass": 30540,
-    "volume": 5857.09,
-    "outputQuantity": 1,
-    "time": 311040,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Uncommon Component": 188,
-      "Uncommon Magnet": 188,
-      "Advanced Component": 438,
-      "Advanced Magnet": 188,
-      "Maraging Steel": 343,
-      "Rare Magnet": 250
-    }
-  },
-  "Exotic Power Transformer L":{ 
-    "tier": 5,
-    "type": "Functional Part",
-    "mass": 5570,
-    "volume": 1066.29,
-    "outputQuantity": 1,
-    "time": 414720,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Electronics Industry M"],
-    "input": {
-      "Advanced Component": 125,
-      "Advanced Magnet": 38,
-      "Rare Magnet": 38,
-      "Mangalloy": 343,
-      "Exotic Magnet": 50
-    }
-  },
-  "Basic Robotic Arm M":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 927,
-    "volume": 249.2,
-    "outputQuantity": 1,
-    "time": 540,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 49,
-      "Basic Component": 25
-    }
-  },
-  "Basic Robotic Arm L":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 4930,
-    "volume": 1324.4,
-    "outputQuantity": 1,
-    "time": 1620,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 343,
-      "Basic Component": 125
-    }
-  },
-  "Basic Robotic Arm XL":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 26700,
-    "volume": 7170.8,
-    "outputQuantity": 1,
-    "time": 4860,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 2401,
-      "Basic Component": 625
-    }
-  },
-  "Basic Screen S":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 21.07,
-    "volume": 25.6,
-    "outputQuantity": 1,
-    "time": 63,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic LED": 5
-    }
-  },
-  "Basic Screen M":{ 
-    "tier": 1,
-    "type": "Functional Part",
-    "mass": 115.17,
-    "volume": 139.2,
-    "outputQuantity": 1,
-    "time": 540,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 49,
-      "Basic LED": 25
-    }
-  },
-  "Uncommon Screen XS":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 7.29,
-    "volume": 8.8,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Basic LED": 1,
-      "Basic Electronics": 1,
-      "Polycalcite Plastic": 1,
-      "Uncommon LED": 1,
-      "Uncommon Electronics": 1
-    }
-  },
-  "Uncommon Screen L":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 671.24,
-    "volume": 778.4,
-    "outputQuantity": 1,
-    "time": 4536,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Basic LED": 38,
-      "Basic Electronics": 38,
-      "Polycalcite Plastic": 343,
-      "Uncommon LED": 88,
-      "Uncommon Electronics": 88
-    }
-  },
-  "Uncommon Screen XL":{ 
-    "tier": 2,
-    "type": "Functional Part",
-    "mass": 3860,
-    "volume": 4424.8,
-    "outputQuantity": 1,
-    "time": 19440,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Basic LED": 188,
-      "Basic Electronics": 188,
-      "Polycalcite Plastic": 2401,
-      "Uncommon LED": 438,
-      "Uncommon Electronics": 438
-    }
-  },
-  "Advanced Screen XS":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 10.73,
-    "volume": 12.8,
-    "outputQuantity": 1,
-    "time": 960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Basic LED": 1,
-      "Basic Electronics": 1,
-      "Uncommon LED": 1,
-      "Uncommon Electronics": 1,
-      "Polysulfide Plastic": 1,
-      "Advanced LED": 1,
-      "Advanced Electronics": 1
-    }
-  },
-  "Advanced Screen XL":{ 
-    "tier": 3,
-    "type": "Functional Part",
-    "mass": 4000,
-    "volume": 4424.8,
-    "outputQuantity": 1,
-    "time": 54420,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Basic LED": 188,
-      "Basic Electronics": 188,
-      "Uncommon LED": 188,
-      "Uncommon Electronics": 188,
-      "Polysulfide Plastic": 2401,
-      "Advanced LED": 250,
-      "Advanced Electronics": 250
-    }
-  },
-  "Basic Casing XS":{ 
-    "tier": 1,
-    "type": "Structural Part",
-    "mass": 1.4,
-    "volume": 2,
-    "outputQuantity": 1,
-    "time": 40,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 2
-    }
-  },
-  "Basic Casing S":{ 
-    "tier": 1,
-    "type": "Structural Part",
-    "mass": 7.7,
-    "volume": 11,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 11
-    }
-  },
-  "Uncommon Casing XS":{ 
-    "tier": 2,
-    "type": "Structural Part",
-    "mass": 1.45,
-    "volume": 2,
-    "outputQuantity": 1,
-    "time": 160,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 1,
-      "Polycalcite Plastic": 1
-    }
-  },
-  "Uncommon Casing S":{ 
-    "tier": 2,
-    "type": "Structural Part",
-    "mass": 8.05,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 4,
-      "Polycalcite Plastic": 7
-    }
-  },
-  "Uncommon Casing M":{ 
-    "tier": 2,
-    "type": "Structural Part",
-    "mass": 54.25,
-    "volume": 74,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 25,
-      "Polycalcite Plastic": 49
-    }
-  },
-  "Uncommon Casing XL":{ 
-    "tier": 2,
-    "type": "Structural Part",
-    "mass": 2640,
-    "volume": 3602,
-    "outputQuantity": 1,
-    "time": 12960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 1201,
-      "Polycalcite Plastic": 2401
-    }
-  },
-  "Advanced Casing XS":{ 
-    "tier": 3,
-    "type": "Structural Part",
-    "mass": 1.5,
-    "volume": 2,
-    "outputQuantity": 1,
-    "time": 640,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 1,
-      "Polysulfide Plastic": 1
-    }
-  },
-  "Advanced Casing S":{ 
-    "tier": 3,
-    "type": "Structural Part",
-    "mass": 8.4,
-    "volume": 1,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 4,
-      "Polysulfide Plastic": 7
-    }
-  },
-  "Advanced Casing M":{ 
-    "tier": 3,
-    "type": "Structural Part",
-    "mass": 56.7,
-    "volume": 74,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 25,
-      "Polysulfide Plastic": 49
-    }
-  },
-  "Advanced Casing L":{ 
-    "tier": 3,
-    "type": "Structural Part",
-    "mass": 394.8,
-    "volume": 515,
-    "outputQuantity": 1,
-    "time": 17280,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 172,
-      "Polysulfide Plastic": 343
-    }
-  },
-  "Advanced Casing XL":{ 
-    "tier": 3,
-    "type": "Structural Part",
-    "mass": 2760,
-    "volume": 3602,
-    "outputQuantity": 1,
-    "time": 51840,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 1201,
-      "Polysulfide Plastic": 2401
-    }
-  },
-  "Rare Casing XS":{ 
-    "tier": 4,
-    "type": "Structural Part",
-    "mass": 1.52,
-    "volume": 2,
-    "outputQuantity": 1,
-    "time": 2560,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 1,
-      "Fluoropolymer": 1
-    }
-  },
-  "Rare Casing S":{ 
-    "tier": 4,
-    "type": "Structural Part",
-    "mass": 8.57,
-    "volume": 11,
-    "outputQuantity": 1,
-    "time": 7680,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 4,
-      "Fluoropolymer": 7
-    }
-  },
-  "Exotic Casing S":{ 
-    "tier": 5,
-    "type": "Structural Part",
-    "mass": 8.29,
-    "volume": 11,
-    "outputQuantity": 1,
-    "time": 30720,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["3D Printer M"],
-    "input": {
-      "Polycarbonate Plastic": 4,
-      "Vanamer": 7
-    }
-  },
-  "Basic Reinforced Frame XS":{ 
-    "tier": 1,
-    "type": "Structural Part",
-    "mass": 12.88,
-    "volume": 2,
-    "outputQuantity": 5,
-    "time": 200,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 10
-    }
-  },
-  "Basic Reinforced Frame S":{ 
-    "tier": 1,
-    "type": "Structural Part",
-    "mass": 70.84,
-    "volume": 11,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 11
-    }
-  },
-  "Basic Reinforced Frame M":{ 
-    "tier": 1,
-    "type": "Structural Part",
-    "mass": 476,
-    "volume": 74,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 74
-    }
-  },
-  "Basic Reinforced Frame L":{ 
-    "tier": 1,
-    "type": "Structural Part",
-    "mass": 3320,
-    "volume": 515,
-    "outputQuantity": 1,
-    "time": 1080,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 515
-    }
-  },
-  "Basic Reinforced Frame XL":{ 
-    "tier": 1,
-    "type": "Structural Part",
-    "mass": 23200,
-    "volume": 3602,
-    "outputQuantity": 1,
-    "time": 3240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Steel": 3602
-    }
-  },
-  "Uncommon Reinforced Frame XS":{ 
-    "tier": 2,
-    "type": "Structural Part",
-    "mass": 12.64,
-    "volume": 2,
-    "outputQuantity": 1,
-    "time": 160,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 1,
-      "Stainless Steel": 1
-    }
-  },
-  "Uncommon Reinforced Frame S":{ 
-    "tier": 2,
-    "type": "Structural Part",
-    "mass": 69.16,
-    "volume": 11,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 4,
-      "Stainless Steel": 7
-    }
-  },
-  "Uncommon Reinforced Frame M":{ 
-    "tier": 2,
-    "type": "Structural Part",
-    "mass": 464.8,
-    "volume": 74,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 25,
-      "Stainless Steel": 49
-    }
-  },
-  "Uncommon Reinforced Frame L":{ 
-    "tier": 2,
-    "type": "Structural Part",
-    "mass": 3230,
-    "volume": 515,
-    "outputQuantity": 1,
-    "time": 4320,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 172,
-      "Stainless Steel": 343
-    }
-  },
-  "Uncommon Reinforced Frame XL":{ 
-    "tier": 2,
-    "type": "Structural Part",
-    "mass": 22620,
-    "volume": 3602,
-    "outputQuantity": 1,
-    "time": 12960,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 1201,
-      "Stainless Steel": 2401
-    }
-  },
-  "Advanced Reinforced Frame XS":{ 
-    "tier": 3,
-    "type": "Structural Part",
-    "mass": 13.24,
-    "volume": 2,
-    "outputQuantity": 1,
-    "time": 640,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 1,
-      "Inconel": 1
-    }
-  },
-  "Advanced Reinforced Frame S":{ 
-    "tier": 3,
-    "type": "Structural Part",
-    "mass": 73.34,
-    "volume": 11,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 4,
-      "Inconel": 7
-    }
-  },
-  "Advanced Reinforced Frame M":{ 
-    "tier": 3,
-    "type": "Structural Part",
-    "mass": 494.08,
-    "volume": 74,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 25,
-      "Inconel": 49
-    }
-  },
-  "Advanced Reinforced Frame L":{ 
-    "tier": 3,
-    "type": "Structural Part",
-    "mass": 3440,
-    "volume": 515,
-    "outputQuantity": 1,
-    "time": 17280,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 172,
-      "Inconel": 343
-    }
-  },
-  "Advanced Reinforced Frame XL":{ 
-    "tier": 3,
-    "type": "Structural Part",
-    "mass": 24060,
-    "volume": 3602,
-    "outputQuantity": 1,
-    "time": 51840,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 1201,
-      "Inconel": 2401
-    }
-  },
-  "Rare Reinforced Frame L":{ 
-    "tier": 4,
-    "type": "Structural Part",
-    "mass": 3370,
-    "volume": 515,
-    "outputQuantity": 1,
-    "time": 69120,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 172,
-      "Maraging Steel": 343
-    }
-  },
-  "Rare Reinforced Frame XL":{ 
-    "tier": 4,
-    "type": "Structural Part",
-    "mass": 23540,
-    "volume": 3602,
-    "outputQuantity": 1,
-    "time": 207360,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 1201,
-      "Maraging Steel": 2401
-    }
-  },
-  "Exotic Reinforced Frame M":{ 
-    "tier": 5,
-    "type": "Structural Part",
-    "mass": 468.05,
-    "volume": 74,
-    "outputQuantity": 1,
-    "time": 92160,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 25,
-      "Mangalloy": 49
-    }
-  },
-  "Exotic Reinforced Frame L":{ 
-    "tier": 5,
-    "type": "Structural Part",
-    "mass": 3260,
-    "volume": 515,
-    "outputQuantity": 1,
-    "time": 276480,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 172,
-      "Mangalloy": 343
-    }
-  },
-  "Exotic Reinforced Frame XL":{ 
-    "tier": 5,
-    "type": "Structural Part",
-    "mass": 22780,
-    "volume": 3602,
-    "outputQuantity": 1,
-    "time": 829440,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Steel": 1201,
-      "Mangalloy": 2401
-    }
-  },
-  "Basic Standard Frame XS":{ 
-    "tier": 1,
-    "type": "Structural Part",
-    "mass": 4.2,
-    "volume": 2,
-    "outputQuantity": 5,
-    "time": 200,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 10
-    }
-  },
-  "Basic Standard Frame S":{ 
-    "tier": 1,
-    "type": "Structural Part",
-    "mass": 23.1,
-    "volume": 11,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 11
-    }
-  },
-  "Basic Standard Frame M":{ 
-    "tier": 1,
-    "type": "Structural Part",
-    "mass": 155.4,
-    "volume": 74,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 74
-    }
-  },
-  "Basic Standard Frame L":{ 
-    "tier": 1,
-    "type": "Structural Part",
-    "mass": 1080,
-    "volume": 515,
-    "outputQuantity": 1,
-    "time": 1080,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Nanopack","Metalwork Industry M"],
-    "input": {
-      "Silumin": 515
-    }
-  },
-  "Uncommon Standard Frame XS":{ 
-    "tier": 2,
-    "type": "Structural Part",
-    "mass": 4.06,
-    "volume": 2,
-    "outputQuantity": 1,
-    "time": 160,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 1,
-      "Duralumin": 1
-    }
-  },
-  "Uncommon Standard Frame S":{ 
-    "tier": 2,
-    "type": "Structural Part",
-    "mass": 22.12,
-    "volume": 11,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 4,
-      "Duralumin": 7
-    }
-  },
-  "Uncommon Standard Frame M":{ 
-    "tier": 2,
-    "type": "Structural Part",
-    "mass": 148.54,
-    "volume": 74,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 25,
-      "Duralumin": 49
-    }
-  },
-  "Uncommon Standard Frame L":{ 
-    "tier": 2,
-    "type": "Structural Part",
-    "mass": 1030,
-    "volume": 515,
-    "outputQuantity": 1,
-    "time": 4320,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 172,
-      "Duralumin": 343
-    }
-  },
-  "Advanced Standard Frame XS":{ 
-    "tier": 3,
-    "type": "Structural Part",
-    "mass": 3.85,
-    "volume": 2,
-    "outputQuantity": 1,
-    "time": 640,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 1,
-      "Al-Li Alloy": 1
-    }
-  },
-  "Advanced Standard Frame S":{ 
-    "tier": 3,
-    "type": "Structural Part",
-    "mass": 20.65,
-    "volume": 11,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 4,
-      "Al-Li Alloy": 7
-    }
-  },
-  "Advanced Standard Frame M":{ 
-    "tier": 3,
-    "type": "Structural Part",
-    "mass": 138.25,
-    "volume": 74,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 25,
-      "Al-Li Alloy": 49
-    }
-  },
-  "Advanced Standard Frame L":{ 
-    "tier": 3,
-    "type": "Structural Part",
-    "mass": 961.45,
-    "volume": 515,
-    "outputQuantity": 1,
-    "time": 17280,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 172,
-      "Al-Li Alloy": 343
-    }
-  },
-  "Advanced Standard Frame XL":{ 
-    "tier": 3,
-    "type": "Structural Part",
-    "mass": 6720,
-    "volume": 3602,
-    "outputQuantity": 1,
-    "time": 36300,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 1201,
-      "Al-Li Alloy": 2401
-    }
-  },
-  "Rare Standard Frame L":{ 
-    "tier": 4,
-    "type": "Structural Part",
-    "mass": 1050,
-    "volume": 515,
-    "outputQuantity": 1,
-    "time": 69120,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 172,
-      "Sc-Al Alloy": 343
-    }
-  },
-  "Exotic Standard Frame XS":{ 
-    "tier": 5,
-    "type": "Structural Part",
-    "mass": 5.2,
-    "volume": 2,
-    "outputQuantity": 1,
-    "time": 10240,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 1,
-      "Grade 5 Titanium Alloy": 1
-    }
-  },
-  "Exotic Standard Frame L":{ 
-    "tier": 5,
-    "type": "Structural Part",
-    "mass": 1420,
-    "volume": 515,
-    "outputQuantity": 1,
-    "time": 276480,
-    "skill": "",
-    "byproducts": {},
-    "industries": ["Metalwork Industry M"],
-    "input": {
-      "Silumin": 172,
-      "Grade 5 Titanium Alloy": 343
-    }
-  },
-  "Dynamic Core XS":{ 
-    "tier": 1,
-    "type": "Core Unit",
-    "mass": 70.89,
-    "volume": 16.1,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Basic Power System": 1,
-      "Basic Core System XS": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Dynamic Core S":{ 
-    "tier": 2,
-    "type": "Core Unit",
-    "mass": 375.97,
-    "volume": 87.2,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic Component": 3,
-      "Uncommon Component": 3,
-      "Uncommon Power System": 5,
-      "Uncommon Core System S": 1,
-      "Uncommon Standard Frame S": 1
-    }
-  },
-  "Dynamic Core M":{ 
-    "tier": 3,
-    "type": "Core Unit",
-    "mass": 1980,
-    "volume": 454.8,
-    "outputQuantity": 1,
-    "time": 21600,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Component": 36,
-      "Advanced Power System": 25,
-      "Advanced Core System M": 1,
-      "Advanced Standard Frame M": 1
-    }
-  },
-  "Dynamic Core L":{ 
-    "tier": 4,
-    "type": "Core Unit",
-    "mass": 12140,
-    "volume": 2501,
-    "outputQuantity": 1,
-    "time": 259200,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Component": 108,
-      "Advanced Component": 108,
-      "Rare Power System": 125,
-      "Rare Core System L": 1,
-      "Rare Standard Frame L": 1
-    }
-  },
-  "Static Core XS":{ 
-    "tier": 1,
-    "type": "Core Unit",
-    "mass": 70.89,
-    "volume": 16.1,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Basic Power System": 1,
-      "Basic Core System XS": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Static Core S":{ 
-    "tier": 1,
-    "type": "Core Unit",
-    "mass": 360.18,
-    "volume": 83.6,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Component": 6,
-      "Basic Power System": 5,
-      "Basic Core System S": 1,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Static Core M":{ 
-    "tier": 2,
-    "type": "Core Unit",
-    "mass": 1930,
-    "volume": 454.80,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Component": 18,
-      "Uncommon Component": 18,
-      "Uncommon Power System": 25,
-      "Uncommon Core System M": 1,
-      "Uncommon Standard Frame M": 1
-    }
-  },
-  "Static Core L":{ 
-    "tier": 2,
-    "type": "Core Unit",
-    "mass": 10700,
-    "volume": 2501,
-    "outputQuantity": 1,
-    "time": 21600,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Component": 108,
-      "Uncommon Component": 108,
-      "Uncommon Power System": 125,
-      "Uncommon Core System L": 1,
-      "Uncommon Standard Frame L": 1
-    }
-  },
-  "Space Core XS":{ 
-    "tier": 1,
-    "type": "Core Unit",
-    "mass": 38.99,
-    "volume": 14,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Basic Power System": 1,
-      "Basic Core System XS": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Space Core S":{ 
-    "tier": 2,
-    "type": "Core Unit",
-    "mass": 459.57,
-    "volume": 120,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic Component": 3,
-      "Uncommon Component": 3,
-      "Uncommon Power System": 5,
-      "Uncommon Core System S": 1,
-      "Uncommon Standard Frame S": 1
-    }
-  },
-  "Space Core M":{ 
-    "tier": 3,
-    "type": "Core Unit",
-    "mass": 3040,
-    "volume": 420,
-    "outputQuantity": 1,
-    "time": 21600,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Component": 36,
-      "Advanced Power System": 25,
-      "Advanced Core System M": 1,
-      "Advanced Anti-Gravity Core": 16,
-      "Advanced Standard Frame M": 1
-    }
-  },
-  "Space Core L":{ 
-    "tier": 4,
-    "type": "Core Unit",
-    "mass": 7680,
-    "volume": 1383,
-    "outputQuantity": 1,
-    "time": 259200,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Component": 108,
-      "Advanced Component": 108,
-      "Rare Power System": 125,
-      "Rare Core System L": 1,
-      "Rare Anti-Gravity Core": 64,
-      "Rare Standard Frame L": 1
-    }
-  },
-  "Territory Unit":{ 
-    "tier": 5,
-    "type": "Core Unit",
-    "mass": 20050,
-    "volume": 4118.29,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Fixation": 18,
-      "Uncommon Fixation": 18,
-      "Uncommon Processor": 25,
-      "Uncommon Power Transformer M": 1,
-      "Uncommon Standard Frame M": 1
-    }
-  },
-  "Container Hub":{ 
-    "tier": 1,
-    "type": "Container",
-    "mass": 55.8,
-    "volume": 44.3,
-    "outputQuantity": 1,
-    "time": 1380,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Component": 1,
-      "Advanced Electronics": 1,
-      "Advanced Screen XS": 1,
-      "Advanced Quantum Alignment Unit": 1,
-      "Advanced Casing XS": 1
-    }
-  },
-  "Container XS":{ 
-    "tier": 1,
-    "type": "Container",
-    "mass": 229.09,
-    "volume": 64,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Component": 6,
-      "Basic Hydraulics": 5,
-      "Basic Reinforced Frame S": 1
-    }
-  },
-  "Container S":{ 
-    "tier": 1,
-    "type": "Container",
-    "mass": 1281.31,
-    "volume": 342,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Component": 36,
-      "Basic Hydraulics": 25,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Container M":{ 
-    "tier": 1,
-    "type": "Container",
-    "mass": 7421.35,
-    "volume": 1873,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Component": 216,
-      "Basic Hydraulics": 125,
-      "Basic Reinforced Frame L": 1
-    }
-  },
-  "Container L":{ 
-    "tier": 1,
-    "type": "Container",
-    "mass": 14842.7,
-    "volume": 3746,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Component": 432,
-      "Basic Hydraulics": 250,
-      "Basic Reinforced Frame L": 2
-    }
-  },
-  "Dispenser":{ 
-    "tier": 1,
-    "type": "Container",
-    "mass": 2060,
-    "volume": 479.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 36,
-      "Basic Power System": 25,
-      "Basic Screen M": 1,
-      "Basic Standard Frame M": 1
-    }
-  },
-  "Heavy Dispenser":{ 
-    "tier": 3,
-    "type": "Container",
-    "mass": 61520,
-    "volume": 15070,
-    "outputQuantity": 1,
-    "time": 277200,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Uncommon Screw": 1296,
-      "Advanced Power System": 625,
-      "Advanced Screen XL": 1,
-      "Advanced Standard Frame XL": 1
-    }
-  },
-  "Medium Dispenser":{ 
-    "tier": 2,
-    "type": "Container",
-    "mass": 11230,
-    "volume": 2659.4,
-    "outputQuantity": 1,
-    "time": 23040,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 108,
-      "Uncommon Screw": 108,
-      "Uncommon Power System": 125,
-      "Uncommon Screen L": 1,
-      "Uncommon Standard Frame L": 1
-    }
-  },
-  "Atmospheric Fuel-Tank XS":{ 
-    "tier": 1,
-    "type": "Piloting",
-    "mass": 35.03,
-    "volume": 17.8,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Pipe": 1,
-      "Basic Injector": 1,
-      "Basic Chemical Container XS": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Atmospheric Fuel-Tank S":{ 
-    "tier": 1,
-    "type": "Piloting",
-    "mass": 182.67,
-    "volume": 92.6,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Pipe": 6,
-      "Basic Injector": 5,
-      "Basic Chemical Container S": 1,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Atmospheric Fuel-Tank M":{ 
-    "tier": 1,
-    "type": "Piloting",
-    "mass": 988.67,
-    "volume": 499.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Pipe": 36,
-      "Basic Injector": 25,
-      "Basic Chemical Container M": 1,
-      "Basic Standard Frame M": 1
-    }
-  },
-  "Atmospheric Fuel-Tank L":{ 
-    "tier": 1,
-    "type": "Container",
-    "mass": 5480,
-    "volume": 2755.4,
-    "outputQuantity": 1,
-    "time": 7200,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Pipe": 216,
-      "Basic Injector": 125,
-      "Basic Chemical Container L": 1,
-      "Basic Standard Frame L": 1
-    }
-  },
-  "Space Fuel-Tank S":{ 
-    "tier": 2,
-    "type": "Container",
-    "mass": 182.67,
-    "volume": 92.6,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Pipe": 6,
-      "Basic Injector": 5,
-      "Basic Chemical Container S": 1,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Space Fuel-Tank M":{ 
-    "tier": 2,
-    "type": "Container",
-    "mass": 988.67,
-    "volume": 499.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Pipe": 36,
-      "Basic Injector": 25,
-      "Basic Chemical Container M": 1,
-      "Basic Standard Frame M": 1
-    }
-  },
-  "Space Fuel-Tank L":{ 
-    "tier": 2,
-    "type": "Container",
-    "mass": 5480,
-    "volume": 2755.4,
-    "outputQuantity": 1,
-    "time": 7200,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Pipe": 216,
-      "Basic Injector": 125,
-      "Basic Chemical Container L": 1,
-      "Basic Standard Frame L": 1
-    }
-  },
-  "Rocket Fuel-Tank XS":{ 
-    "tier": 3,
-    "type": "Container",
-    "mass": 173.42,
-    "volume": 96.6,
-    "outputQuantity": 1,
-    "time": 4320,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Pipe": 6,
-      "Advanced Injector": 5,
-      "Advanced Chemical Container S": 1,
-      "Advanced Casing S": 1
-    }
-  },
-  "Rocket Fuel-Tank S":{ 
-    "tier": 3,
-    "type": "Container",
-    "mass": 886.72,
-    "volume": 503.2,
-    "outputQuantity": 1,
-    "time": 18000,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Pipe": 36,
-      "Advanced Injector": 25,
-      "Advanced Chemical Container M": 1,
-      "Advanced Casing M": 1
-    }
-  },
-  "Rocket Fuel-Tank M":{ 
-    "tier": 3,
-    "type": "Container",
-    "mass": 6231,
-    "volume": 6400,
-    "outputQuantity": 1,
-    "time": 68400,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Pipe": 216,
-      "Advanced Injector": 125,
-      "Advanced Chemical Container L": 1,
-      "Advanced Casing L": 1
-    }
-  },
-  "Rocket Fuel-Tank L":{ 
-    "tier": 3,
-    "type": "Container",
-    "mass": 25740,
-    "volume": 15570,
-    "outputQuantity": 1,
-    "time": 259200,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Uncommon Pipe": 1296,
-      "Advanced Injector": 625,
-      "Advanced Chemical Container XL": 1,
-      "Advanced Casing XL": 1
-    }
-  },
-  "Ammo Container XS":{ 
-    "tier": 1,
-    "type": "Container",
-    "mass": 216.15,
-    "volume": 67,
-    "outputQuantity": 1,
-    "time": 720,
-    "skill": "Combat",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Screw": 6,
-      "Basic Hydraulics": 5,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Ammo Container S":{ 
-    "tier": 1,
-    "type": "Container",
-    "mass": 1170,
-    "volume": 360,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "Combat",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 36,
-      "Basic Hydraulics": 25,
-      "Basic Standard Frame M": 1
-    }
-  },
-  "Ammo Container M":{ 
-    "tier": 1,
-    "type": "Container",
-    "mass": 6440,
-    "volume": 1981,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Combat",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 216,
-      "Basic Hydraulics": 125,
-      "Basic Standard Frame L": 1
-    }
-  },
-  "Ammo Container L":{ 
-    "tier": 1,
-    "type": "Container",
-    "mass": 12880,
-    "volume": 3962,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Combat",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 432,
-      "Basic Hydraulics": 250,
-      "Basic Standard Frame L": 2
-    }
-  },
-  "Assembly Line XS":{ 
-    "tier": 1,
-    "type": "Industry",
-    "mass": 100.93,
-    "volume": 21.8,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Nanopack", "Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Basic Power System": 1,
-      "Basic Mobile Panel XS": 1,
-      "Basic Reinforced Frame XS": 1
-    }
-  },
-  
-  "Assembly Line S":{ 
-    "tier": 1,
-    "type": "Industry",
-    "mass": 522.14,
-    "volume": 112.6,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS","Assembly Line S"],
-    "input": {
-      "Basic Screw": 6,
-      "Basic Power System": 5,
-      "Basic Mobile Panel S": 1,
-      "Basic Reinforced Frame S": 1
-    }
-  },
-  "Assembly Line M":{ 
-    "tier": 1,
-    "type": "Industry",
-    "mass": 2800,
-    "volume": 599.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line S","Assembly Line M"],
-    "input": {
-      "Basic Screw": 36,
-      "Basic Power System": 25,
-      "Basic Mobile Panel M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Assembly Line L":{ 
-    "tier": 1,
-    "type": "Industry",
-    "mass": 15380,
-    "volume": 3255.4,
-    "outputQuantity": 1,
-    "time": 7200,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line M","Assembly Line L"],
-    "input": {
-      "Basic Screw": 216,
-      "Basic Power System": 125,
-      "Basic Mobile Panel L": 1,
-      "Basic Reinforced Frame L": 1
-    }
-  },
-  "Assembly Line XL":{ 
-    "tier": 1,
-    "type": "Industry",
-    "mass": 86290,
-    "volume": 18070,
-    "outputQuantity": 1,
-    "time": 32400,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line L","Assembly Line XL"],
-    "input": {
-      "Basic Screw": 1296,
-      "Basic Power System": 625,
-      "Basic Mobile Panel XL": 1,
-      "Basic Reinforced Frame XL": 1
-    }
-  },
-  "3D Printer M":{ 
-    "tier": 1,
-    "type": "Industry",
-    "mass": 2000,
-    "volume": 609.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Pipe": 36,
-      "Basic Injector": 25,
-      "Basic Robotic Arm M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Chemical Industry M":{ 
-    "tier": 1,
-    "type": "Industry",
-    "mass": 2300,
-    "volume": 479.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Pipe": 36,
-      "Basic Power System": 25,
-      "Basic Chemical Container M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Electronics Industry M":{ 
-    "tier": 1,
-    "type": "Industry",
-    "mass": 1620,
-    "volume": 459.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Pipe": 36,
-      "Basic Electronics": 25,
-      "Basic Robotic Arm M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Glass Furnace M":{ 
-    "tier": 1,
-    "type": "Industry",
-    "mass": 2830,
-    "volume": 556.4,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Pipe": 36,
-      "Basic Burner": 25,
-      "Basic Power Transformer M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Honeycomb Refinery M":{ 
-    "tier": 1,
-    "type": "Industry",
-    "mass": 2990,
-    "volume": 589.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Pipe": 36,
-      "Basic Power System": 25,
-      "Basic Robotic Arm M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Metalwork Industry M":{ 
-    "tier": 1,
-    "type": "Industry",
-    "mass": 2600,
-    "volume": 599.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Pipe": 36,
-      "Basic Power System": 25,
-      "Basic Mobile Panel M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Recycler M":{ 
-    "tier": 1,
-    "type": "Industry",
-    "mass": 2350,
-    "volume": 619.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Pipe": 36,
-      "Basic Burner": 25,
-      "Basic Mobile Panel M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Refiner M":{ 
-    "tier": 1,
-    "type": "Industry",
-    "mass": 2300,
-    "volume": 479.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Pipe": 36,
-      "Basic Power System": 25,
-      "Basic Chemical Container M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Smelter M":{ 
-    "tier": 1,
-    "type": "Industry",
-    "mass": 2060,
-    "volume": 499.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Pipe": 36,
-      "Basic Burner": 25,
-      "Basic Chemical Container M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Transfer Unit":{ 
-    "tier": 1,
-    "type": "Industry",
-    "mass": 10150,
-    "volume": 3305.4,
-    "outputQuantity": 1,
-    "time": 7200,
-    "skill": "InIn",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Pipe": 216,
-      "Basic Hydraulics": 125,
-      "Basic Robotic Arm L": 1,
-      "Basic Standard Frame L": 1
-    }
-  },
-  "Retro-Rocket Brake S":{ 
-    "tier": 1,
-    "type": "Space Brake",
-    "mass": 137.55,
-    "volume": 20.33,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Basic Burner": 1,
-      "Basic Ionic Chamber XS": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Retro-Rocket Brake M":{ 
-    "tier": 1,
-    "type": "Space Brake",
-    "mass": 714,
-    "volume": 105.24,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Screw": 6,
-      "Basic Burner": 5,
-      "Basic Ionic Chamber S": 1,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Retro-Rocket Brake L":{ 
-    "tier": 1,
-    "type": "Space Brake",
-    "mass": 3770,
-    "volume": 562.4,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 36,
-      "Basic Burner": 25,
-      "Basic Ionic Chamber M": 1,
-      "Basic Standard Frame M": 1
-    }
-  },
-  "Atmospheric Airbrake S":{ 
-    "tier": 1,
-    "type": "Airbrake",
-    "mass": 55.55,
-    "volume": 22.6,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Pipe": 1,
-      "Basic Hydraulics": 1,
-      "Basic Mobile Panel XS": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Atmospheric Airbrake M":{ 
-    "tier": 1,
-    "type": "Airbrake",
-    "mass": 285.25,
-    "volume": 116.6,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Pipe": 6,
-      "Basic Hydraulics": 5,
-      "Basic Mobile Panel S": 1,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Atmospheric Airbrake L":{ 
-    "tier": 1,
-    "type": "Airbrake",
-    "mass": 1500,
-    "volume": 619.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Pipe": 36,
-      "Basic Hydraulics": 25,
-      "Basic Mobile Panel M": 1,
-      "Basic Standard Frame M": 1
-    }
-  },
-  "Compact Aileron XS":{ 
-    "tier": 1,
-    "type": "Aileron",
-    "mass": 61.2,
-    "volume": 22.6,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Basic Hydraulics": 1,
-      "Basic Mobile Panel XS": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Compact Aileron S":{ 
-    "tier": 1,
-    "type": "Aileron",
-    "mass": 319.15,
-    "volume": 116.6,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Screw": 6,
-      "Basic Hydraulics": 5,
-      "Basic Mobile Panel S": 1,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Compact Aileron M":{ 
-    "tier": 1,
-    "type": "Aileron",
-    "mass": 1705,
-    "volume": 619.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 36,
-      "Basic Hydraulics": 25,
-      "Basic Mobile Panel M": 1,
-      "Basic Standard Frame M": 1
-    }
-  },
-  "Aileron XS":{ 
-    "tier": 1,
-    "type": "Aileron",
-    "mass": 122.4,
-    "volume": 45.2,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Screw": 2,
-      "Basic Hydraulics": 2,
-      "Basic Mobile Panel XS": 2,
-      "Basic Standard Frame XS": 2
-    }
-  },
-  "Aileron S":{ 
-    "tier": 1,
-    "type": "Aileron",
-    "mass": 638.3,
-    "volume": 233.2,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Screw": 12,
-      "Basic Hydraulics": 10,
-      "Basic Mobile Panel S": 2,
-      "Basic Standard Frame S": 2
-    }
-  },
-  "Aileron M":{ 
-    "tier": 1,
-    "type": "Aileron",
-    "mass": 3410,
-    "volume": 1238.4,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 72,
-      "Basic Hydraulics": 50,
-      "Basic Mobile Panel M": 2,
-      "Basic Standard Frame M": 2
-    }
-  },
-  "Stabilizer XS":{ 
-    "tier": 1,
-    "type": "Stabilizer",
-    "mass": 69.88,
-    "volume": 22.6,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Basic Hydraulics": 1,
-      "Basic Mobile Panel XS": 1,
-      "Basic Reinforced Frame XS": 1
-    }
-  },
-  "Stabilizer S":{ 
-    "tier": 1,
-    "type": "Stabilizer",
-    "mass": 366.89,
-    "volume": 116.6,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Screw": 6,
-      "Basic Hydraulics": 5,
-      "Basic Mobile Panel S": 1,
-      "Basic Reinforced Frame S": 1
-    }
-  },
-  "Stabilizer M":{ 
-    "tier": 1,
-    "type": "Stabilizer",
-    "mass": 2030,
-    "volume": 619.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 36,
-      "Basic Hydraulics": 25,
-      "Basic Mobile Panel M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Stabilizer L":{ 
-    "tier": 1,
-    "type": "Stabilizer",
-    "mass": 11500,
-    "volume": 3355.4,
-    "outputQuantity": 1,
-    "time": 7200,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 216,
-      "Basic Hydraulics": 125,
-      "Basic Mobile Panel L": 1,
-      "Basic Reinforced Frame L": 1
-    }
-  },
-  "Wing XS":{ 
-    "tier": 1,
-    "type": "Wing",
-    "mass": 61.2,
-    "volume": 22.6,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Basic Hydraulics": 1,
-      "Basic Mobile Panel XS": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Wing S":{ 
-    "tier": 1,
-    "type": "Wing",
-    "mass": 319.15,
-    "volume": 116.6,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Screw": 6,
-      "Basic Hydraulics": 5,
-      "Basic Mobile Panel S": 1,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Wing M":{ 
-    "tier": 1,
-    "type": "Wing",
-    "mass": 1700,
-    "volume": 619.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 36,
-      "Basic Hydraulics": 35,
-      "Basic Mobile Panel M": 1,
-      "Basic Standard Frame M": 1
-    }
-  },
-  "Wing Variant M":{ 
-    "tier": 1,
-    "type": "Wing",
-    "mass": 1700,
-    "volume": 619.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 36,
-      "Basic Hydraulics": 35,
-      "Basic Mobile Panel M": 1,
-      "Basic Standard Frame M": 1
-    }
-  },
-  "Atmospheric Engine XS":{ 
-    "tier": 1,
-    "type": "Atmospheric Engine",
-    "mass": 101.88,
-    "volume": 22.6,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Basic Injector": 1,
-      "Basic Combustion Chamber XS": 1,
-      "Basic Reinforced Frame XS": 1
-    }
-  },
-  "Atmospheric Engine S":{ 
-    "tier": 1,
-    "type": "Atmospheric Engine",
-    "mass": 539.99,
-    "volume": 116.6,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Screw": 6,
-      "Basic Injector": 5,
-      "Basic Combustion Chamber S": 1,
-      "Basic Reinforced Frame S": 1
-    }
-  },
-  "Atmospheric Engine M":{ 
-    "tier": 1,
-    "type": "Atmospheric Engine",
-    "mass": 2980,
-    "volume": 619.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 36,
-      "Basic Injector": 25,
-      "Basic Combustion Chamber M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Atmospheric Engine L":{ 
-    "tier": 1,
-    "type": "Atmospheric Engine",
-    "mass": 16930,
-    "volume": 3355.4,
-    "outputQuantity": 1,
-    "time": 7200,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 216,
-      "Basic Injector": 125,
-      "Basic Combustion Chamber L": 1,
-      "Basic Reinforced Frame L": 1
-    }
-  },
-  "Space Engine XS":{ 
-    "tier": 1,
-    "type": "Space Engine",
-    "mass": 146.23,
-    "volume": 20.33,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Basic Burner": 1,
-      "Basic Ionic Chamber XS": 1,
-      "Basic Reinforced Frame XS": 1
-    }
-  },
-  "Space Engine S":{ 
-    "tier": 1,
-    "type": "Space Engine",
-    "mass": 761.74,
-    "volume": 105.24,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Screw": 6,
-      "Basic Burner": 5,
-      "Basic Ionic Chamber S": 1,
-      "Basic Reinforced Frame S": 1
-    }
-  },
-  "Space Engine M":{ 
-    "tier": 1,
-    "type": "Space Engine",
-    "mass": 4090,
-    "volume": 562.4,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 36,
-      "Basic Burner": 25,
-      "Basic Ionic Chamber M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Space Engine L":{ 
-    "tier": 1,
-    "type": "Space Engine",
-    "mass": 22470,
-    "volume": 3071.4,
-    "outputQuantity": 1,
-    "time": 7200,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 216,
-      "Basic Burner": 125,
-      "Basic Ionic Chamber L": 1,
-      "Basic Reinforced Frame L": 1
-    }
-  },
-  "Space Engine XL":{ 
-    "tier": 1,
-    "type": "Space Engine",
-    "mass": 126240,
-    "volume": 17150,
-    "outputQuantity": 1,
-    "time": 32400,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Basic Screw": 1296,
-      "Basic Burner": 625,
-      "Basic Ionic Chamber XL": 1,
-      "Basic Reinforced Frame XL": 1
-    }
-  },
-  "Hover Engine S":{ 
-    "tier": 1,
-    "type": "Hover Engine",
-    "mass": 56.91,
-    "volume": 22.6,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Basic Injector": 1,
-      "Basic Gas Cylinder XS": 1,
-      "Basic Reinforced Frame XS": 1
-    }
-  },
-  "Hover Engine M":{ 
-    "tier": 2,
-    "type": "Hover Engine",
-    "mass": 302.02,
-    "volume": 116.6,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Screw": 6,
-      "Basic Injector": 5,
-      "Basic Gas Cylinder S": 1,
-      "Basic Reinforced Frame S": 1
-    }
-  },
-  "Hover Engine L":{ 
-    "tier": 2,
-    "type": "Hover Engine",
-    "mass": 1700,
-    "volume": 619.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 36,
-      "Basic Injector": 25,
-      "Basic Gas Cylinder M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Flat Hover Engine L":{ 
-    "tier": 2,
-    "type": "Hover Engine",
-    "mass": 1700,
-    "volume": 619.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 36,
-      "Basic Injector": 25,
-      "Basic Gas Cylinder M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Adjustor XS":{ 
-    "tier": 1,
-    "type": "Adjustor",
-    "mass": 22.7,
-    "volume": 11,
-    "outputQuantity": 1,
-    "time": 30,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Pipe": 1,
-      "Basic Injector": 1
-    }
-  },
-  "Adjustor S":{ 
-    "tier": 1,
-    "type": "Adjustor",
-    "mass": 42.58,
-    "volume": 22.6,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Pipe": 1,
-      "Basic Injector": 1,
-      "Basic Gas Cylinder XS": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Adjustor M":{ 
-    "tier": 1,
-    "type": "Adjustor",
-    "mass": 220.38,
-    "volume": 116.6,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Pipe": 6,
-      "Basic Injector": 5,
-      "Basic Gas Cylinder S": 1,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Adjustor L":{ 
-    "tier": 1,
-    "type": "Adjustor",
-    "mass": 1180,
-    "volume": 619.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Pipe": 36,
-      "Basic Injector": 25,
-      "Basic Gas Cylinder M": 1,
-      "Basic Standard Frame M": 1
-    }
-  },
-  "Rocket Engine S":{ 
-    "tier": 3,
-    "type": "Rocket Engine",
-    "mass": 2223.76,
-    "volume": 40.2,
-    "outputQuantity": 1,
-    "time": 1080,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Screw": 1,
-      "Advanced Burner": 1,
-      "Advanced Combustion Chamber XS": 1,
-      "Advanced Standard Frame XS": 1
-    }
-  },
-  "Rocket Engine M":{ 
-    "tier": 3,
-    "type": "Rocket Engine",
-    "mass": 680.05,
-    "volume": 125.4,
-    "outputQuantity": 1,
-    "time": 4320,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Screw": 6,
-      "Advanced Burner": 5,
-      "Advanced Combustion Chamber S": 1,
-      "Advanced Standard Frame S": 1
-    }
-  },
-  "Rocket Engine L":{ 
-    "tier": 4,
-    "type": "Rocket Engine",
-    "mass": 3390,
-    "volume": 628,
-    "outputQuantity": 1,
-    "time": 18000,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Screw": 36,
-      "Advanced Burner": 25,
-      "Advanced Combustion Chamber M": 1,
-      "Advanced Standard Frame M": 1
-    }
-  },
-  "Vertical Booster XS":{ 
-    "tier": 1,
-    "type": "Vertical Booster",
-    "mass": 22.7,
-    "volume": 11,
-    "outputQuantity": 1,
-    "time": 30,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Pipe": 1,
-      "Basic Injector": 1
-    }
-  },
-  "Vertical Booster S":{ 
-    "tier": 1,
-    "type": "Vertical Booster",
-    "mass": 102,
-    "volume": 20.33,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Pipe": 1,
-      "Basic Injector": 1,
-      "Basic Ionic Chamber XS": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Vertical Booster M":{ 
-    "tier": 1,
-    "type": "Vertical Booster",
-    "mass": 530.6,
-    "volume": 105.24,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Pipe": 6,
-      "Basic Injector": 5,
-      "Basic Ionic Chamber S": 1,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Vertical Booster L":{ 
-    "tier": 1,
-    "type": "Vertical Booster",
-    "mass": 2820,
-    "volume": 562.4,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Pipe": 36,
-      "Basic Injector": 25,
-      "Basic Ionic Chamber M": 1,
-      "Basic Standard Frame M": 1
-    }
-  },
-  "Elevator XS":{ 
-    "tier": 1,
-    "type": "Interactive Element",
-    "mass": 207.86,
-    "volume": 57.56,
-    "outputQuantity": 1,
-    "time": 1380,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Component": 1,
-      "Advanced Power System": 1,
-      "Advanced Mechanical Sensor XS": 1,
-      "Advanced Quantum Alignment Unit": 1,
-      "Advanced Standard Frame XS": 1
-    }
-  },
-  "Landing Gear XS":{ 
-    "tier": 1,
-    "type": "Landing Gear",
-    "mass": 49.88,
-    "volume": 13,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Basic Hydraulics": 1,
-      "Basic Reinforced Frame XS": 1
-    }
-  },
-  "Landing Gear S":{ 
-    "tier": 2,
-    "type": "Landing Gear",
-    "mass": 258.76,
-    "volume": 67,
-    "outputQuantity": 1,
-    "time": 1080,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic Screw": 3,
-      "Uncommon Screw": 3,
-      "Uncommon Hydraulics": 5,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Landing Gear M":{ 
-    "tier": 2,
-    "type": "Landing Gear",
-    "mass": 1460,
-    "volume": 360,
-    "outputQuantity": 1,
-    "time": 4320,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 18,
-      "Uncommon Screw": 18,
-      "Uncommon Hydraulics": 25,
-      "Uncommon Reinforced Frame M": 1
-    }
-  },
-  "Landing Gear L":{ 
-    "tier": 2,
-    "type": "Landing Gear",
-    "mass": 8500,
-    "volume": 1981,
-    "outputQuantity": 1,
-    "time": 18000,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 108,
-      "Uncommon Screw": 108,
-      "Uncommon Hydraulics": 125,
-      "Uncommon Reinforced Frame L": 1
-    }
-  },
-  "Force Field XS":{ 
-    "tier": 1,
-    "type": "Force Field",
-    "mass": 207.86,
-    "volume": 57.56,
-    "outputQuantity": 1,
-    "time": 1380,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Component": 1,
-      "Advanced Power System": 1,
-      "Advanced Quantum Barrier": 1
-    }
-  },
-  "Force Field S":{ 
-    "tier": 3,
-    "type": "Force Field",
-    "mass": 110.62,
-    "volume": 34.7,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Component": 1,
-      "Advanced Power System": 1,
-      "Advanced Quantum Barrier": 1
-    }
-  },
-  "Force Field M":{ 
-    "tier": 3,
-    "type": "Force Field",
-    "mass": 110.62,
-    "volume": 34.7,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Component": 1,
-      "Advanced Power System": 1,
-      "Advanced Quantum Barrier": 1
-    }
-  },
-  "Force Field L":{ 
-    "tier": 3,
-    "type": "Force Field",
-    "mass": 110.62,
-    "volume": 34.7,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Component": 1,
-      "Advanced Power System": 1,
-      "Advanced Quantum Barrier": 1
-    }
-  },
-  "Territory Scanner":{ 
-    "tier": 2,
-    "type": "Instrument",
-    "mass": 66460,
-    "volume": 12700,
-    "outputQuantity": 1,
-    "time": 93600,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Basic Component": 648,
-      "Uncommon Component": 648,
-      "Uncommon Power System": 625,
-      "Uncommon Ore Scanner XL": 1,
-      "Uncommon Reinforced Frame XL": 1
-    }
-  },
-  "Gyroscope":{ 
-    "tier": 1,
-    "type": "Instrument",
-    "mass": 104.41,
-    "volume": 17.65,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Connector": 1,
-      "Basic Magnet": 1,
-      "Basic Mechanical Sensor XS": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Telemeter":{ 
-    "tier": 2,
-    "type": "Instrument",
-    "mass": 40.79,
-    "volume": 31.4,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Optics": 1,
-      "Uncommon Laser Chamber XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Remote Controller":{ 
-    "tier": 3,
-    "type": "Control Unit",
-    "mass": 7.79,
-    "volume": 4.5,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Component": 1,
-      "Advanced Electronics": 1
-    }
-  },
-  "Hovercraft Seat Controller":{ 
-    "tier": 1,
-    "type": "Control Unit",
-    "mass": 110.33,
-    "volume": 61.6,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Component": 6,
-      "Basic Electronics": 5,
-      "Basic Control System S": 1,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Emergency Controller":{ 
-    "tier": 3,
-    "type": "Control Unit",
-    "mass": 9.35,
-    "volume": 4.8,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Connector": 1,
-      "Advanced Electronics": 1
-    }
-  },
-  "Command Seat Controller":{ 
-    "tier": 1,
-    "type": "Control Unit",
-    "mass": 158.45,
-    "volume": 66.6,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Component": 6,
-      "Basic Processor": 5,
-      "Basic Control System S": 1,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Cockpit Controller":{ 
-    "tier": 1,
-    "type": "Control Unit",
-    "mass": 1210,
-    "volume": 491.2,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Component": 36,
-      "Basic Hydraulics": 25,
-      "Basic Control System M": 1,
-      "Basic Standard Frame M": 1
-    }
-  },
-  "Programming Board":{ 
-    "tier": 1,
-    "type": "Control Unit",
-    "mass": 27.74,
-    "volume": 12.7,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Basic Processor": 1,
-      "Basic Control System XS": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Gunner Module S":{ 
-    "tier": 2,
-    "type": "Control Unit",
-    "mass": 427.9,
-    "volume": 93.8,
-    "outputQuantity": 1,
-    "time": 4320,
-    "skill": "Combat",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Connector": 6,
-      "Advanced Power System": 5,
-      "Advanced Control System S": 1,
-      "Advanced Standard Frame S": 1
-    }
-  },
-  "Gunner Module M":{ 
-    "tier": 2,
-    "type": "Control Unit",
-    "mass": 2170,
-    "volume": 486.4,
-    "outputQuantity": 1,
-    "time": 18000,
-    "skill": "Combat",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Connector": 36,
-      "Advanced Power System": 25,
-      "Advanced Control System M": 1,
-      "Advanced Standard Frame M": 1
-    }
-  },
-  "Gunner Module L":{ 
-    "tier": 2,
-    "type": "Control Unit",
-    "mass": 11320,
-    "volume": 2666.6,
-    "outputQuantity": 1,
-    "time": 68400,
-    "skill": "Combat",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Connector": 216,
-      "Advanced Power System": 125,
-      "Advanced Control System L": 1,
-      "Advanced Standard Frame L": 1
-    }
-  },
-  "Anti-Gravity Generator S":{ 
-    "tier": 4,
-    "type": "Anti-Gravity Generator",
-    "mass": 27130,
-    "volume": 4279.69,
-    "outputQuantity": 1,
-    "time": 259200,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Component": 108,
-      "Advanced Component": 108,
-      "Rare Power System": 125,
-      "Rare Power Transformer L": 1,
-      "Rare Anti-Gravity Core": 64,
-      "Rare Reinforced Frame L": 1
-    }
-  },
-  "Anti-Gravity Generator M":{ 
-    "tier": 4,
-    "type": "Anti-Gravity Generator",
-    "mass": 137720,
-    "volume": 21620,
-    "outputQuantity": 1,
-    "time": 1036800,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Uncommon Component": 648,
-      "Advanced Component": 648,
-      "Rare Power System": 625,
-      "Rare Power Transformer XL": 1,
-      "Rare Anti-Gravity Core": 256,
-      "Rare Reinforced Frame XL": 1
-    }
-  },
-  "Anti-Gravity Generator L":{ 
-    "tier": 4,
-    "type": "Anti-Gravity Generator",
-    "mass": 550870,
-    "volume": 86470,
-    "outputQuantity": 1,
-    "time": 1036800,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Uncommon Component": 2592,
-      "Advanced Component": 2592,
-      "Rare Power System": 2500,
-      "Rare Power Transformer XL": 4,
-      "Rare Anti-Gravity Core": 1024,
-      "Rare Reinforced Frame XL": 4
-    }
-  },
-  "Anti-Gravity Pulsor":{ 
-    "tier": 3,
-    "type": "Anti-Gravity Generator",
-    "mass": 6210,
-    "volume": 804.93,
-    "outputQuantity": 1,
-    "time": 21600,
-    "skill": "Piloting",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Component": 36,
-      "Advanced Magnet": 25,
-      "Advanced Ionic Chamber M": 1,
-      "Advanced Anti-Gravity Core": 16,
-      "Advanced Reinforced Frame M": 1
-    }
-  },
-  "Sliding Door S":{ 
-    "tier": 1,
-    "type": "Door/Gate",
-    "mass": 749.15,
-    "volume": 102.04,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Screw": 6,
-      "Basic Power System": 5,
-      "Basic Electric Engine S": 1,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Sliding Door M":{ 
-    "tier": 1,
-    "type": "Door/Gate",
-    "mass": 1010,
-    "volume": 151.8,
-    "outputQuantity": 1,
-    "time": 1200,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Steel": 49,
-      "Basic Connector": 36,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Reinforced Sliding Door":{ 
-    "tier": 1,
-    "type": "Door/Gate",
-    "mass": 4200,
-    "volume": 546.4,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 36,
-      "Basic Power System": 25,
-      "Basic Electric Engine M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Interior Door":{ 
-    "tier": 1,
-    "type": "Door/Gate",
-    "mass": 4200,
-    "volume": 546.4,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 36,
-      "Basic Power System": 25,
-      "Basic Electric Engine M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Airlock":{ 
-    "tier": 1,
-    "type": "Door/Gate",
-    "mass": 4200,
-    "volume": 546.4,
-    "outputQuantity": 1,
-    "time": 1920,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 36,
-      "Basic Power System": 25,
-      "Basic Electric Engine M": 1,
-      "Basic Reinforced Frame M": 1
-    }
-  },
-  "Gate XS":{ 
-    "tier": 2,
-    "type": "Door/Gate",
-    "mass": 122750,
-    "volume": 16760,
-    "outputQuantity": 1,
-    "time": 93600,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Basic Screw": 648,
-      "Uncommon Screw": 648,
-      "Uncommon Power System": 625,
-      "Uncommon Electric Engine XL": 1,
-      "Uncommon Reinforced Frame XL": 1
-    }
-  },
-  "Expanded Gate S":{ 
-    "tier": 2,
-    "type": "Door/Gate",
-    "mass": 122750,
-    "volume": 16760,
-    "outputQuantity": 1,
-    "time": 93600,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Basic Screw": 1296,
-      "Uncommon Screw": 1296,
-      "Uncommon Power System": 1250,
-      "Uncommon Electric Engine XL": 2,
-      "Uncommon Reinforced Frame XL": 2
-    }
-  },
-  "Gate M":{ 
-    "tier": 2,
-    "type": "Door/Gate",
-    "mass": 122750,
-    "volume": 16760,
-    "outputQuantity": 1,
-    "time": 93600,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Basic Screw": 2592,
-      "Uncommon Screw": 2592,
-      "Uncommon Power System": 2500,
-      "Uncommon Electric Engine XL": 4,
-      "Uncommon Reinforced Frame XL": 4
-    }
-  },
-  "Expanded Gate L":{ 
-    "tier": 2,
-    "type": "Door/Gate",
-    "mass": 122750,
-    "volume": 16760,
-    "outputQuantity": 1,
-    "time": 93600,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Basic Screw": 3240,
-      "Uncommon Screw": 3240,
-      "Uncommon Power System": 3125,
-      "Uncommon Electric Engine XL": 5,
-      "Uncommon Reinforced Frame XL": 5
-    }
-  },
-  "Gate XL":{ 
-    "tier": 2,
-    "type": "Door/Gate",
-    "mass": 122750,
-    "volume": 16760,
-    "outputQuantity": 1,
-    "time": 93600,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Basic Screw": 5184,
-      "Uncommon Screw": 5184,
-      "Uncommon Power System": 5000,
-      "Uncommon Electric Engine XL": 8,
-      "Uncommon Reinforced Frame XL": 8
-    }
-  },
-  "AND Operator":{ 
-    "tier": 2,
-    "type": "Electronics",
-    "mass": 13.27,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 70,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Uncommon Screw": 1,
-      "Uncommon Electronics": 1
-    }
-  },
-  "NOT Operator":{ 
-    "tier": 2,
-    "type": "Electronics",
-    "mass": 7.47,
-    "volume": 4.5,
-    "outputQuantity": 1,
-    "time": 70,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1
-    }
-  },
-  "OR Operator":{ 
-    "tier": 2,
-    "type": "Electronics",
-    "mass": 7.47,
-    "volume": 4.5,
-    "outputQuantity": 1,
-    "time": 70,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1
-    }
-  },
-  "Relay":{ 
-    "tier": 1,
-    "type": "Electronics",
-    "mass": 8.87,
-    "volume": 6.5,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Basic Electronics": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Databank":{ 
-    "tier": 1,
-    "type": "Electronics",
-    "mass": 17.09,
-    "volume": 5.5,
-    "outputQuantity": 1,
-    "time": 30,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Basic Processor": 1
-    }
-  },
-  "2 Counter":{ 
-    "tier": 2,
-    "type": "Electronics",
-    "mass":9.93,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1
-    }
-  },
-  "3 Counter":{ 
-    "tier": 2,
-    "type": "Electronics",
-    "mass":9.93,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1
-    }
-  },
-  "5 Counter":{ 
-    "tier": 2,
-    "type": "Electronics",
-    "mass":9.93,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1
-    }
-  },
-  "7 Counter":{ 
-    "tier": 2,
-    "type": "Electronics",
-    "mass":9.93,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1
-    }
-  },
-  "10 Counter":{ 
-    "tier": 2,
-    "type": "Electronics",
-    "mass":9.93,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1
-    }
-  },
-  "Infra-Red Laser Emitter":{ 
-    "tier": 2,
-    "type": "Electronics",
-    "mass":9.93,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1
-    }
-  },
-  "Laser Emitter":{ 
-    "tier": 1,
-    "type": "Electronics",
-    "mass": 7.47,
-    "volume": 4.5,
-    "outputQuantity": 1,
-    "time": 30,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Basic Electronics": 1
-    }
-  },
-  "Delay Line":{ 
-    "tier": 1,
-    "type": "Electronics",
-    "mass": 7.47,
-    "volume": 4.5,
-    "outputQuantity": 1,
-    "time": 30,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Basic Electronics": 1
-    }
-  },
-  "Receiver XS":{ 
-    "tier": 1,
-    "type": "Electronics",
-    "mass": 13.27,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 30,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Basic Electronics": 1
-    }
-  },
-  "Receiver S":{ 
-    "tier": 2,
-    "type": "Electronics",
-    "mass": 475.87,
-    "volume": 91.56,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic Screw": 3,
-      "Uncommon Screw": 3,
-      "Uncommon Electronics": 5,
-      "Uncommon Antenna S": 1,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Receiver M":{ 
-    "tier": 2,
-    "type": "Electronics",
-    "mass": 6636.912,
-    "volume": 1500,
-    "outputQuantity": 1,
-    "time": 21600,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 108,
-      "Uncommon Screw": 108,
-      "Uncommon Electronics": 125,
-      "Uncommon Antenna L": 1,
-      "Uncommon Standard Frame L": 1
-    }
-  },
-  "Emitter XS":{ 
-    "tier": 1,
-    "type": "Electronics",
-    "mass": 69.31,
-    "volume": 15.46,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Basic Electronics": 1,
-      "Basic Antenna XS": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Emitter S":{ 
-    "tier": 2,
-    "type": "Electronics",
-    "mass": 427.72,
-    "volume": 88.56,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic Component": 3,
-      "Uncommon Component": 3,
-      "Uncommon Electronics": 5,
-      "Uncommon Antenna S": 1,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Emitter M":{ 
-    "tier": 2,
-    "type": "Electronics",
-    "mass": 2040,
-    "volume": 44.36,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Component": 18,
-      "Uncommon Component": 18,
-      "Uncommon Electronics": 25,
-      "Uncommon Antenna M": 1,
-      "Uncommon Casing M": 1
-    }
-  },
-  "Long Light XS":{ 
-    "tier": 2,
-    "type": "Light",
-    "mass": 70.05,
-    "volume": 10.8,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Connector": 1,
-      "Uncommon Connector": 1,
-      "Uncommon Power System": 1
-    }
-  },
-  "Long Light S":{ 
-    "tier": 2,
-    "type": "Light",
-    "mass": 79.34,
-    "volume": 21.6,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Connector": 1,
-      "Uncommon Connector": 1,
-      "Uncommon Power System": 1,
-      "Uncommon Light XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Long Light M":{ 
-    "tier": 2,
-    "type": "Light",
-    "mass": 79.34,
-    "volume": 21.6,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Connector": 1,
-      "Uncommon Connector": 1,
-      "Uncommon Power System": 1,
-      "Uncommon Light XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Long Light L":{ 
-    "tier": 2,
-    "type": "Light",
-    "mass": 79.34,
-    "volume": 21.6,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Connector": 1,
-      "Uncommon Connector": 1,
-      "Uncommon Power System": 1,
-      "Uncommon Light XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Square Light XS":{ 
-    "tier": 2,
-    "type": "Light",
-    "mass": 70.05,
-    "volume": 10.8,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Connector": 1,
-      "Uncommon Connector": 1,
-      "Uncommon Power System": 1
-    }
-  },
-  "Square Light S":{ 
-    "tier": 2,
-    "type": "Light",
-    "mass": 79.34,
-    "volume": 21.6,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Connector": 1,
-      "Uncommon Connector": 1,
-      "Uncommon Power System": 1,
-      "Uncommon Light XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Square Light M":{ 
-    "tier": 2,
-    "type": "Light",
-    "mass": 79.34,
-    "volume": 21.6,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Connector": 1,
-      "Uncommon Connector": 1,
-      "Uncommon Power System": 1,
-      "Uncommon Light XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Square Light L":{ 
-    "tier": 2,
-    "type": "Light",
-    "mass": 79.34,
-    "volume": 21.6,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Connector": 1,
-      "Uncommon Connector": 1,
-      "Uncommon Power System": 1,
-      "Uncommon Light XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Vertical Light XS":{ 
-    "tier": 2,
-    "type": "Light",
-    "mass": 70.05,
-    "volume": 10.8,
-    "outputQuantity": 1,
-    "time": 240,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Connector": 1,
-      "Uncommon Connector": 1,
-      "Uncommon Power System": 1
-    }
-  },
-  "Vertical Light S":{ 
-    "tier": 2,
-    "type": "Light",
-    "mass": 79.34,
-    "volume": 21.6,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Connector": 1,
-      "Uncommon Connector": 1,
-      "Uncommon Power System": 1,
-      "Uncommon Light XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Vertical Light M":{ 
-    "tier": 2,
-    "type": "Light",
-    "mass": 79.34,
-    "volume": 21.6,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Connector": 1,
-      "Uncommon Connector": 1,
-      "Uncommon Power System": 1,
-      "Uncommon Light XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Vertical Light L":{ 
-    "tier": 2,
-    "type": "Light",
-    "mass": 79.34,
-    "volume": 21.6,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Connector": 3,
-      "Uncommon Connector": 3,
-      "Uncommon Power System": 5,
-      "Uncommon Light S": 1,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Headlight":{ 
-    "tier": 2,
-    "type": "Light",
-    "mass": 79.34,
-    "volume": 21.6,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Connector": 1,
-      "Uncommon Connector": 1,
-      "Uncommon Power System": 1,
-      "Uncommon Light XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Small Atmospheric Radar PvP S":{ 
-    "tier": 1,
-    "type": "Radar",
-    "mass": 486.72,
-    "volume": 96.56,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "Combat",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic LED": 3,
-      "Uncommon LED": 3,
-      "Uncommon Magnet": 5,
-      "Uncommon Antenna S": 1,
-      "Uncommon Standard Frame S": 1
-    }
-  },
-  "Medium Atmospheric Radar PvP M":{ 
-    "tier": 2,
-    "type": "Radar",
-    "mass": 1740,
-    "volume": 420,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Combat",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic LED": 18,
-      "Uncommon LED": 18,
-      "Uncommon Magnet": 25,
-      "Uncommon Antenna M": 1,
-      "Uncommon Reinforced Frame M": 1
-    }
-  },
-  "Large Atmospheric Radar PvP L":{ 
-    "tier": 2,
-    "type": "Radar",
-    "mass": 6640,
-    "volume": 1500,
-    "outputQuantity": 1,
-    "time": 23040,
-    "skill": "Combat",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic LED": 108,
-      "Uncommon LED": 108,
-      "Uncommon Magnet": 125,
-      "Uncommon Antenna L": 1,
-      "Uncommon Reinforced Frame L": 1
-    }
-  },
-  "Space Radar S":{ 
-    "tier": 1,
-    "type": "Radar",
-    "mass": 486.72,
-    "volume": 96.56,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "Combat",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic LED": 3,
-      "Uncommon LED": 3,
-      "Uncommon Processor": 5,
-      "Uncommon Antenna S": 1,
-      "Uncommon Standard Frame S": 1
-    }
-  },
-  "Space Radar M":{ 
-    "tier": 1,
-    "type": "Radar",
-    "mass": 2350,
-    "volume": 486.36,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Combat",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic LED": 18,
-      "Uncommon LED": 18,
-      "Uncommon Processor": 25,
-      "Uncommon Antenna M": 1,
-      "Uncommon Standard Frame M": 1
-    }
-  },
-  "Space Radar L":{ 
-    "tier": 1,
-    "type": "Radar",
-    "mass": 12490,
-    "volume": 2658.56,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Combat",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic LED": 108,
-      "Uncommon LED": 108,
-      "Uncommon Processor": 125,
-      "Uncommon Antenna L": 1,
-      "Uncommon Standard Frame L": 1
-    }
-  },
-  "Screen XS":{ 
-    "tier": 2,
-    "type": "Screen/Sign",
-    "mass": 18.67,
-    "volume": 15.8,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1,
-      "Uncommon Screen XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Screen S":{ 
-    "tier": 2,
-    "type": "Screen/Sign",
-    "mass": 18.67,
-    "volume": 15.8,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1,
-      "Uncommon Screen XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Screen M":{ 
-    "tier": 2,
-    "type": "Screen/Sign",
-    "mass": 18.67,
-    "volume": 15.8,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1,
-      "Uncommon Screen XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Screen XL":{ 
-    "tier": 3,
-    "type": "Screen/Sign",
-    "mass": 12810,
-    "volume": 11170,
-    "outputQuantity": 1,
-    "time": 93600,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Basic Component": 648,
-      "Uncommon Component": 648,
-      "Uncommon Electronics": 625,
-      "Uncommon Screen XL": 1,
-      "Uncommon Casing XL": 1
-    }
-  },
-  "Transparent Screen XS":{ 
-    "tier": 2,
-    "type": "Screen/Sign",
-    "mass": 18.67,
-    "volume": 15.8,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1,
-      "Uncommon Screen XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Transparent Screen S":{ 
-    "tier": 2,
-    "type": "Screen/Sign",
-    "mass": 18.67,
-    "volume": 15.8,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1,
-      "Uncommon Screen XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Transparent Screen M":{ 
-    "tier": 2,
-    "type": "Screen/Sign",
-    "mass": 18.67,
-    "volume": 15.8,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1,
-      "Uncommon Screen XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Transparent Screen L":{ 
-    "tier": 2,
-    "type": "Screen/Sign",
-    "mass": 18.67,
-    "volume": 15.8,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1,
-      "Uncommon Screen XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Sign XS":{ 
-    "tier": 2,
-    "type": "Screen/Sign",
-    "mass": 18.67,
-    "volume": 15.8,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1,
-      "Uncommon Screen XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Sign S":{ 
-    "tier": 2,
-    "type": "Screen/Sign",
-    "mass": 18.67,
-    "volume": 15.8,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1,
-      "Uncommon Screen XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Sign M":{ 
-    "tier": 2,
-    "type": "Screen/Sign",
-    "mass": 18.67,
-    "volume": 15.8,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1,
-      "Uncommon Screen XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Sign L":{ 
-    "tier": 2,
-    "type": "Screen/Sign",
-    "mass": 18.67,
-    "volume": 15.8,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1,
-      "Uncommon Screen XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Sign Vertical XS":{ 
-    "tier": 2,
-    "type": "Screen/Sign",
-    "mass": 18.67,
-    "volume": 15.8,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1,
-      "Uncommon Screen XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Sign Vertical M":{ 
-    "tier": 2,
-    "type": "Screen/Sign",
-    "mass": 18.67,
-    "volume": 15.8,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1,
-      "Uncommon Screen XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Sign Vertical L":{ 
-    "tier": 2,
-    "type": "Screen/Sign",
-    "mass": 18.67,
-    "volume": 15.8,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1,
-      "Uncommon Screen XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Sensors S":{ 
-    "tier": 1,
-    "type": "Surrogate Element",
-    "mass": 28,
-    "volume": 27,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack", "Assembly Line XS"],
-    "input": {
-      "Basic LED": 1,
-      "Uncommon LED": 1,
-      "Uncommon Electronics": 1,
-      "Uncommon Antenna XS": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Office Chair":{ 
-    "tier": 1,
-    "type": "Chair",
-    "mass": 916.52,
-    "volume": 13,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Fixation": 6
-    }
-  },
-  "Navigator Chair":{ 
-    "tier": 1,
-    "type": "Chair",
-    "mass": 39.62,
-    "volume": 24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Fixation": 6,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Encampment Chair":{ 
-    "tier": 1,
-    "type": "Chair",
-    "mass": 2.52,
-    "volume": 2,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Polycarbonate Plastic": 1,
-      "Basic Fixation": 1
-    }
-  },
-  "Manual Switch":{ 
-    "tier": 1,
-    "type": "Sensor",
-    "mass": 13.27,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 22,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Basic Electronics": 1
-    }
-  },
-  "Pressure Tile":{ 
-    "tier": 1,
-    "type": "Sensor",
-    "mass": 50.63,
-    "volume": 14.49,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Basic Electronics": 1,
-      "Basic Mechanical Sensor XS": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Manual Button XS":{ 
-    "tier": 1,
-    "type": "Sensor",
-    "mass": 13.27,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 22,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Basic Electronics": 1
-    }
-  },
-  "Manual Button S":{ 
-    "tier": 1,
-    "type": "Sensor",
-    "mass": 13.27,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 22,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Basic Electronics": 1
-    }
-  },
-  "Laser Receiver":{ 
-    "tier": 2,
-    "type": "Sensor",
-    "mass": 9.93,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1
-    }
-  },
-  "Infra-Red Laser Receiver":{ 
-    "tier": 2,
-    "type": "Sensor",
-    "mass": 9.93,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Electronics": 1
-    }
-  },
-  
-  "Detection Zone XS":{ 
-    "tier": 3,
-    "type": "Sensor",
-    "mass": 7.79,
-    "volume": 4.5,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Component": 1,
-      "Advanced Electronics": 1
-    }
-  },
-  "Detection Zone S":{ 
-    "tier": 3,
-    "type": "Sensor",
-    "mass": 7.79,
-    "volume": 4.5,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Component": 1,
-      "Advanced Electronics": 1
-    }
-  },
-  "Detection Zone M":{ 
-    "tier": 3,
-    "type": "Sensor",
-    "mass": 7.79,
-    "volume": 4.5,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Component": 1,
-      "Advanced Electronics": 1
-    }
-  },
-  "Detection Zone L":{ 
-    "tier": 3,
-    "type": "Sensor",
-    "mass": 7.79,
-    "volume": 4.5,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Component": 1,
-      "Advanced Electronics": 1
-    }
-  },
-  "Keyboard Unit":{ 
-    "tier": 1,
-    "type": "Decorative",
-    "mass": 24.68,
-    "volume": 3.8,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Steel": 1,
-      "Basic Connector": 1,
-      "Basic Reinforced Frame XS": 1
-    }
-  },
-  "Antenna S":{ 
-    "tier": 1,
-    "type": "Antenna",
-    "mass": 130.06,
-    "volume": 24,
-    "outputQuantity": 1,
-    "time": 600,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Al-Fe Alloy": 7,
-      "Basic Fixation": 6,
-      "Basic Reinforced Frame S": 1
-    }
-  },
-  "Antenna M":{ 
-    "tier": 2,
-    "type": "Antenna",
-    "mass": 902.74,
-    "volume": 159,
-    "outputQuantity": 1,
-    "time": 3600,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Calcium Reinforced Copper": 49,
-      "Basic Fixation": 18,
-      "Uncommon Fixation": 18,
-      "Uncommon Reinforced Frame M": 1
-    }
-  },
-  "Antenna L":{ 
-    "tier": 3,
-    "type": "Antenna",
-    "mass": 6850,
-    "volume": 1074,
-    "outputQuantity": 1,
-    "time": 43200,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Cu-Ag Alloy": 343,
-      "Uncommon Fixation": 216,
-      "Advanced Reinforced Frame L": 1
-    }
-  },
-  "Barrier Corner":{ 
-    "tier": 1,
-    "type": "Barrier",
-    "mass": 14.65,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Steel": 1,
-      "Basic Pipe": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Barrier S":{ 
-    "tier": 1,
-    "type": "Barrier",
-    "mass": 14.65,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Steel": 1,
-      "Basic Screw": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Barrier M":{ 
-    "tier": 1,
-    "type": "Barrier",
-    "mass": 14.65,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Steel": 1,
-      "Basic Screw": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Sink Unit":{ 
-    "tier": 1,
-    "type": "Bathroom",
-    "mass": 6.72,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Polycarbonate Plastic": 1,
-      "Basic Fixation": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Shower Unit":{ 
-    "tier": 1,
-    "type": "Bathroom",
-    "mass": 25.62,
-    "volume": 13,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Injector": 1,
-      "Basic Fixation": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Urinal Unit":{ 
-    "tier": 1,
-    "type": "Bathroom",
-    "mass": 8.32,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Silumin": 1,
-      "Basic Fixation": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Toilet Unit A":{ 
-    "tier": 1,
-    "type": "Bathroom",
-    "mass": 6.72,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Polycarbonate Plastic": 1,
-      "Basic Fixation": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Toilet Unit B":{ 
-    "tier": 1,
-    "type": "Bathroom",
-    "mass": 6.72,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Polycarbonate Plastic": 1,
-      "Basic Fixation": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Cable Model-A S":{ 
-    "tier": 1,
-    "type": "Cable",
-    "mass": 14.1,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Al-Fe Alloy": 1,
-      "Basic Pipe": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Cable Model-B S":{ 
-    "tier": 1,
-    "type": "Cable",
-    "mass": 14.1,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Al-Fe Alloy": 1,
-      "Basic Pipe": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Cable Model-C S":{ 
-    "tier": 1,
-    "type": "Cable",
-    "mass": 14.1,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Al-Fe Alloy": 1,
-      "Basic Pipe": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Cable Model-A M":{ 
-    "tier": 1,
-    "type": "Cable",
-    "mass": 14.1,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Al-Fe Alloy": 1,
-      "Basic Pipe": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Cable Model-B M":{ 
-    "tier": 1,
-    "type": "Cable",
-    "mass": 14.1,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Al-Fe Alloy": 1,
-      "Basic Pipe": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Cable Model-C M":{ 
-    "tier": 1,
-    "type": "Cable",
-    "mass": 14.1,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Al-Fe Alloy": 1,
-      "Basic Pipe": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Corner Cable Model-A":{ 
-    "tier": 1,
-    "type": "Cable",
-    "mass": 14.1,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Al-Fe Alloy": 1,
-      "Basic Pipe": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Corner Cable Model-B":{ 
-    "tier": 1,
-    "type": "Cable",
-    "mass": 14.1,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Al-Fe Alloy": 1,
-      "Basic Pipe": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Corner Cable Model-C":{ 
-    "tier": 1,
-    "type": "Cable",
-    "mass": 14.1,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Al-Fe Alloy": 1,
-      "Basic Pipe": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Dresser":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 8.32,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Silumin": 1,
-      "Basic Fixation": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Bench":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 22.33,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Polycarbonate Plastic": 1,
-      "Basic Screw": 1,
-      "Basic Reinforced Frame XS": 1
-    }
-  },
-  "Wooden Low Table":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 5.92,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Wood": 1,
-      "Basic Fixation": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Sofa":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 39.62,
-    "volume": 24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Fixation": 6,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Wooden Wardrobe":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 39.62,
-    "volume": 24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Fixation": 6,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Table":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 264.32,
-    "volume": 159,
-    "outputQuantity": 1,
-    "time": 1200,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Polycarbonate Plastic": 49,
-      "Basic Fixation": 36,
-      "Basic Standard Frame M": 1
-    }
-  },
-  "Trash":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 6.72,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Polycarbonate Plastic": 1,
-      "Basic Fixation": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Wooden Sofa":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 39.62,
-    "volume": 24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Fixation": 6,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Nightstand":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 6.72,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Polycarbonate Plastic": 1,
-      "Basic Fixation": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Wardrobe":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 39.62,
-    "volume": 24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Fixation": 6,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Wooden Chair":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 2.52,
-    "volume": 2,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Polycarbonate Plastic": 1,
-      "Basic Fixation": 1
-    }
-  },
-  "\"HMS Ajax33\" - Artist Unknown":{
-    "tier": 4,
-    "type": "Furniture",
-    "mass": 5.54,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 2040,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Fluoropolymer": 1,
-      "Uncommon Fixation": 1,
-      "Advanced Fixation": 1,
-      "Rare Casing XS":1
-    }
-  },
-  "\"Parrotos Sanctuary\" - Artist Unknown":{
-    "tier": 4,
-    "type": "Furniture",
-    "mass": 5.54,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 2040,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Fluoropolymer": 1,
-      "Uncommon Fixation": 1,
-      "Advanced Fixation": 1,
-      "Rare Casing XS":1
-    }
-  },
-  "\"Eye Doll's Workshop\" - Artist Unknown":{
-    "tier": 4,
-    "type": "Furniture",
-    "mass": 5.54,
-    "volume": 5,
-    "outputQuantity": 1,
-    "time": 2040,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Fluoropolymer": 1,
-      "Uncommon Fixation": 1,
-      "Advanced Fixation": 1,
-      "Rare Casing XS":1
-    }
-  },
-  "Wooden Armchair":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 1.72,
-    "volume": 2,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Wood": 1,
-      "Basic Fixation": 1
-    }
-  },
-  "Round Carpet":{ 
-    "tier": 5,
-    "type": "Furniture",
-    "mass": 2.78,
-    "volume": 2,
-    "outputQuantity": 1,
-    "time": 6060,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Vanamer": 1,
-      "Advanced Fixation": 1
-    }
-  },
-  "Square Carpet":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 2.52,
-    "volume": 2,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Polycarbonate Plastic": 1,
-      "Basic Fixation": 1
-    }
-  },
-  "Wooden Dresser":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 34.02,
-    "volume": 24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Wood": 7,
-      "Basic Fixation": 6,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Wooden Table M":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 34.02,
-    "volume": 24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Wood": 7,
-      "Basic Fixation": 6,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Wooden Table L":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 34.02,
-    "volume": 24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Wood": 7,
-      "Basic Fixation": 6,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Shelf Empty":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 8.32,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Silumin": 1,
-      "Basic Fixation": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Shelf Half Full":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 8.32,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Silumin": 1,
-      "Basic Fixation": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Shelf Full":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 8.32,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Silumin": 1,
-      "Basic Fixation": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Bed":{ 
-    "tier": 1,
-    "type": "Furniture",
-    "mass": 128.94,
-    "volume": 24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Screw": 6,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Spaceship Hologram S":{ 
-    "tier": 2,
-    "type": "Hologram",
-    "mass": 112.72,
-    "volume": 9,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Basic Optics": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Spaceship Hologram M":{ 
-    "tier": 2,
-    "type": "Hologram",
-    "mass": 15.98,
-    "volume": 13,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Uncommon Component": 1,
-      "Uncommon Optics": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Spaceship Hologram L":{ 
-    "tier": 2,
-    "type": "Hologram",
-    "mass": 14.02,
-    "volume": 12.5,
-    "outputQuantity": 1,
-    "time": 840,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Component": 1,
-      "Uncommon Optics": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Planet Hologram":{ 
-    "tier": 1,
-    "type": "Hologram",
-    "mass": 13.39,
-    "volume": 12.5,
-    "outputQuantity": 1,
-    "time": 120,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Basic Component": 1,
-      "Basic Optics": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Planet Hologram L":{ 
-    "tier": 1,
-    "type": "Hologram",
-    "mass": 69.9,
-    "volume": 64,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Basic Component": 6,
-      "Basic Optics": 5,
-      "Basic Casing S": 1
-    }
-  },
-  "Steel Column":{ 
-    "tier": 1,
-    "type": "Hull",
-    "mass": 13.37,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Steel": 1,
-      "Basic Fixation": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Steel Panel":{ 
-    "tier": 1,
-    "type": "Hull",
-    "mass": 13.37,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Steel": 1,
-      "Basic Fixation": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Hull Decorative Element A":{ 
-    "tier": 1,
-    "type": "Hull",
-    "mass": 14.65,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Steel": 1,
-      "Basic Pipe": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Hull Decorative Element B":{ 
-    "tier": 1,
-    "type": "Hull",
-    "mass": 14.65,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Steel": 1,
-      "Basic Pipe": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Hull Decorative Element C":{ 
-    "tier": 1,
-    "type": "Hull",
-    "mass": 14.65,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Steel": 1,
-      "Basic Pipe": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Pipe A M":{ 
-    "tier": 1,
-    "type": "Pipe",
-    "mass": 4320,
-    "volume": 1074,
-    "outputQuantity": 1,
-    "time": 4800,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Polycarbonate Plastic": 343,
-      "Basic Pipe": 216,
-      "Basic Reinforced Frame L": 1
-    }
-  },
-  "Pipe B M":{ 
-    "tier": 1,
-    "type": "Pipe",
-    "mass": 4320,
-    "volume": 1074,
-    "outputQuantity": 1,
-    "time": 4800,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Polycarbonate Plastic": 343,
-      "Basic Pipe": 216,
-      "Basic Reinforced Frame L": 1
-    }
-  },
-  "Pipe C M":{ 
-    "tier": 1,
-    "type": "Pipe",
-    "mass": 4320,
-    "volume": 1074,
-    "outputQuantity": 1,
-    "time": 4800,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Polycarbonate Plastic": 343,
-      "Basic Pipe": 216,
-      "Basic Reinforced Frame L": 1
-    }
-  },
-  "Pipe D M":{ 
-    "tier": 1,
-    "type": "Pipe",
-    "mass": 4320,
-    "volume": 1074,
-    "outputQuantity": 1,
-    "time": 4800,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Polycarbonate Plastic": 343,
-      "Basic Pipe": 216,
-      "Basic Reinforced Frame L": 1
-    }
-  },
-  "Pipe Corner M":{ 
-    "tier": 1,
-    "type": "Pipe",
-    "mass": 4320,
-    "volume": 1074,
-    "outputQuantity": 1,
-    "time": 4800,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Polycarbonate Plastic": 343,
-      "Basic Pipe": 216,
-      "Basic Reinforced Frame L": 1
-    }
-  },
-  "Pipe Connector M":{ 
-    "tier": 1,
-    "type": "Pipe",
-    "mass": 4320,
-    "volume": 1074,
-    "outputQuantity": 1,
-    "time": 4800,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Polycarbonate Plastic": 343,
-      "Basic Pipe": 216,
-      "Basic Reinforced Frame L": 1
-    }
-  },
-  "Plant Case A":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 21.42,
-    "volume":24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Biological Matter": 7,
-      "Basic Fixation": 6,
-      "Basic Casing S": 1
-    }
-  },
-  "Plant Case B":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 3.52,
-    "volume":4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Biological Matter": 1,
-      "Basic Fixation": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Plant Case C":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 3.52,
-    "volume":4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Biological Matter": 1,
-      "Basic Fixation": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Plant Case D":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 3.52,
-    "volume":4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Biological Matter": 1,
-      "Basic Fixation": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Plant Case E":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 3.52,
-    "volume":4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Biological Matter": 1,
-      "Basic Fixation": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Suspended Fruit Plant":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 3.52,
-    "volume":4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Biological Matter": 1,
-      "Basic Fixation": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Suspended Plant A":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 3.52,
-    "volume":4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Biological Matter": 1,
-      "Basic Fixation": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Suspended Plant B":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 3.52,
-    "volume":4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Biological Matter": 1,
-      "Basic Fixation": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Bagged Plant A":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 3.52,
-    "volume":4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Biological Matter": 1,
-      "Basic Fixation": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Bagged Plant B":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 3.52,
-    "volume":4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Biological Matter": 1,
-      "Basic Fixation": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Plant":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 3.52,
-    "volume":4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Biological Matter": 1,
-      "Basic Fixation": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Bonsai":{ 
-    "tier": 5,
-    "type": "Plant",
-    "mass": 902.04,
-    "volume": 180.6,
-    "outputQuantity": 1,
-    "time": 50400,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Fixation": 6,
-      "Exotic Magnet": 5,
-      "Exotic Core System S": 1,
-      "Exotic Anti-Gravity Core": 4,
-      "Exotic Casing S": 1
-    }
-  },
-  "Eggplant Plant Case":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 31.9,
-    "volume":24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Pipe": 6,
-      "Basic Casing S": 1
-    }
-  },
-  "Salad Plant Case":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 31.9,
-    "volume":24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Pipe": 6,
-      "Basic Casing S": 1
-    }
-  },
-  "Squash Plant Case":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 31.9,
-    "volume":24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Pipe": 6,
-      "Basic Casing S": 1
-    }
-  },
-  "Plant Case S":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 31.9,
-    "volume":24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Pipe": 6,
-      "Basic Casing S": 1
-    }
-  },
-  "Plant Case M":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 31.9,
-    "volume":24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Pipe": 6,
-      "Basic Casing S": 1
-    }
-  },
-  "Ficus Plant A":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 31.9,
-    "volume":24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Pipe": 6,
-      "Basic Casing S": 1
-    }
-  },
-  "Ficus Plant B":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 31.9,
-    "volume":24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Pipe": 6,
-      "Basic Casing S": 1
-    }
-  },
-  "Foliage Plant Case A":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 31.9,
-    "volume":24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Pipe": 6,
-      "Basic Casing S": 1
-    }
-  },
-  "Foliage Plant Case B":{ 
-    "tier": 1,
-    "type": "Plant",
-    "mass": 31.9,
-    "volume":24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Polycarbonate Plastic": 7,
-      "Basic Pipe": 6,
-      "Basic Casing S": 1
-    }
-  },
-  "Window XS":{ 
-    "tier": 1,
-    "type": "Window",
-    "mass": 47.32,
-    "volume": 24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Glass": 7,
-      "Basic Fixation": 6,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Window S":{ 
-    "tier": 1,
-    "type": "Window",
-    "mass": 94.64,
-    "volume": 48,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Glass": 14,
-      "Basic Fixation": 12,
-      "Basic Standard Frame S": 2
-    }
-  },
-  "Window M":{ 
-    "tier": 1,
-    "type": "Window",
-    "mass": 189.28,
-    "volume": 96,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Glass": 28,
-      "Basic Fixation": 24,
-      "Basic Standard Frame S": 14
-    }
-  },
-  "Window L":{ 
-    "tier": 1,
-    "type": "Window",
-    "mass": 378.56,
-    "volume": 192,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Glass": 56,
-      "Basic Fixation": 48,
-      "Basic Standard Frame S": 8
-    }
-  },
-  "Armored Window XS":{ 
-    "tier": 2,
-    "type": "Window",
-    "mass": 47.16,
-    "volume": 24,
-    "outputQuantity": 1,
-    "time": 900,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Glass": 7,
-      "Basic Fixation": 3,
-      "Uncommon Fixation": 3,
-      "Uncommon Standard Frame S": 1
-    }
-  },
-  "Armored Window S":{ 
-    "tier": 2,
-    "type": "Window",
-    "mass": 94.32,
-    "volume": 48,
-    "outputQuantity": 1,
-    "time": 900,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Glass": 14,
-      "Basic Fixation": 6,
-      "Uncommon Fixation": 6,
-      "Uncommon Standard Frame S": 2
-    }
-  },
-  "Armored Window M":{ 
-    "tier": 2,
-    "type": "Window",
-    "mass": 188.64,
-    "volume": 96,
-    "outputQuantity": 1,
-    "time": 900,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Glass": 28,
-      "Basic Fixation": 12,
-      "Uncommon Fixation": 12,
-      "Uncommon Standard Frame S": 4
-    }
-  },
-  "Armored Window L":{ 
-    "tier": 2,
-    "type": "Window",
-    "mass": 377.28,
-    "volume": 192,
-    "outputQuantity": 1,
-    "time": 900,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Glass": 56,
-      "Basic Fixation": 24,
-      "Uncommon Fixation": 24,
-      "Uncommon Standard Frame S": 8
-    }
-  },
-  "Glass Panel S":{ 
-    "tier": 1,
-    "type": "Window",
-    "mass": 5.02,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Glass": 1,
-      "Basic Fixation": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Glass Panel M":{ 
-    "tier": 1,
-    "type": "Window",
-    "mass": 20.08,
-    "volume": 16,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Glass": 4,
-      "Basic Fixation": 4,
-      "Basic Casing XS": 4
-    }
-  },
-  "Glass Panel L":{ 
-    "tier": 1,
-    "type": "Window",
-    "mass": 31.92,
-    "volume": 24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Glass": 7,
-      "Basic Fixation": 6,
-      "Basic Casing S": 1
-    }
-  },
-  "Bay Window XL":{ 
-    "tier": 1,
-    "type": "Window",
-    "mass": 5090,
-    "volume": 2544,
-    "outputQuantity": 1,
-    "time": 1200,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Glass": 784,
-      "Basic Fixation": 576,
-      "Basic Standard Frame M": 16
-    }
-  },
-  "Vertical Wing":{ 
-    "tier": 1,
-    "type": "Winglets",
-    "mass": 20.3,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Steel": 1,
-      "Basic Screw": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Wing Tip S":{ 
-    "tier": 1,
-    "type": "Winglets",
-    "mass": 20.3,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Steel": 1,
-      "Basic Screw": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Wing Tip M":{ 
-    "tier": 1,
-    "type": "Winglets",
-    "mass": 20.3,
-    "volume": 4,
-    "outputQuantity": 1,
-    "time": 60,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line XS"],
-    "input": {
-      "Steel": 1,
-      "Basic Screw": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Wing Tip L":{ 
-    "tier": 1,
-    "type": "Winglets",
-    "mass": 127.75,
-    "volume": 24,
-    "outputQuantity": 1,
-    "time": 300,
-    "skill": "Furniture/Appliance",
-    "byproducts": {},
-    "industries": ["Nanopack","Assembly Line S"],
-    "input": {
-      "Steel": 7,
-      "Basic Screw": 6,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Aluminium Scrap":{ 
-    "tier": 1,
-    "type": "Scrap",
-    "mass": 2.7,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 3,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Recycler M"],
-    "input": {
-      "Aluminium Pure": 50
-    }
-  },
-  "Carbon Scrap":{ 
-    "tier": 1,
-    "type": "Scrap",
-    "mass": 2.27,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 3,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Recycler M"],
-    "input": {
-      "Carbon Pure": 50
-    }
-  },
-  "Silicon Scrap":{ 
-    "tier": 1,
-    "type": "Scrap",
-    "mass": 2.33,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 3,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Recycler M"],
-    "input": {
-      "Silicon Pure": 50
-    }
-  },
-  "Iron Scrap":{ 
-    "tier": 1,
-    "type": "Scrap",
-    "mass": 7.85,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 3,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Recycler M"],
-    "input": {
-      "Iron Pure": 50
-    }
-  },
-  "Calcium Scrap":{ 
-    "tier": 2,
-    "type": "Scrap",
-    "mass": 1.55,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 12,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Recycler M"],
-    "input": {
-      "Calcium Pure": 50
-    }
-  },
-  "Chromium Scrap":{ 
-    "tier": 2,
-    "type": "Scrap",
-    "mass": 7.19,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 12,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Recycler M"],
-    "input": {
-      "Chromium Pure": 50
-    }
-  },
-  "Copper Scrap":{ 
-    "tier": 2,
-    "type": "Scrap",
-    "mass": 8.96,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 12,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Recycler M"],
-    "input": {
-      "Copper Pure": 50
-    }
-  },
-  "Sodium Scrap":{ 
-    "tier": 2,
-    "type": "Scrap",
-    "mass": 0.97,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 12,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Recycler M"],
-    "input": {
-      "Sodium Pure": 50
-    }
-  },
-  "Lithium Scrap":{ 
-    "tier": 3,
-    "type": "Scrap",
-    "mass": 0.53,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 48,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Recycler M"],
-    "input": {
-      "Lithium Pure": 50
-    }
-  },
-  "Nickel Scrap":{ 
-    "tier": 3,
-    "type": "Scrap",
-    "mass": 8.91,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 48,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Recycler M"],
-    "input": {
-      "Nickel Pure": 50
-    }
-  },
-  "Silver Scrap":{ 
-    "tier": 3,
-    "type": "Scrap",
-    "mass": 10.49,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 48,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Recycler M"],
-    "input": {
-      "Silver Pure": 50
-    }
-  },
-  "Sulfur Scrap":{ 
-    "tier": 3,
-    "type": "Scrap",
-    "mass": 1.82,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 48,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Recycler M"],
-    "input": {
-      "Sulfur Pure": 50
-    }
-  },
-  "Cobalt Scrap":{ 
-    "tier": 4,
-    "type": "Scrap",
-    "mass": 8.9,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Recycler M"],
-    "input": {
-      "Cobalt Pure": 50
-    }
-  },
-  "Fluorine Scrap":{ 
-    "tier": 4,
-    "type": "Scrap",
-    "mass": 1.7,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Recycler M"],
-    "input": {
-      "Fluorine Pure": 50
-    }
-  },
-  "Gold Scrap":{ 
-    "tier": 4,
-    "type": "Scrap",
-    "mass": 19.3,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Recycler M"],
-    "input": {
-      "Gold Pure": 50
-    }
-  },
-  "Scandium Scrap":{ 
-    "tier": 4,
-    "type": "Scrap",
-    "mass": 2.98,
-    "volume": 1,
-    "outputQuantity": 50,
-    "time": 180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Recycler M"],
-    "input": {
-      "Scandium Pure": 50
-    }
-  },
-  "Iron Honeycomb":{ 
-    "tier": 1,
-    "type": "Pure Honeycomb",
-    "mass": 78.5,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 5,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Honeycomb Refinery M"],
-    "input": {
-      "Iron Pure": 100
-    }
-  },
-  "Aluminium Honeycomb":{ 
-    "tier": 1,
-    "type": "Pure Honeycomb",
-    "mass": 27,
-    "volume": 5,
-    "outputQuantity": 10,
-    "time": 5,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Honeycomb Refinery M"],
-    "input": {
-      "Aluminium Pure": 100
-    }
-  },
-  "Carbon Honeycomb":{ 
-    "tier": 1,
-    "type": "Pure Honeycomb",
-    "mass": 22.7,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 5,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Honeycomb Refinery M"],
-    "input": {
-      "Iron Pure": 100
-    }
-  },
-  "Silicon Honeycomb":{ 
-    "tier": 1,
-    "type": "Pure Honeycomb",
-    "mass": 23.3,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 5,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Honeycomb Refinery M"],
-    "input": {
-      "Silicon Pure": 100
-    }
-  },
-  "Copper Honeycomb":{ 
-    "tier": 2,
-    "type": "Pure Honeycomb",
-    "mass": 89.6,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 15,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Copper Pure": 100
-    }
-  },
-  "Chromium Honeycomb":{ 
-    "tier": 2,
-    "type": "Pure Honeycomb",
-    "mass": 71.9,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 15,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Chromium Pure": 100
-    }
-  },
-  "Calcium Honeycomb":{ 
-    "tier": 2,
-    "type": "Pure Honeycomb",
-    "mass": 15.5,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 15,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Calcium Pure": 100
-    }
-  },
-  "Sodium Honeycomb":{ 
-    "tier": 2,
-    "type": "Pure Honeycomb",
-    "mass": 9.7,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 15,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Sodium Pure": 100
-    }
-  },
-  "Lithium Honeycomb":{ 
-    "tier": 3,
-    "type": "Pure Honeycomb",
-    "mass": 5.3,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 45,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Lithium Pure": 100
-    }
-  },
-  "Nickel Honeycomb":{ 
-    "tier": 3,
-    "type": "Pure Honeycomb",
-    "mass": 89.1,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 45,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Nickel Pure": 100
-    }
-  },
-  "Silver Honeycomb":{ 
-    "tier": 3,
-    "type": "Pure Honeycomb",
-    "mass": 104.9,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 45,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Silver Pure": 100
-    }
-  },
-  "Sulfur Honeycomb":{ 
-    "tier": 3,
-    "type": "Pure Honeycomb",
-    "mass": 18.19,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 45,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Sulfur Pure": 100
-    }
-  },
-  "Gold Honeycomb":{ 
-    "tier": 4,
-    "type": "Pure Honeycomb",
-    "mass": 193,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 120,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Gold Pure": 100
-    }
-  },
-  "Cobalt Honeycomb":{ 
-    "tier": 4,
-    "type": "Pure Honeycomb",
-    "mass": 89,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 120,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Cobalt Pure": 100
-    }
-  },
-  "Fluorine Honeycomb":{ 
-    "tier": 4,
-    "type": "Pure Honeycomb",
-    "mass": 16.96,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 120,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Fluorine Pure": 100
-    }
-  },
-  "Scandium Honeycomb":{ 
-    "tier": 4,
-    "type": "Pure Honeycomb",
-    "mass": 29.85,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 120,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Scandium Pure": 100
-    }
-  },
-  "Manganese Honeycomb":{ 
-    "tier": 5,
-    "type": "Pure Honeycomb",
-    "mass": 72.1,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Manganese Pure": 100
-    }
-  },
-  "Niobium Honeycomb":{ 
-    "tier": 5,
-    "type": "Pure Honeycomb",
-    "mass": 85.7,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Niobium Pure": 100
-    }
-  },
-  "Titanium Honeycomb":{ 
-    "tier": 5,
-    "type": "Pure Honeycomb",
-    "mass": 45.1,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Titanium Pure": 100
-    }
-  },
-  "Vanadium Honeycomb":{ 
-    "tier": 5,
-    "type": "Pure Honeycomb",
-    "mass": 60,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Vanadium Pure": 100
-    }
-  },
-  "Plastic Honeycomb":{ 
-    "tier": 1,
-    "type": "Product Honeycomb",
-    "mass": 27.57,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 20,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Honeycomb Refinery M"],
-    "input": {
-      "Polycarbonate Plastic": 100
-    }
-  },
-  "Wood Honeycomb":{ 
-    "tier": 1,
-    "type": "Product Honeycomb",
-    "mass": 27.19,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 10,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Honeycomb Refinery M"],
-    "input": {
-      "Wood": 100
-    }
-  },
-  "Concrete Honeycomb":{ 
-    "tier": 1,
-    "type": "Product Honeycomb",
-    "mass": 27.57,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 20,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Honeycomb Refinery M"],
-    "input": {
-      "Concrete": 100
-    }
-  },
-  "Carbonfiber Honeycomb":{ 
-    "tier": 2,
-    "type": "Product Honeycomb",
-    "mass": 27.38,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 20,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Honeycomb Refinery M"],
-    "input": {
-      "Carbon Fiber": 100
-    }
-  },
-  "Brick Honeycomb":{ 
-    "tier": 1,
-    "type": "Product Honeycomb",
-    "mass": 27.57,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 10,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Honeycomb Refinery M"],
-    "input": {
-      "Brick": 100
-    }
-  },
-  "Steel Honeycomb":{ 
-    "tier": 2,
-    "type": "Product Honeycomb",
-    "mass": 115.14,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 20,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack","Honeycomb Refinery M"],
-    "input": {
-      "Steel": 100
-    }
-  },
-  "Marble Honeycomb":{ 
-    "tier": 2,
-    "type": "Product Honeycomb",
-    "mass": 129.4,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 30,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Honeycomb Refinery M"],
-    "input": {
-      "Marble": 100
-    }
-  },
-  "Luminescent White Glass":{ 
-    "tier": 1,
-    "type": "Product Honeycomb",
-    "mass": 26,
-    "volume": 10,
-    "outputQuantity": 10,
-    "time": 15,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Advanced Glass": 100,
-	  "Uncommon LED": 10
-    }
-  },
-  "Resurrection Node":{ 
-    "tier": 2,
-    "type": "Resurrection Node",
-    "mass": 728.43,
-    "volume": 203.33,
-    "outputQuantity": 1,
-    "time": 5400,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic Component": 3,
-      "Uncommon Component": 3,
-      "Uncommon Power System": 5,
-      "Uncommon Power Transformer S": 1,
-      "Uncommon Standard Frame S": 1
-    }
-  },
-  "Virtual Scaffolding Projector":{ 
-    "tier": 4,
-    "type": "Virtual Projector",
-    "mass": 167.11,
-    "volume": 122.4,
-    "outputQuantity": 1,
-    "time": 14400,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Component": 3,
-      "Advanced Component": 3,
-      "Rare Optics": 5,
-      "Rare Laser Chamber S": 1,
-      "Rare Casing S": 1
-    }
-  },
-  "Cannon XS":{ 
-    "tier": 1,
-    "type": "Cannon",
-    "mass": 190.1,
-    "volume": 34.2,
-    "outputQuantity": 1,
-    "time": 1080,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Screw": 1,
-      "Advanced Electronics": 1,
-      "Advanced Firing System XS": 1,
-      "Advanced Reinforced Frame XS": 1
-    }
-  },
-  "Cannon S":{ 
-    "tier": 2,
-    "type": "Cannon",
-    "mass": 517.52,
-    "volume": 95.4,
-    "outputQuantity": 1,
-    "time": 4320,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Screw": 6,
-      "Advanced Electronics": 5,
-      "Advanced Firing System S": 1,
-      "Advanced Reinforced Frame S": 1
-    }
-  },
-  "Cannon M":{ 
-    "tier": 3,
-    "type": "Cannon",
-    "mass": 2670,
-    "volume": 478,
-    "outputQuantity": 1,
-    "time": 18000,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Screw": 36,
-      "Advanced Electronics": 25,
-      "Advanced Firing System M": 1,
-      "Advanced Reinforced Frame M": 1
-    }
-  },
-  "Cannon L":{ 
-    "tier": 4,
-    "type": "Cannon",
-    "mass": 15240,
-    "volume": 2614.2,
-    "outputQuantity": 1,
-    "time": 68400,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Screw": 216,
-      "Advanced Electronics": 125,
-      "Advanced Firing System L": 1,
-      "Advanced Reinforced Frame L": 1
-    }
-  },
-  "Laser XS":{ 
-    "tier": 1,
-    "type": "Laser",
-    "mass": 118.55,
-    "volume": 39.2,
-    "outputQuantity": 1,
-    "time": 1080,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Connector": 1,
-      "Advanced Power System": 1,
-      "Advanced Laser Chamber XS": 1,
-      "Advanced Reinforced Frame XS": 1
-    }
-  },
-  "Laser S":{ 
-    "tier": 2,
-    "type": "Laser",
-    "mass": 508.26,
-    "volume": 120.2,
-    "outputQuantity": 1,
-    "time": 4320,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Connector": 6,
-      "Advanced Power System": 5,
-      "Advanced Laser Chamber S": 1,
-      "Advanced Reinforced Frame S": 1
-    }
-  },
-  "Laser M":{ 
-    "tier": 3,
-    "type": "Laser",
-    "mass": 2690,
-    "volume": 600.8,
-    "outputQuantity": 1,
-    "time": 18000,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Connector": 36,
-      "Advanced Power System": 25,
-      "Advanced Laser Chamber M": 1,
-      "Advanced Reinforced Frame M": 1
-    }
-  },
-  "Laser L":{ 
-    "tier": 4,
-    "type": "Laser",
-    "mass": 14770,
-    "volume": 3221,
-    "outputQuantity": 1,
-    "time": 68400,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Connector": 216,
-      "Advanced Power System": 125,
-      "Advanced Laser Chamber L": 1,
-      "Advanced Reinforced Frame L": 1
-    }
-  },
-  "Missile XS":{ 
-    "tier": 1,
-    "type": "Missile",
-    "mass": 207.67,
-    "volume": 40.2,
-    "outputQuantity": 1,
-    "time": 1080,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Screw": 1,
-      "Advanced Hydraulics": 1,
-      "Advanced Missile Silo XS": 1,
-      "Advanced Reinforced Frame XS": 1
-    }
-  },
-  "Missile S":{ 
-    "tier": 2,
-    "type": "Missile",
-    "mass": 593.35,
-    "volume": 125.4,
-    "outputQuantity": 1,
-    "time": 4320,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Screw": 6,
-      "Advanced Hydraulics": 5,
-      "Advanced Missile Silo S": 1,
-      "Advanced Reinforced Frame S": 1
-    }
-  },
-  "Missile M":{ 
-    "tier": 3,
-    "type": "Missile",
-    "mass": 2970,
-    "volume": 628,
-    "outputQuantity": 1,
-    "time": 18000,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Screw": 36,
-      "Advanced Hydraulics": 25,
-      "Advanced Missile Silo M": 1,
-      "Advanced Reinforced Frame M": 1
-    }
-  },
-  "Missile L":{ 
-    "tier": 4,
-    "type": "Missile",
-    "mass": 16130,
-    "volume": 3364.2,
-    "outputQuantity": 1,
-    "time": 68400,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Screw": 216,
-      "Advanced Hydraulics": 125,
-      "Advanced Missile Silo L": 1,
-      "Advanced Reinforced Frame L": 1
-    }
-  },
-  "Railgun XS":{ 
-    "tier": 1,
-    "type": "Railgun",
-    "mass": 232.02,
-    "volume": 33.66,
-    "outputQuantity": 1,
-    "time": 1080,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Connector": 1,
-      "Advanced Optics": 1,
-      "Advanced Magnetic Rail XS": 1,
-      "Advanced Reinforced Frame XS": 1
-    }
-  },
-  "Railgun S":{ 
-    "tier": 2,
-    "type": "Railgun",
-    "mass": 517.52,
-    "volume": 95.4,
-    "outputQuantity": 1,
-    "time": 4320,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Connector": 6,
-      "Advanced Optics": 5,
-      "Advanced Magnetic Rail S": 1,
-      "Advanced Reinforced Frame S": 1
-    }
-  },
-  "Railgun M":{ 
-    "tier": 3,
-    "type": "Railgun",
-    "mass": 3010,
-    "volume": 565.89,
-    "outputQuantity": 1,
-    "time": 18000,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Connector": 36,
-      "Advanced Optics": 25,
-      "Advanced Magnetic Rail M": 1,
-      "Advanced Reinforced Frame M": 1
-    }
-  },
-  "Railgun L":{ 
-    "tier": 4,
-    "type": "Railgun",
-    "mass": 16720,
-    "volume": 3054.89,
-    "outputQuantity": 1,
-    "time": 68400,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Connector": 216,
-      "Advanced Optics": 125,
-      "Advanced Magnetic Rail L": 1,
-      "Advanced Reinforced Frame L": 1
-    }
-  },
-  "Cannon Agile Kinetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.61,
-    "volume": 1,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Solid Warhead": 1,
-      "Uncommon Explosive Module": 1,
-      "Al-Li Alloy": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Cannon Defense Kinetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.59,
-    "volume": 1,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Solid Warhead": 1,
-      "Uncommon Explosive Module": 1,
-      "Polysulfide Plastic": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Cannon Heavy Kinetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.73,
-    "volume": 1,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Solid Warhead": 1,
-      "Uncommon Explosive Module": 1,
-      "Inconel": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Cannon Kinetic Ammo XS":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 1.54,
-    "volume": 1,
-    "outputQuantity": 40,
-    "time": 180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Solid Warhead": 1,
-      "Basic Explosive Module": 1,
-      "Basic Reinforced Frame XS": 1
-    }
-  },
-  "Cannon Precision Kinetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.54,
-    "volume": 1,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Solid Warhead": 1,
-      "Uncommon Explosive Module": 1,
-      "Ag-Li Reinforced Glass": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Cannon Agile Thermic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.07,
-    "volume": 1,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Explosive Module": 1,
-      "Uncommon Explosive Module": 1,
-      "Al-Li Alloy": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Cannon Defense Thermic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.05,
-    "volume": 1,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Explosive Module": 1,
-      "Uncommon Explosive Module": 1,
-      "Polysulfide Plastic": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Cannon Heavy Thermic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.19,
-    "volume": 1,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Explosive Module": 1,
-      "Uncommon Explosive Module": 1,
-      "Inconel": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Cannon Precision Thermic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.08,
-    "volume": 1,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Explosive Module": 1,
-      "Uncommon Explosive Module": 1,
-      "Ag-Li Reinforced Glass": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Cannon Thermic Ammo XS":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 1.01,
-    "volume": 1,
-    "outputQuantity": 40,
-    "time": 180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Explosive Module": 1,
-      "Basic Explosive Module": 1,
-      "Basic Reinforced Frame XS": 1
-    }
-  },
-  "Cannon Agile Kinetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 4.1,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Solid Warhead": 2,
-      "Uncommon Explosive Module": 2,
-      "Al-Li Alloy": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Cannon Defense Kinetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 4.07,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Solid Warhead": 2,
-      "Uncommon Explosive Module": 2,
-      "Polysulfide Plastic": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Cannon Heavy Kinetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 4.34,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Solid Warhead": 2,
-      "Uncommon Explosive Module": 2,
-      "Inconel": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Cannon Kinetic Ammo S":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 3.98,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Solid Warhead": 2,
-      "Basic Explosive Module": 2,
-      "Basic Reinforced Frame XS": 2
-    }
-  },
-  "Cannon Precision Kinetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 4.11,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Solid Warhead": 2,
-      "Uncommon Explosive Module": 2,
-      "Ag-Li Reinforced Glass": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Cannon Agile Thermic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 3.2,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Explosive Module": 2,
-      "Uncommon Explosive Module": 2,
-      "Al-Li Alloy": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Cannon Defense Thermic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 2.99,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Explosive Module": 2,
-      "Uncommon Explosive Module": 2,
-      "Polysulfide Plastic": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Cannon Heavy Thermic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 3.28,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Explosive Module": 2,
-      "Uncommon Explosive Module": 2,
-      "Inconel": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Cannon Precision Thermic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 3.2,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Explosive Module": 2,
-      "Uncommon Explosive Module": 2,
-      "Ag-Li Reinforced Glass": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Cannon Thermic Ammo S":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 2.93,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Explosive Module": 2,
-      "Basic Explosive Module": 2,
-      "Basic Reinforced Frame XS": 2
-    }
-  },
-  "Cannon Agile Kinetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 14.73,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Solid Warhead": 4,
-      "Uncommon Explosive Module": 4,
-      "Al-Li Alloy": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Cannon Defense Kinetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 14.66,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Solid Warhead": 4,
-      "Uncommon Explosive Module": 4,
-      "Polysulfide Plastic": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Cannon Heavy Kinetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 15.21,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Solid Warhead": 4,
-      "Uncommon Explosive Module": 4,
-      "Inconel": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Cannon Kinetic Ammo M":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 14.66,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Solid Warhead": 4,
-      "Basic Explosive Module": 4,
-      "Basic Reinforced Frame S": 1
-    }
-  },
-  "Cannon Precision Kinetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 14.76,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Solid Warhead": 4,
-      "Uncommon Explosive Module": 4,
-      "Ag-Li Reinforced Glass": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Cannon Agile Thermic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 12.57,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Explosive Module": 4,
-      "Uncommon Explosive Module": 4,
-      "Al-Li Alloy": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Cannon Defense Thermic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 12.5,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Explosive Module": 4,
-      "Uncommon Explosive Module": 4,
-      "Polysulfide Plastic": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Cannon Heavy Thermic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 13.05,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Explosive Module": 4,
-      "Uncommon Explosive Module": 4,
-      "Inconel": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Cannon Precision Thermic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 12.6,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Explosive Module": 4,
-      "Uncommon Explosive Module": 4,
-      "Ag-Li Reinforced Glass": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Cannon Thermic Ammo M":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 12.55,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Explosive Module": 4,
-      "Basic Explosive Module": 4,
-      "Basic Reinforced Frame S": 1
-    }
-  },
-  "Cannon Agile Kinetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 75.56,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Solid Warhead": 8,
-      "Uncommon Explosive Module": 8,
-      "Al-Li Alloy": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Cannon Defense Kinetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 75.42,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Solid Warhead": 8,
-      "Uncommon Explosive Module": 8,
-      "Polysulfide Plastic": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Cannon Heavy Kinetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 76.52,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Solid Warhead": 8,
-      "Uncommon Explosive Module": 8,
-      "Inconel": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Cannon Kinetic Ammo L":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 76.58,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Solid Warhead": 8,
-      "Basic Explosive Module": 8,
-      "Basic Reinforced Frame S": 2
-    }
-  },
-  "Cannon Precision Kinetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 75.61,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Solid Warhead": 8,
-      "Uncommon Explosive Module": 8,
-      "Ag-Li Reinforced Glass": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Cannon Agile Thermic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 71.24,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Explosive Module": 8,
-      "Uncommon Explosive Module": 8,
-      "Al-Li Alloy": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Cannon Defense Thermic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 71.1,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Explosive Module": 8,
-      "Uncommon Explosive Module": 8,
-      "Polysulfide Plastic": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Cannon Heavy Thermic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 72.2,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Explosive Module": 8,
-      "Uncommon Explosive Module": 8,
-      "Inconel": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Cannon Precision Thermic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 71.29,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Explosive Module": 8,
-      "Uncommon Explosive Module": 8,
-      "Ag-Li Reinforced Glass": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Cannon Thermic Ammo L":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 72.37,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Explosive Module": 8,
-      "Basic Explosive Module": 8,
-      "Basic Reinforced Frame S": 2
-    }
-  },
-  "Laser Agile Electromagnetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 31.56,
-    "volume": 2,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Magnet": 1,
-      "Uncommon Optics": 1,
-      "Al-Li Alloy": 1,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Defense Electromagnetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.54,
-    "volume": 2,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Magnet": 1,
-      "Uncommon Optics": 1,
-      "Polysulfide Plastic": 1,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Electromagnetic Ammo XS":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 1.46,
-    "volume": 2,
-    "outputQuantity": 40,
-    "time": 180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Magnet": 1,
-      "Basic Optics": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Laser Heavy Electromagnetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.68,
-    "volume": 2,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Magnet": 1,
-      "Uncommon Optics": 1,
-      "Inconel": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Laser Precision Electromagnetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass":1.56,
-    "volume": 2,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Magnet": 1,
-      "Uncommon Optics": 1,
-      "Ag-Li Reinforced Glass": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Laser Agile Thermic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 0.67,
-    "volume": 2,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Explosive Module": 1,
-      "Uncommon Optics": 1,
-      "Al-Li Alloy": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Laser Defense Thermic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 0.65,
-    "volume": 2,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Explosive Module": 1,
-      "Uncommon Optics": 1,
-      "Polysulfide Plastic": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Laser Heavy Thermic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 0.79,
-    "volume": 2,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Explosive Module": 1,
-      "Uncommon Optics": 1,
-      "Inconel": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Laser Precision Thermic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 0.67,
-    "volume": 2,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Explosive Module": 1,
-      "Uncommon Optics": 1,
-      "Ag-Li Reinforced Glass": 1,
-      "Uncommon Casing XS": 1
-    }
-  },
-  "Laser Thermic Ammo XS":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 0.6,
-    "volume": 2,
-    "outputQuantity": 40,
-    "time": 180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Explosive Module": 1,
-      "Basic Optics": 1,
-      "Basic Casing XS": 1
-    }
-  },
-  "Laser Agile Electromagnetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 3.21,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Magnet": 2,
-      "Uncommon Optics": 2,
-      "Al-Li Alloy": 2,
-      "Uncommon Casing XS": 2
-    }
-  },
-  "Laser Defense Electromagnetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 3.18,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Magnet": 2,
-      "Uncommon Optics": 2,
-      "Polysulfide Plastic": 2,
-      "Uncommon Casing XS": 2
-    }
-  },
-  "Laser Electromagnetic Ammo S":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 3.03,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Magnet": 2,
-      "Basic Optics": 2,
-      "Basic Casing XS": 2
-    }
-  },
-  "Laser Heavy Electromagnetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 3.45,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Magnet": 2,
-      "Uncommon Optics": 2,
-      "Inconel": 2,
-      "Uncommon Casing XS": 2
-    }
-  },
-  "Laser Precision Electromagnetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 3.23,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Magnet": 2,
-      "Uncommon Optics": 2,
-      "Ag-Li Reinforced Glass": 2,
-      "Uncommon Casing XS": 2
-    }
-  },
-  "Laser Agile Thermic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.44,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Explosive Module": 2,
-      "Uncommon Optics": 2,
-      "Al-Li Alloy": 2,
-      "Uncommon Casing XS": 2
-    }
-  },
-  "Laser Defense Thermic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.4,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Explosive Module": 2,
-      "Uncommon Optics": 2,
-      "Polysulfide Plastic": 2,
-      "Uncommon Casing XS": 2
-    }
-  },
-  "Laser Heavy Thermic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.68,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Explosive Module": 2,
-      "Uncommon Optics": 2,
-      "Inconel": 2,
-      "Uncommon Casing XS": 2
-    }
-  },
-  "Laser Precision Thermic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.45,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Explosive Module": 2,
-      "Uncommon Optics": 2,
-      "Ag-Li Reinforced Glass": 2,
-      "Uncommon Casing XS": 2
-    }
-  },
-  "Laser Thermic Ammo S":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 1.31,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Explosive Module": 2,
-      "Basic Optics": 2,
-      "Basic Casing XS": 2
-    }
-  },
-  "Laser Agile Electromagnetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 7.19,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Magnet": 4,
-      "Uncommon Optics": 4,
-      "Al-Li Alloy": 4,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Defense Electromagnetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 7.12,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Magnet": 4,
-      "Uncommon Optics": 4,
-      "Polysulfide Plastic": 4,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Electromagnetic Ammo M":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 6.78,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Magnet": 4,
-      "Basic Optics": 4,
-      "Basic Casing S": 1
-    }
-  },
-  "Laser Heavy Electromagnetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 7.67,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Magnet": 4,
-      "Uncommon Optics": 4,
-      "Inconel": 4,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Precision Electromagnetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 7.22,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Magnet": 4,
-      "Uncommon Optics": 4,
-      "Ag-Li Reinforced Glass": 4,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Agile Thermic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 3.64,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Explosive Module": 4,
-      "Uncommon Optics": 4,
-      "Al-Li Alloy": 4,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Defense Thermic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 3.56,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Explosive Module": 4,
-      "Uncommon Optics": 4,
-      "Polysulfide Plastic": 4,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Heavy Thermic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 3.56,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Explosive Module": 4,
-      "Uncommon Optics": 4,
-      "Inconel": 4,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Precision Thermic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 4.12,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Explosive Module": 4,
-      "Uncommon Optics": 4,
-      "Ag-Li Reinforced Glass": 4,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Thermic Ammo M":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 3.34,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Explosive Module": 4,
-      "Basic Optics": 4,
-      "Basic Casing S": 1
-    }
-  },
-  "Laser Agile Electromagnetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 19.77,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Magnet": 8,
-      "Uncommon Optics": 8,
-      "Al-Li Alloy": 8,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Defense Electromagnetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 19.62,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Magnet": 8,
-      "Uncommon Optics": 8,
-      "Polysulfide Plastic": 8,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Electromagnetic Ammo L":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 18.7,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Magnet": 8,
-      "Basic Optics": 8,
-      "Basic Casing S": 1
-    }
-  },
-  "Laser Heavy Electromagnetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 20.73,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Magnet": 8,
-      "Uncommon Optics": 8,
-      "Inconel": 8,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Precision Electromagnetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 19.81,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Magnet": 8,
-      "Uncommon Optics": 8,
-      "Ag-Li Reinforced Glass": 8,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Agile Thermic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 12.65,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Explosive Module": 8,
-      "Uncommon Optics": 8,
-      "Al-Li Alloy": 8,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Defense Thermic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 12.51,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Explosive Module": 8,
-      "Uncommon Optics": 8,
-      "Polysulfide Plastic": 8,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Heavy Thermic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 13.61,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Explosive Module": 8,
-      "Uncommon Optics": 8,
-      "Inconel": 8,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Precision Thermic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 12.7,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Explosive Module": 8,
-      "Uncommon Optics": 8,
-      "Ag-Li Reinforced Glass": 8,
-      "Uncommon Casing S": 1
-    }
-  },
-  "Laser Thermic Ammo L":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 11.81,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Explosive Module": 8,
-      "Basic Optics": 8,
-      "Basic Casing S": 1
-    }
-  },
-  "Missile Agile Antimatter Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 0.94,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 1,
-      "Uncommon Processor": 1,
-      "Al-Li Alloy": 1,
-      "Uncommon Standard Frame XS": 1
-    }
-  },
-  "Missile Antimatter Ammo XS":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 0.87,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Anti-Matter Capsule": 1,
-      "Basic Processor": 1,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Missile Defense Antimatter Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 0.92,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 1,
-      "Uncommon Processor": 1,
-      "Polysulfide Plastic": 1,
-      "Uncommon Standard Frame XS": 1
-    }
-  },
-  "Missile Heavy Antimatter Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.06,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 1,
-      "Uncommon Processor": 1,
-      "Inconel": 1,
-      "Uncommon Standard Frame XS": 1
-    }
-  },
-  "Missile Precision Antimatter Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 0.95,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 1,
-      "Uncommon Processor": 1,
-      "Ag-Li Reinforced Glass": 1,
-      "Uncommon Standard Frame XS": 1
-    }
-  },
-  "Missile Agile Kinetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.37,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Solid Warhead": 1,
-      "Uncommon Processor": 1,
-      "Al-Li Alloy": 1,
-      "Uncommon Standard Frame XS": 1
-    }
-  },
-  "Missile Defense Kinetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.35,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Solid Warhead": 1,
-      "Uncommon Processor": 1,
-      "Polysulfide Plastic": 1,
-      "Uncommon Standard Frame XS": 1
-    }
-  },
-  "Missile Heavy Kinetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.49,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Solid Warhead": 1,
-      "Uncommon Processor": 1,
-      "Inconel": 1,
-      "Uncommon Standard Frame XS": 1
-    }
-  },
-  "Missile Kinetic Ammo XS":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 1.29,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Solid Warhead": 1,
-      "Basic Processor": 2,
-      "Basic Standard Frame XS": 1
-    }
-  },
-  "Missile Precision Kinetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 1.38,
-    "volume": 5,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Solid Warhead": 1,
-      "Uncommon Processor": 1,
-      "Ag-Li Reinforced Glass": 1,
-      "Uncommon Standard Frame XS": 1
-    }
-  },
-  "Missile Agile Antimatter Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 2.16,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 2,
-      "Uncommon Processor": 2,
-      "Al-Li Alloy": 2,
-      "Uncommon Standard Frame XS": 2
-    }
-  },
-  "Missile Antimatter Ammo S":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 2.16,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Anti-Matter Capsule": 2,
-      "Basic Processor": 2,
-      "Basic Standard Frame XS": 2
-    }
-  },
-  "Missile Defense Antimatter Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 2.12,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 2,
-      "Uncommon Processor": 2,
-      "Polysulfide Plastic": 2,
-      "Uncommon Standard Frame XS": 2
-    }
-  },
-  "Missile Heavy Antimatter Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 2.40,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 2,
-      "Uncommon Processor": 2,
-      "Inconel": 2,
-      "Uncommon Standard Frame XS": 2
-    }
-  },
-  "Missile Precision Antimatter Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 2.17,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 2,
-      "Uncommon Processor": 2,
-      "Ag-Li Reinforced Glass": 2,
-      "Uncommon Standard Frame XS": 2
-    }
-  },
-  "Missile Agile Kinetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 3.02,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Solid Warhead": 2,
-      "Uncommon Processor": 2,
-      "Al-Li Alloy": 2,
-      "Uncommon Standard Frame XS": 2
-    }
-  },
-  "Missile Defense Kinetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 2.99,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Solid Warhead": 2,
-      "Uncommon Processor": 2,
-      "Polysulfide Plastic": 2,
-      "Uncommon Standard Frame XS": 2
-    }
-  },
-  "Missile Heavy Kinetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 3.26,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Solid Warhead": 2,
-      "Uncommon Processor": 2,
-      "Inconel": 2,
-      "Uncommon Standard Frame XS": 2
-    }
-  },
-  "Missile Kinetic Ammo S":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 2.87,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Solid Warhead": 2,
-      "Basic Processor": 2,
-      "Basic Standard Frame XS": 2
-    }
-  },
-  "Missile Precision Kinetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 3.03,
-    "volume": 25,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Solid Warhead": 2,
-      "Uncommon Processor": 2,
-      "Ag-Li Reinforced Glass": 2,
-      "Uncommon Standard Frame XS": 2
-    }
-  },
-  "Missile Agile Antimatter Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 6.41,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 4,
-      "Uncommon Processor": 4,
-      "Al-Li Alloy": 4,
-      "Uncommon Standard Frame S": 1
-    }
-  },
-  "Missile Antimatter Ammo M":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 6.24,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Anti-Matter Capsule": 4,
-      "Basic Processor": 4,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Missile Defense Antimatter Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 6.33,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 4,
-      "Uncommon Processor": 4,
-      "Polysulfide Plastic": 4,
-      "Uncommon Standard Frame S": 1
-    }
-  },
-  "Missile Heavy Antimatter Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 6.89,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 4,
-      "Uncommon Processor": 4,
-      "Inconel": 4,
-      "Uncommon Standard Frame S": 1
-    }
-  },
-  "Missile Precision Antimatter Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 6.43,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 4,
-      "Uncommon Processor": 4,
-      "Ag-Li Reinforced Glass": 4,
-      "Uncommon Standard Frame S": 1
-    }
-  },
-  "Missile Agile Kinetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 8.13,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Solid Warhead": 4,
-      "Uncommon Processor": 4,
-      "Al-Li Alloy": 4,
-      "Uncommon Standard Frame S": 1
-    }
-  },
-  "Missile Defense Kinetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 8.06,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Solid Warhead": 4,
-      "Uncommon Processor": 4,
-      "Polysulfide Plastic": 4,
-      "Uncommon Standard Frame S": 1
-    }
-  },
-  "Missile Heavy Kinetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 8.61,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Solid Warhead": 4,
-      "Uncommon Processor": 4,
-      "Inconel": 4,
-      "Uncommon Standard Frame S": 1
-    }
-  },
-  "Missile Kinetic Ammo M":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 7.92,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Solid Warhead": 4,
-      "Basic Processor": 4,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Missile Precision Kinetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 8.15,
-    "volume": 125,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Solid Warhead": 4,
-      "Uncommon Processor": 4,
-      "Ag-Li Reinforced Glass": 4,
-      "Uncommon Standard Frame S": 1
-    }
-  },
-"Missile Agile Antimatter Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 27.54,
-    "volume": 625,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 8,
-      "Uncommon Processor": 8,
-      "Al-Li Alloy": 8,
-      "Uncommon Standard Frame S": 2
-    }
-  },
-  "Missile Antimatter Ammo L":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 27.9,
-    "volume": 625,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Anti-Matter Capsule": 8,
-      "Basic Processor": 8,
-      "Basic Standard Frame S": 2
-    }
-  },
-  "Missile Defense Antimatter Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 6.33,
-    "volume": 625,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 8,
-      "Uncommon Processor": 8,
-      "Polysulfide Plastic": 8,
-      "Uncommon Standard Frame S": 2
-    }
-  },
-  "Missile Heavy Antimatter Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 27.4,
-    "volume": 625,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 8,
-      "Uncommon Processor": 8,
-      "Inconel": 8,
-      "Uncommon Standard Frame S": 2
-    }
-  },
-  "Missile Precision Antimatter Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 27.59,
-    "volume": 625,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 8,
-      "Uncommon Processor": 8,
-      "Ag-Li Reinforced Glass": 8,
-      "Uncommon Standard Frame S": 2
-    }
-  },
-  "Missile Agile Kinetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 30.99,
-    "volume": 625,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Solid Warhead": 8,
-      "Uncommon Processor": 8,
-      "Al-Li Alloy": 8,
-      "Uncommon Standard Frame S": 2
-    }
-  },
-  "Missile Defense Kinetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 30.84,
-    "volume": 625,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Solid Warhead": 8,
-      "Uncommon Processor": 8,
-      "Polysulfide Plastic": 8,
-      "Uncommon Standard Frame S": 2
-    }
-  },
-  "Missile Heavy Kinetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 31.95,
-    "volume": 625,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Solid Warhead": 8,
-      "Uncommon Processor": 8,
-      "Inconel": 8,
-      "Uncommon Standard Frame S": 2
-    }
-  },
-  "Missile Kinetic Ammo L":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 31.26,
-    "volume": 625,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Solid Warhead": 8,
-      "Basic Processor": 8,
-      "Basic Standard Frame S": 2
-    }
-  },
-  "Missile Precision Kinetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 31.04,
-    "volume": 625,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Solid Warhead": 8,
-      "Uncommon Processor": 8,
-      "Ag-Li Reinforced Glass": 8,
-      "Uncommon Standard Frame S": 2
-    }
-  },
-  "Railgun Agile Antimatter Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 2.04,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 1,
-      "Uncommon Magnet": 1,
-      "Al-Li Alloy": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Railgun Antimatter Ammo XS":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 2.01,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Anti-Matter Capsule": 1,
-      "Basic Magnet": 1,
-      "Basic Reinforced Frame XS": 1
-    }
-  },
-  "Railgun Defense Antimatter Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 2.02,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 1,
-      "Uncommon Magnet": 1,
-      "Polysulfide Plastic": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Railgun Heavy Antimatter Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 2.16,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 1,
-      "Uncommon Magnet": 1,
-      "Inconel": 2,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Railgun Precision Antimatter Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 2.05,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 1,
-      "Uncommon Magnet": 1,
-      "Ag-Li Reinforced Glass": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Railgun Agile Electromagnetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 2.77,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Magnet": 1,
-      "Uncommon Magnet": 1,
-      "Al-Li Alloy": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Railgun Defense Electromagnetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 2.8,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Magnet": 1,
-      "Uncommon Magnet": 1,
-      "Polysulfide Plastic": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Railgun Electromagnetic Ammo XS":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 6.43,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Magnet": 1,
-      "Basic Magnet": 1,
-      "Basic Reinforced Frame XS": 1
-    }
-  },
-  "Railgun Heavy Electromagnetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 2.94,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Magnet": 1,
-      "Uncommon Magnet": 1,
-      "Inconel": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Railgun Precision Electromagnetic Ammo XS":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 2.83,
-    "volume": 10,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Advanced Magnet": 1,
-      "Uncommon Magnet": 1,
-      "Ag-Li Reinforced Glass": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Railgun Agile Antimatter Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 4.96,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 2,
-      "Uncommon Magnet": 2,
-      "Al-Li Alloy": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Railgun Antimatter Ammo S":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 4.92,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Anti-Matter Capsule": 2,
-      "Basic Magnet": 2,
-      "Basic Reinforced Frame XS": 2
-    }
-  },
-  "Railgun Defense Antimatter Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 4.93,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 2,
-      "Uncommon Magnet": 2,
-      "Polysulfide Plastic": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Railgun Heavy Antimatter Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 5.2,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 2,
-      "Uncommon Magnet": 2,
-      "Inconel": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Railgun Precision Antimatter Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 4.97,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 2,
-      "Uncommon Magnet": 2,
-      "Ag-Li Reinforced Glass": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Railgun Agile Electromagnetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 6.52,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Magnet": 2,
-      "Uncommon Magnet": 2,
-      "Al-Li Alloy": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Railgun Defense Electromagnetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 6.49,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Magnet": 2,
-      "Uncommon Magnet": 2,
-      "Polysulfide Plastic": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Railgun Electromagnetic Ammo S":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 6.43,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 420,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Magnet": 2,
-      "Basic Magnet": 2,
-      "Basic Reinforced Frame XS": 2
-    }
-  },
-  "Railgun Heavy Electromagnetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 6.76,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Magnet": 2,
-      "Uncommon Magnet": 2,
-      "Inconel": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Railgun Precision Electromagnetic Ammo S":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 6.53,
-    "volume": 50,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Advanced Magnet": 2,
-      "Uncommon Magnet": 2,
-      "Ag-Li Reinforced Glass": 2,
-      "Uncommon Reinforced Frame XS": 2
-    }
-  },
-  "Railgun Agile Antimatter Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 16.45,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 4,
-      "Uncommon Magnet": 4,
-      "Al-Li Alloy": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Railgun Antimatter Ammo M":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 16.54,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Anti-Matter Capsule": 4,
-      "Basic Magnet": 4,
-      "Basic Reinforced Frame S": 1
-    }
-  },
-  "Railgun Defense Antimatter Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 16.38,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 4,
-      "Uncommon Magnet": 4,
-      "Polysulfide Plastic": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Railgun Heavy Antimatter Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 16.93,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 4,
-      "Uncommon Magnet": 4,
-      "Inconel": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Railgun Precision Antimatter Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 16.48,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 4,
-      "Uncommon Magnet": 4,
-      "Ag-Li Reinforced Glass": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Railgun Agile Electromagnetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 19.58,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Magnet": 4,
-      "Uncommon Magnet": 4,
-      "Al-Li Alloy": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Railgun Defense Electromagnetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 19.5,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Magnet": 4,
-      "Uncommon Magnet": 4,
-      "Polysulfide Plastic": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Railgun Electromagnetic Ammo M":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 19.56,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 780,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Uncommon Magnet": 4,
-      "Basic Magnet": 4,
-      "Basic Reinforced Frame S": 1
-    }
-  },
-  "Railgun Heavy Electromagnetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 20.06,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Magnet": 4,
-      "Uncommon Magnet": 4,
-      "Inconel": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Railgun Precision Electromagnetic Ammo M":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 19.6,
-    "volume": 250,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Advanced Magnet": 4,
-      "Uncommon Magnet": 4,
-      "Ag-Li Reinforced Glass": 4,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Railgun Agile Antimatter Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 79,
-    "volume": 1250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 8,
-      "Uncommon Magnet": 8,
-      "Al-Li Alloy": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Railgun Antimatter Ammo L":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 80.35,
-    "volume": 1250,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Anti-Matter Capsule": 8,
-      "Basic Magnet": 8,
-      "Basic Reinforced Frame S": 2
-    }
-  },
-  "Railgun Defense Antimatter Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 78.86,
-    "volume": 1250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 8,
-      "Uncommon Magnet": 8,
-      "Polysulfide Plastic": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Railgun Heavy Antimatter Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 79.96,
-    "volume": 1250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 8,
-      "Uncommon Magnet": 8,
-      "Inconel": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Railgun Precision Antimatter Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 79.05,
-    "volume": 1250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Anti-Matter Capsule": 8,
-      "Uncommon Magnet": 8,
-      "Ag-Li Reinforced Glass": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Railgun Agile Electromagnetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 85.24,
-    "volume": 1250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Magnet": 8,
-      "Uncommon Magnet": 8,
-      "Al-Li Alloy": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Railgun Defense Electromagnetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 85.1,
-    "volume": 1250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Magnet": 8,
-      "Uncommon Magnet": 8,
-      "Polysulfide Plastic": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Railgun Electromagnetic Ammo L":{ 
-    "tier": 2,
-    "type": "Uncommon Ammo",
-    "mass": 86.4,
-    "volume": 1250,
-    "outputQuantity": 40,
-    "time": 1620,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Magnet": 8,
-      "Basic Magnet": 8,
-      "Basic Reinforced Frame S": 2
-    }
-  },
-  "Railgun Heavy Electromagnetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 86.2,
-    "volume": 1250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Magnet": 8,
-      "Uncommon Magnet": 8,
-      "Inconel": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Railgun Precision Electromagnetic Ammo L":{ 
-    "tier": 3,
-    "type": "Advanced Ammo",
-    "mass": 85.29,
-    "volume": 1250,
-    "outputQuantity": 40,
-    "time": 3180,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Advanced Magnet": 8,
-      "Uncommon Magnet": 8,
-      "Ag-Li Reinforced Glass": 8,
-      "Uncommon Reinforced Frame S": 2
-    }
-  },
-  "Warp Cell":{ 
-    "tier": 3,
-    "type": "Warp Cell",
-    "mass": 100,
-    "volume": 40,
-    "outputQuantity": 1,
-    "time": 3000,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Glass Furnace M"],
-    "input": {
-      "Advanced Quantum Alignment Unit": 1,
-      "Advanced Anti-Matter Core Unit": 1
-    }
-  },
-  "Warp Drive L":{ 
-    "tier": 1,
-    "type": "Warp Drive Unit",
-    "mass": 31360,
-    "volume": 75,
-    "outputQuantity": 1,
-    "time": 86400,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Screw": 216,
-      "Advanced Magnet": 125,
-      "Advanced Ionic Chamber L": 1,
-      "Advanced Anti-Matter Core Unit": 64,
-      "Advanced Reinforced Frame L": 1
-    }
-  },
-  "Warp Beacon XL":{ 
-    "tier": 5,
-    "type": "Warp Beacon Unit",
-    "mass": 148940,
-    "volume": 25360,
-    "outputQuantity": 1,
-    "time": 3110400,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Advanced LED": 1296,
-      "Exotic Power System": 625,
-      "Exotic Antenna XL": 1,
-      "Exotic Quantum Alignment Unit": 256,
-      "Exotic Reinforced Frame XL": 1
-    }
-  },
-  "Hatch S":{ 
-    "tier": 1,
-    "type": "Door/Gate",
-    "mass": 229.09,
-    "volume": 64,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack", "Assembly Line S"],
-    "input": {
-      "Silumin": 7,
-      "Basic Fixation": 6,
-      "Basic Reinforced Frame S": 1
-    }
-  },
-  "Fuel Intake XS":{ 
-    "tier": 1,
-    "type": "Door/Gate",
-    "mass": 4.12,
-    "volume": 2,
-    "outputQuantity": 1,
-    "time": 18,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack", "Assembly Line XS"],
-    "input": {
-      "Silumin": 2,
-      "Basic Fixation": 1
-    }
-  },
-  "Freight Atmospheric Engine XS":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 101.88,
-    "volume": 22.6,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Uncommon Screw": 1,
-      "Uncommon Injector": 1,
-      "Uncommon Combustion Chamber XS": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Safe Atmospheric Engine XS":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 101.88,
-    "volume": 22.6,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Uncommon Screw": 1,
-      "Uncommon Injector": 1,
-      "Uncommon Combustion Chamber XS": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Maneuver Atmospheric Engine XS":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 101.88,
-    "volume": 22.6,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Uncommon Screw": 1,
-      "Uncommon Injector": 1,
-      "Uncommon Combustion Chamber XS": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Military Atmospheric Engine XS":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 101.88,
-    "volume": 22.6,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Uncommon Screw": 1,
-      "Uncommon Injector": 1,
-      "Uncommon Combustion Chamber XS": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Freight Atmospheric Engine S":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 539.99,
-    "volume": 116.6,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic Screw": 3,
-      "Uncommon Screw": 3,
-      "Uncommon Injector": 5,
-      "Uncommon Combustion Chamber S": 1,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Maneuver Atmospheric Engine S":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 539.99,
-    "volume": 116.6,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic Screw": 3,
-      "Uncommon Screw": 3,
-      "Uncommon Injector": 5,
-      "Uncommon Combustion Chamber S": 1,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Military Atmospheric Engine S":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 539.99,
-    "volume": 116.6,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic Screw": 3,
-      "Uncommon Screw": 3,
-      "Uncommon Injector": 5,
-      "Uncommon Combustion Chamber S": 1,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Safe Atmospheric Engine S":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 539.99,
-    "volume": 116.6,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic Screw": 3,
-      "Uncommon Screw": 3,
-      "Uncommon Injector": 5,
-      "Uncommon Combustion Chamber S": 1,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Freight Atmospheric Engine M":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 2980,
-    "volume": 619.2,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 18,
-      "Uncommon Screw": 18,
-      "Uncommon Injector": 25,
-      "Uncommon Combustion Chamber M": 1,
-      "Uncommon Reinforced Frame M": 1
-    }
-  },
-  "Maneuver Atmospheric Engine M":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 2980,
-    "volume": 619.2,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 18,
-      "Uncommon Screw": 18,
-      "Uncommon Injector": 25,
-      "Uncommon Combustion Chamber M": 1,
-      "Uncommon Reinforced Frame M": 1
-    }
-  },
-  "Military Atmospheric Engine M":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 2980,
-    "volume": 619.2,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 18,
-      "Uncommon Screw": 18,
-      "Uncommon Injector": 25,
-      "Uncommon Combustion Chamber M": 1,
-      "Uncommon Reinforced Frame M": 1
-    }
-  },
-  "Safe Atmospheric Engine M":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 2980,
-    "volume": 619.2,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 18,
-      "Uncommon Screw": 18,
-      "Uncommon Injector": 25,
-      "Uncommon Combustion Chamber M": 1,
-      "Uncommon Reinforced Frame M": 1
-    }
-  },
-  "Freight Atmospheric Engine L":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 16930,
-    "volume": 3355.4,
-    "outputQuantity": 1,
-    "time": 23040,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 108,
-      "Uncommon Screw": 108,
-      "Uncommon Injector": 125,
-      "Uncommon Combustion Chamber L": 1,
-      "Uncommon Reinforced Frame L": 1
-    }
-  },
-  "Maneuver Atmospheric Engine L":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 16930,
-    "volume": 3355.4,
-    "outputQuantity": 1,
-    "time": 23040,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 108,
-      "Uncommon Screw": 108,
-      "Uncommon Injector": 125,
-      "Uncommon Combustion Chamber L": 1,
-      "Uncommon Reinforced Frame L": 1
-    }
-  },
-  "Military Atmospheric Engine L":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 16930,
-    "volume": 3355.4,
-    "outputQuantity": 1,
-    "time": 23040,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 108,
-      "Uncommon Screw": 108,
-      "Uncommon Injector": 125,
-      "Uncommon Combustion Chamber L": 1,
-      "Uncommon Reinforced Frame L": 1
-    }
-  },
-  "Safe Atmospheric Engine L":{ 
-    "tier": 2,
-    "type": "Atmospheric Engine",
-    "mass": 16930,
-    "volume": 3355.4,
-    "outputQuantity": 1,
-    "time": 23040,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 108,
-      "Uncommon Screw": 108,
-      "Uncommon Injector": 125,
-      "Uncommon Combustion Chamber L": 1,
-      "Uncommon Reinforced Frame L": 1
-    }
-  },
-  "Freight Space Engine XS":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 146.23,
-    "volume": 20.33,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Uncommon Screw": 1,
-      "Uncommon Burner": 1,
-      "Uncommon Ionic Chamber XS": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Maneuver Space Engine XS":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 146.23,
-    "volume": 20.33,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Uncommon Screw": 1,
-      "Uncommon Burner": 1,
-      "Uncommon Ionic Chamber XS": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Military Space Engine XS":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 146.23,
-    "volume": 20.33,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Uncommon Screw": 1,
-      "Uncommon Burner": 1,
-      "Uncommon Ionic Chamber XS": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Safe Space Engine XS":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 146.23,
-    "volume": 20.33,
-    "outputQuantity": 1,
-    "time": 360,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Basic Screw": 1,
-      "Uncommon Screw": 1,
-      "Uncommon Burner": 1,
-      "Uncommon Ionic Chamber XS": 1,
-      "Uncommon Reinforced Frame XS": 1
-    }
-  },
-  "Freight Space Engine S":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 761.74,
-    "volume": 105.24,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic Screw": 3,
-      "Uncommon Screw": 3,
-      "Uncommon Burner": 5,
-      "Uncommon Ionic Chamber S": 1,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Maneuver Space Engine S":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 761.74,
-    "volume": 105.24,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic Screw": 3,
-      "Uncommon Screw": 3,
-      "Uncommon Burner": 5,
-      "Uncommon Ionic Chamber S": 1,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Military Space Engine S":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 761.74,
-    "volume": 105.24,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic Screw": 3,
-      "Uncommon Screw": 3,
-      "Uncommon Burner": 5,
-      "Uncommon Ionic Chamber S": 1,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Safe Space Engine S":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 761.74,
-    "volume": 105.24,
-    "outputQuantity": 1,
-    "time": 1440,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Basic Screw": 3,
-      "Uncommon Screw": 3,
-      "Uncommon Burner": 5,
-      "Uncommon Ionic Chamber S": 1,
-      "Uncommon Reinforced Frame S": 1
-    }
-  },
-  "Freight Space Engine M":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 4090,
-    "volume": 562.4,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 18,
-      "Uncommon Screw": 18,
-      "Uncommon Burner": 25,
-      "Uncommon Ionic Chamber M": 1,
-      "Uncommon Reinforced Frame M": 1
-    }
-  },
-  "Maneuver Space Engine M":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 4090,
-    "volume": 562.4,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 18,
-      "Uncommon Screw": 18,
-      "Uncommon Burner": 25,
-      "Uncommon Ionic Chamber M": 1,
-      "Uncommon Reinforced Frame M": 1
-    }
-  },
-  "Military Space Engine M":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 4090,
-    "volume": 562.4,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 18,
-      "Uncommon Screw": 18,
-      "Uncommon Burner": 25,
-      "Uncommon Ionic Chamber M": 1,
-      "Uncommon Reinforced Frame M": 1
-    }
-  },
-  "Safe Space Engine M":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 4090,
-    "volume": 562.4,
-    "outputQuantity": 1,
-    "time": 5760,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line M"],
-    "input": {
-      "Basic Screw": 18,
-      "Uncommon Screw": 18,
-      "Uncommon Burner": 25,
-      "Uncommon Ionic Chamber M": 1,
-      "Uncommon Reinforced Frame M": 1
-    }
-  },
-  "Freight Space Engine L":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 22470,
-    "volume": 3071.4,
-    "outputQuantity": 1,
-    "time": 23040,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 108,
-      "Uncommon Screw": 108,
-      "Uncommon Burner": 125,
-      "Uncommon Ionic Chamber L": 1,
-      "Uncommon Reinforced Frame L": 1
-    }
-  },
-  "Maneuver Space Engine L":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 22470,
-    "volume": 3071.4,
-    "outputQuantity": 1,
-    "time": 23040,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 108,
-      "Uncommon Screw": 108,
-      "Uncommon Burner": 125,
-      "Uncommon Ionic Chamber L": 1,
-      "Uncommon Reinforced Frame L": 1
-    }
-  },
-  "Military Space Engine L":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 22470,
-    "volume": 3071.4,
-    "outputQuantity": 1,
-    "time": 23040,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 108,
-      "Uncommon Screw": 108,
-      "Uncommon Burner": 125,
-      "Uncommon Ionic Chamber L": 1,
-      "Uncommon Reinforced Frame L": 1
-    }
-  },
-  "Safe Space Engine L":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 22470,
-    "volume": 3071.4,
-    "outputQuantity": 1,
-    "time": 23040,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Basic Screw": 108,
-      "Uncommon Screw": 108,
-      "Uncommon Burner": 125,
-      "Uncommon Ionic Chamber L": 1,
-      "Uncommon Reinforced Frame L": 1
-    }
-  },
-  "Freight Space Engine XL":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 126240,
-    "volume": 17150,
-    "outputQuantity": 1,
-    "time": 92160,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Basic Screw": 648,
-      "Uncommon Screw": 648,
-      "Uncommon Burner": 625,
-      "Uncommon Ionic Chamber XL": 1,
-      "Uncommon Reinforced Frame XL": 1
-    }
-  },
-  "Maneuver Space Engine XL":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 126240,
-    "volume": 17150,
-    "outputQuantity": 1,
-    "time": 92160,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Basic Screw": 648,
-      "Uncommon Screw": 648,
-      "Uncommon Burner": 625,
-      "Uncommon Ionic Chamber XL": 1,
-      "Uncommon Reinforced Frame XL": 1
-    }
-  },
-  "Military Space Engine XL":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 126240,
-    "volume": 17150,
-    "outputQuantity": 1,
-    "time": 92160,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Basic Screw": 648,
-      "Uncommon Screw": 648,
-      "Uncommon Burner": 625,
-      "Uncommon Ionic Chamber XL": 1,
-      "Uncommon Reinforced Frame XL": 1
-    }
-  },
-  "Safe Space Engine XL":{ 
-    "tier": 2,
-    "type": "Space Engine",
-    "mass": 126240,
-    "volume": 17150,
-    "outputQuantity": 1,
-    "time": 92160,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Basic Screw": 648,
-      "Uncommon Screw": 648,
-      "Uncommon Burner": 625,
-      "Uncommon Ionic Chamber XL": 1,
-      "Uncommon Reinforced Frame XL": 1
-    }
-  },
-  "Advanced Space Engine XS":{ 
-    "tier": 3,
-    "type": "Space Engine",
-    "mass": 146.23,
-    "volume": 20.33,
-    "outputQuantity": 1,
-    "time": 1080,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XS"],
-    "input": {
-      "Uncommon Screw": 1,
-      "Advanced Burner": 1,
-      "Advanced Ionic Chamber XS": 1,
-      "Advanced Reinforced Frame XS": 1
-    }
-  },
-  "Advanced Space Engine S":{ 
-    "tier": 3,
-    "type": "Space Engine",
-    "mass": 761.74,
-    "volume": 105.24,
-    "outputQuantity": 1,
-    "time": 4320,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Screw": 6,
-      "Advanced Burner": 5,
-      "Advanced Ionic Chamber S": 1,
-      "Advanced Reinforced Frame S": 1
-    }
-  },
-  "Advanced Space Engine M":{ 
-    "tier": 3,
-    "type": "Space Engine",
-    "mass": 4090,
-    "volume": 562.4,
-    "outputQuantity": 1,
-    "time": 69120,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Screw": 216,
-      "Advanced Burner": 125,
-      "Advanced Ionic Chamber L": 1,
-      "Advanced Reinforced Frame L": 1
-    }
-  },
-  "Advanced Space Engine XL":{ 
-    "tier": 3,
-    "type": "Space Engine",
-    "mass": 126240,
-    "volume": 17150,
-    "outputQuantity": 1,
-    "time": 259500,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line XL"],
-    "input": {
-      "Uncommon Screw": 1296,
-      "Advanced Burner": 625,
-      "Advanced Ionic Chamber XL": 1,
-      "Advanced Reinforced Frame XL": 1
-    }
-  },
-  "Repair Unit":{ 
-    "tier": 1,
-    "type": "Combat Element",
-    "mass": 400,
-    "volume": 0,
-    "outputQuantity": 1,
-    "time": 86400,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line L"],
-    "input": {
-      "Uncommon Component": 216,
-      "Advanced Hydraulics": 125,
-      "Advanced Magnetic Rail L": 1,
-      "Advanced Anti-Matter Core Unit": 64,
-      "Advanced Reinforced Frame L": 1
-    }
-  },
-  "Surrogate Pod Station":{ 
-    "tier": 1,
-    "type": "Surrogate Element",
-    "mass": 569.52,
-    "volume": 360,
-    "outputQuantity": 1,
-    "time": 4320,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Component": 6,
-      "Advanced Hydraulics": 5,
-      "Advanced Antenna S": 1,
-      "Advanced Standard Frame S": 1
-    }
-  },
-  "Surrogate VR Station":{ 
-    "tier": 1,
-    "type": "Surrogate Element",
-    "mass": 742.42,
-    "volume": 360.2,
-    "outputQuantity": 1,
-    "time": 480,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Nanopack", "Assembly Line S"],
-    "input": {
-      "Basic Component": 6,
-      "Basic Processor": 5,
-      "Basic Screen S": 1,
-      "Basic Standard Frame S": 1
-    }
-  },
-  "Transponder":{ 
-    "tier": 3,
-    "type": "Radar",
-    "mass": 340,
-    "volume": 97,
-    "outputQuantity": 1,
-    "time": 4320,
-    "skill": "Systems",
-    "byproducts": {},
-    "industries": ["Assembly Line S"],
-    "input": {
-      "Uncommon Screw": 6,
-      "Advanced Processor": 5,
-      "Advanced Antenna S": 1,
-      "Advanced Standard Frame S": 1
-    }
-  }
+	"Bauxite": {
+		"tier": 1,
+		"type": "Ore",
+		"mass": 1.28,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Coal": {
+		"tier": 1,
+		"type": "Ore",
+		"mass": 1.35,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Quartz": {
+		"tier": 1,
+		"type": "Ore",
+		"mass": 2.65,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Hematite": {
+		"tier": 1,
+		"type": "Ore",
+		"mass": 5.04,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Chromite": {
+		"tier": 2,
+		"type": "Ore",
+		"mass": 7.19,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Malachite": {
+		"tier": 2,
+		"type": "Ore",
+		"mass": 4,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Limestone": {
+		"tier": 2,
+		"type": "Ore",
+		"mass": 0.968,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Natron": {
+		"tier": 2,
+		"type": "Ore",
+		"mass": 1.55,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Petalite": {
+		"tier": 3,
+		"type": "Ore",
+		"mass": 2.41,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Garnierite": {
+		"tier": 3,
+		"type": "Ore",
+		"mass": 2.6,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Acanthite": {
+		"tier": 3,
+		"type": "Ore",
+		"mass": 7.2,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Pyrite": {
+		"tier": 3,
+		"type": "Ore",
+		"mass": 5.01,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Cobaltite": {
+		"tier": 4,
+		"type": "Ore",
+		"mass": 6.33,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Cryolite": {
+		"tier": 4,
+		"type": "Ore",
+		"mass": 2.95,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Kolbeckite": {
+		"tier": 4,
+		"type": "Ore",
+		"mass": 2.37,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Gold Nuggets": {
+		"tier": 4,
+		"type": "Ore",
+		"mass": 19.3,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Rhodonite": {
+		"tier": 5,
+		"type": "Ore",
+		"mass": 3.76,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Columbite": {
+		"tier": 5,
+		"type": "Ore",
+		"mass": 5.38,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Illmenite": {
+		"tier": 5,
+		"type": "Ore",
+		"mass": 4.55,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Vanadinite": {
+		"tier": 5,
+		"type": "Ore",
+		"mass": 6.95,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Thoramine": {
+		"tier": 5,
+		"type": "Ore",
+		"mass": 21.3,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 0,
+		"skill": "",
+		"byproducts": {},
+		"industries": [],
+		"input": {}
+	},
+	"Oxygen Pure": {
+		"tier": 1,
+		"type": "Pure",
+		"mass": 1,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 100,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Recycler M"
+		],
+		"input": {}
+	},
+	"Hydrogen Pure": {
+		"tier": 1,
+		"type": "Pure",
+		"mass": 0.07,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 100,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Recycler M"
+		],
+		"input": {}
+	},
+	"Aluminium Pure": {
+		"tier": 1,
+		"type": "Pure",
+		"mass": 2.7,
+		"volume": 1,
+		"outputQuantity": 405,
+		"time": 225,
+		"skill": "",
+		"byproducts": {
+			"Hydrogen Pure": 135
+		},
+		"industries": [
+			"Nanopack",
+			"Refiner M"
+		],
+		"input": {
+			"Bauxite": 585
+		}
+	},
+	"Carbon Pure": {
+		"tier": 1,
+		"type": "Pure",
+		"mass": 2.27,
+		"volume": 1,
+		"outputQuantity": 405,
+		"time": 225,
+		"skill": "",
+		"byproducts": {
+			"Oxygen Pure": 67.5,
+			"Hydrogen Pure": 67.5
+		},
+		"industries": [
+			"Nanopack",
+			"Refiner M"
+		],
+		"input": {
+			"Coal": 585
+		}
+	},
+	"Silicon Pure": {
+		"tier": 1,
+		"type": "Pure",
+		"mass": 2.33,
+		"volume": 1,
+		"outputQuantity": 405,
+		"time": 225,
+		"skill": "",
+		"byproducts": {
+			"Oxygen Pure": 135
+		},
+		"industries": [
+			"Nanopack",
+			"Refiner M"
+		],
+		"input": {
+			"Quartz": 585
+		}
+	},
+	"Iron Pure": {
+		"tier": 1,
+		"type": "Pure",
+		"mass": 7.85,
+		"volume": 1,
+		"outputQuantity": 405,
+		"time": 225,
+		"skill": "",
+		"byproducts": {
+			"Oxygen Pure": 135
+		},
+		"industries": [
+			"Nanopack",
+			"Refiner M"
+		],
+		"input": {
+			"Hematite": 585
+		}
+	},
+	"Calcium Pure": {
+		"tier": 2,
+		"type": "Pure",
+		"mass": 1.55,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 120,
+		"skill": "",
+		"byproducts": {
+			"Oxygen Pure": 7.5,
+			"Carbon Pure": 7.5
+		},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Limestone": 65
+		}
+	},
+	"Chromium Pure": {
+		"tier": 2,
+		"type": "Pure",
+		"mass": 7.19,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 120,
+		"skill": "",
+		"byproducts": {
+			"Oxygen Pure": 7.5,
+			"Iron Pure": 7.5
+		},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Chromite": 65
+		}
+	},
+	"Copper Pure": {
+		"tier": 2,
+		"type": "Pure",
+		"mass": 8.96,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 120,
+		"skill": "",
+		"byproducts": {
+			"Hydrogen Pure": 7.5,
+			"Carbon Pure": 7.5
+		},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Malachite": 65
+		}
+	},
+	"Sodium Pure": {
+		"tier": 2,
+		"type": "Pure",
+		"mass": 0.97,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 120,
+		"skill": "",
+		"byproducts": {
+			"Hydrogen Pure": 7.5,
+			"Carbon Pure": 7.5
+		},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Natron": 65
+		}
+	},
+	"Lithium Pure": {
+		"tier": 3,
+		"type": "Pure",
+		"mass": 0.53,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 600,
+		"skill": "",
+		"byproducts": {
+			"Silicon Pure": 7.5,
+			"Aluminium Pure": 7.5
+		},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Petalite": 65
+		}
+	},
+	"Nickel Pure": {
+		"tier": 3,
+		"type": "Pure",
+		"mass": 8.91,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 600,
+		"skill": "",
+		"byproducts": {
+			"Oxygen Pure": 7.5,
+			"Silicon Pure": 7.5
+		},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Garnierite": 65
+		}
+	},
+	"Silver Pure": {
+		"tier": 3,
+		"type": "Pure",
+		"mass": 10.49,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 600,
+		"skill": "",
+		"byproducts": {
+			"Sulfur Pure": 15
+		},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Acanthite": 65
+		}
+	},
+	"Sulfur Pure": {
+		"tier": 3,
+		"type": "Pure",
+		"mass": 1.82,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 600,
+		"skill": "",
+		"byproducts": {
+			"Iron Pure": 15
+		},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Pyrite": 65
+		}
+	},
+	"Cobalt Pure": {
+		"tier": 4,
+		"type": "Pure",
+		"mass": 8.9,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 3120,
+		"skill": "",
+		"byproducts": {
+			"Sulfur Pure": 15
+		},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Cobaltite": 65
+		}
+	},
+	"Fluorine Pure": {
+		"tier": 4,
+		"type": "Pure",
+		"mass": 1.7,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 3120,
+		"skill": "",
+		"byproducts": {
+			"Sodium Pure": 7.5,
+			"Aluminium Pure": 7.5
+		},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Cryolite": 65
+		}
+	},
+	"Gold Pure": {
+		"tier": 4,
+		"type": "Pure",
+		"mass": 19.3,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 3120,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Gold Nuggets": 65
+		}
+	},
+	"Scandium Pure": {
+		"tier": 4,
+		"type": "Pure",
+		"mass": 2.98,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 3120,
+		"skill": "",
+		"byproducts": {
+			"Oxygen Pure": 7.5,
+			"Hydrogen Pure": 7.5
+		},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Kolbeckite": 65
+		}
+	},
+	"Manganese Pure": {
+		"tier": 5,
+		"type": "Pure",
+		"mass": 7.21,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 14400,
+		"skill": "",
+		"byproducts": {
+			"Calcium Pure": 5,
+			"Silicon Pure": 5,
+			"Oxygen Pure": 5
+		},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Rhodonite": 65
+		}
+	},
+	"Niobium Pure": {
+		"tier": 5,
+		"type": "Pure",
+		"mass": 8.57,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 14400,
+		"skill": "",
+		"byproducts": {
+			"Iron Pure": 5,
+			"Manganese Pure": 5,
+			"Oxygen Pure": 5
+		},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Columbite": 65
+		}
+	},
+	"Titanium Pure": {
+		"tier": 5,
+		"type": "Pure",
+		"mass": 4.51,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 14400,
+		"skill": "",
+		"byproducts": {
+			"Iron Pure": 7.5,
+			"Oxygen Pure": 7.5
+		},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Illmenite": 65
+		}
+	},
+	"Vanadium Pure": {
+		"tier": 5,
+		"type": "Pure",
+		"mass": 6,
+		"volume": 1,
+		"outputQuantity": 45,
+		"time": 14400,
+		"skill": "",
+		"byproducts": {
+			"Oxygen Pure": 15
+		},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Vanadinite": 65
+		}
+	},
+	"Catalyst 3": {
+		"tier": 3,
+		"type": "Catalyst",
+		"mass": 649.39,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 2500,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Chemical Industry M"
+		],
+		"input": {
+			"Hydrogen Pure": 300,
+			"Iron Pure": 200,
+			"Sodium Pure": 100,
+			"Sulfur Pure": 50
+		}
+	},
+	"Catalyst 4": {
+		"tier": 4,
+		"type": "Catalyst",
+		"mass": 606.65,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 12480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Chemical Industry M"
+		],
+		"input": {
+			"Hydrogen Pure": 300,
+			"Iron Pure": 500,
+			"Sodium Pure": 200,
+			"Sulfur Pure": 100,
+			"Fluorine Pure": 50
+		}
+	},
+	"Catalyst 5": {
+		"tier": 5,
+		"type": "Catalyst",
+		"mass": 657.68,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 62520,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Chemical Industry M"
+		],
+		"input": {
+			"Hydrogen Pure": 300,
+			"Iron Pure": 1000,
+			"Sodium Pure": 500,
+			"Sulfur Pure": 200,
+			"Fluorine Pure": 100,
+			"Manganese Pure": 50
+		}
+	},
+	"Nitron Fuel": {
+		"tier": 1,
+		"type": "Fuel",
+		"mass": 4,
+		"volume": 1,
+		"outputQuantity": 100,
+		"time": 20,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Chemical Industry M"
+		],
+		"input": {
+			"Silicon Pure": 20,
+			"Carbon Pure": 20,
+			"Oxygen Pure": 40,
+			"Hydrogen Pure": 20
+		}
+	},
+	"Kergon-X1 Fuel": {
+		"tier": 1,
+		"type": "Fuel",
+		"mass": 6,
+		"volume": 1,
+		"outputQuantity": 100,
+		"time": 40,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Chemical Industry M"
+		],
+		"input": {
+			"Sodium Pure": 40,
+			"Oxygen Pure": 30,
+			"Hydrogen Pure": 30
+		}
+	},
+	"Kergon-X2 Fuel": {
+		"tier": 1,
+		"type": "Fuel",
+		"mass": 6,
+		"volume": 1,
+		"outputQuantity": 100,
+		"time": 40,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Chemical Industry M"
+		],
+		"input": {
+			"Calcium Pure": 40,
+			"Oxygen Pure": 25,
+			"Hydrogen Pure": 35
+		}
+	},
+	"Kergon-X3 Fuel": {
+		"tier": 1,
+		"type": "Fuel",
+		"mass": 6,
+		"volume": 1,
+		"outputQuantity": 100,
+		"time": 40,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Chemical Industry M"
+		],
+		"input": {
+			"Chromium Pure": 40,
+			"Oxygen Pure": 35,
+			"Hydrogen Pure": 25
+		}
+	},
+	"Kergon-X4 Fuel": {
+		"tier": 1,
+		"type": "Fuel",
+		"mass": 6,
+		"volume": 1,
+		"outputQuantity": 100,
+		"time": 40,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Chemical Industry M"
+		],
+		"input": {
+			"Copper Pure": 40,
+			"Oxygen Pure": 30,
+			"Hydrogen Pure": 30
+		}
+	},
+	"Xeron Fuel": {
+		"tier": 2,
+		"type": "Fuel",
+		"mass": 0.8,
+		"volume": 1,
+		"outputQuantity": 100,
+		"time": 60,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Chemical Industry M"
+		],
+		"input": {
+			"Chromium Pure": 10,
+			"Sodium Pure": 10,
+			"Hydrogen Pure": 60,
+			"Oxygen Pure": 20
+		}
+	},
+	"Al-Fe Alloy": {
+		"tier": 1,
+		"type": "Product",
+		"mass": 7.5,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 150,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Smelter M"
+		],
+		"input": {
+			"Aluminium Pure": 100,
+			"Iron Pure": 50
+		}
+	},
+	"Al-Li Alloy": {
+		"tier": 3,
+		"type": "Product",
+		"mass": 2.5,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 3780,
+		"skill": "",
+		"byproducts": {
+			"Catalyst 3": 1
+		},
+		"industries": [
+			"Smelter M"
+		],
+		"input": {
+			"Lithium Pure": 100,
+			"Aluminium Pure": 50,
+			"Catalyst 3": 1
+		}
+	},
+	"Calcium Reinforced Copper": {
+		"tier": 2,
+		"type": "Product",
+		"mass": 8.1,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 750,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Smelter M"
+		],
+		"input": {
+			"Copper Pure": 100,
+			"Calcium Pure": 50
+		}
+	},
+	"Cu-Ag Alloy": {
+		"tier": 3,
+		"type": "Product",
+		"mass": 9.2,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 3780,
+		"skill": "",
+		"byproducts": {
+			"Catalyst 3": 1
+		},
+		"industries": [
+			"Smelter M"
+		],
+		"input": {
+			"Silver Pure": 100,
+			"Copper Pure": 50,
+			"Catalyst 3": 1
+		}
+	},
+	"Duralumin": {
+		"tier": 2,
+		"type": "Product",
+		"mass": 2.8,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 750,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Smelter M"
+		],
+		"input": {
+			"Copper Pure": 100,
+			"Aluminium Pure": 50
+		}
+	},
+	"Grade 5 Titanium Alloy": {
+		"tier": 5,
+		"type": "Product",
+		"mass": 4.43,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 93780,
+		"skill": "",
+		"byproducts": {
+			"Catalyst 5": 1
+		},
+		"industries": [
+			"Smelter M"
+		],
+		"input": {
+			"Titanium Pure": 100,
+			"Vanadium Pure": 50,
+			"Aluminium Pure": 50,
+			"Catalyst 5": 1
+		}
+	},
+	"Inconel": {
+		"tier": 3,
+		"type": "Product",
+		"mass": 8.5,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 3780,
+		"skill": "",
+		"byproducts": {
+			"Catalyst 3": 1
+		},
+		"industries": [
+			"Smelter M"
+		],
+		"input": {
+			"Nickel Pure": 100,
+			"Chromium Pure": 50,
+			"Iron Pure": 50,
+			"Catalyst 3": 1
+		}
+	},
+	"Mangalloy": {
+		"tier": 5,
+		"type": "Product",
+		"mass": 7.83,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 93780,
+		"skill": "",
+		"byproducts": {
+			"Catalyst 5": 1
+		},
+		"industries": [
+			"Smelter M"
+		],
+		"input": {
+			"Manganese Pure": 100,
+			"Niobium Pure": 50,
+			"Iron Pure": 50,
+			"Catalyst 5": 1
+		}
+	},
+	"Maraging Steel": {
+		"tier": 4,
+		"type": "Product",
+		"mass": 8.23,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 18780,
+		"skill": "",
+		"byproducts": {
+			"Catalyst 4": 1
+		},
+		"industries": [
+			"Smelter M"
+		],
+		"input": {
+			"Cobalt Pure": 100,
+			"Nickel Pure": 50,
+			"Iron Pure": 50,
+			"Catalyst 4": 1
+		}
+	},
+	"Red Gold": {
+		"tier": 4,
+		"type": "Product",
+		"mass": 14.13,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 18780,
+		"skill": "",
+		"byproducts": {
+			"Catalyst 4": 1
+		},
+		"industries": [
+			"Smelter M"
+		],
+		"input": {
+			"Gold Pure": 100,
+			"Copper Pure": 50,
+			"Catalyst 4": 1
+		}
+	},
+	"Sc-Al Alloy": {
+		"tier": 4,
+		"type": "Product",
+		"mass": 2.85,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 18780,
+		"skill": "",
+		"byproducts": {
+			"Catalyst 4": 1
+		},
+		"industries": [
+			"Smelter M"
+		],
+		"input": {
+			"Scandium Pure": 100,
+			"Aluminium Pure": 50,
+			"Lithium Pure": 50,
+			"Catalyst 4": 1
+		}
+	},
+	"Stainless Steel": {
+		"tier": 2,
+		"type": "Product",
+		"mass": 7.75,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 750,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Smelter M"
+		],
+		"input": {
+			"Chromium Pure": 100,
+			"Iron Pure": 50,
+			"Carbon Pure": 50
+		}
+	},
+	"Ti-Nb Supraconductor": {
+		"tier": 5,
+		"type": "Product",
+		"mass": 10.1,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 93780,
+		"skill": "",
+		"byproducts": {
+			"Catalyst 5": 1
+		},
+		"industries": [
+			"Smelter M"
+		],
+		"input": {
+			"Niobium Pure": 100,
+			"Titanium Pure": 50,
+			"Catalyst 5": 1
+		}
+	},
+	"Biological Matter": {
+		"tier": 1,
+		"type": "Product",
+		"mass": 1,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 150,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Chemical Industry M"
+		],
+		"input": {
+			"Carbon Pure": 100,
+			"Oxygen Pure": 50,
+			"Hydrogen Pure": 50
+		}
+	},
+	"Brick": {
+		"tier": 1,
+		"type": "Product",
+		"mass": 1.92,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 150,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Smelter M"
+		],
+		"input": {
+			"Silicon Pure": 50,
+			"Aluminium Pure": 50,
+			"Oxygen Pure": 50
+		}
+	},
+	"Marble": {
+		"tier": 2,
+		"type": "Product",
+		"mass": 2.7,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 750,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Calcium Pure": 50,
+			"Carbon Pure": 50,
+			"Oxygen Pure": 50
+		}
+	},
+	"Concrete": {
+		"tier": 2,
+		"type": "Product",
+		"mass": 2.41,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 750,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Refiner M"
+		],
+		"input": {
+			"Calcium Pure": 5,
+			"Carbon Pure": 37.5,
+			"Silicon Pure": 37.5
+		}
+	},
+	"Carbon Fiber": {
+		"tier": 1,
+		"type": "Product",
+		"mass": 1.5,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 150,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 50,
+			"Carbon Pure": 50
+		}
+	},
+	"Glass": {
+		"tier": 1,
+		"type": "Product",
+		"mass": 2.5,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 150,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Glass Furnace M"
+		],
+		"input": {
+			"Silicon Pure": 100,
+			"Oxygen Pure": 50
+		}
+	},
+	"Advanced Glass": {
+		"tier": 2,
+		"type": "Product",
+		"mass": 2.6,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 750,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Sodium Pure": 100,
+			"Calcium Pure": 50,
+			"Silicon Pure": 50,
+			"Oxygen Pure": 50
+		}
+	},
+	"Ag-Li Reinforced Glass": {
+		"tier": 3,
+		"type": "Product",
+		"mass": 2.8,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 3750,
+		"skill": "",
+		"byproducts": {
+			"Catalyst 3": 1
+		},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Silver Pure": 100,
+			"Lithium Pure": 50,
+			"Silicon Pure": 50,
+			"Oxygen Pure": 50,
+			"Catalyst 3": 1
+		}
+	},
+	"Gold Coated Glass": {
+		"tier": 4,
+		"type": "Product",
+		"mass": 3,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 18780,
+		"skill": "",
+		"byproducts": {
+			"Catalyst 4": 1
+		},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Gold Pure": 100,
+			"Silicon Pure": 50,
+			"Sodium Pure": 50,
+			"Oxygen Pure": 50,
+			"Catalyst 4": 1
+		}
+	},
+	"Manganese Reinforced Glass": {
+		"tier": 5,
+		"type": "Product",
+		"mass": 2.9,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 93780,
+		"skill": "",
+		"byproducts": {
+			"Catalyst 5": 1
+		},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Manganese Pure": 100,
+			"Calcium Pure": 50,
+			"Silicon Pure": 50,
+			"Oxygen Pure": 50,
+			"Catalyst 5": 1
+		}
+	},
+	"Polycarbonate Plastic": {
+		"tier": 1,
+		"type": "Product",
+		"mass": 1.4,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 150,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Chemical Industry M"
+		],
+		"input": {
+			"Carbon Pure": 100,
+			"Hydrogen Pure": 50
+		}
+	},
+	"Polycalcite Plastic": {
+		"tier": 2,
+		"type": "Product",
+		"mass": 1.5,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 750,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Chemical Industry M"
+		],
+		"input": {
+			"Calcium Pure": 100,
+			"Carbon Pure": 50,
+			"Hydrogen Pure": 50
+		}
+	},
+	"Polysulfide Plastic": {
+		"tier": 3,
+		"type": "Product",
+		"mass": 1.6,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 3750,
+		"skill": "",
+		"byproducts": {
+			"Catalyst 3": 1
+		},
+		"industries": [
+			"Chemical Industry M"
+		],
+		"input": {
+			"Sulfur Pure": 100,
+			"Carbon Pure": 50,
+			"Hydrogen Pure": 50,
+			"Catalyst 3": 1
+		}
+	},
+	"Fluoropolymer": {
+		"tier": 4,
+		"type": "Product",
+		"mass": 1.65,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 18780,
+		"skill": "",
+		"byproducts": {
+			"Catalyst 4": 1
+		},
+		"industries": [
+			"Chemical Industry M"
+		],
+		"input": {
+			"Fluorine Pure": 100,
+			"Carbon Pure": 50,
+			"Hydrogen Pure": 50,
+			"Catalyst 4": 1
+		}
+	},
+	"Vanamer": {
+		"tier": 5,
+		"type": "Product",
+		"mass": 1.57,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 93780,
+		"skill": "",
+		"byproducts": {
+			"Catalyst 5": 1
+		},
+		"industries": [
+			"Chemical Industry M"
+		],
+		"input": {
+			"Vanadium Pure": 100,
+			"Sulfur Pure": 50,
+			"Carbon Pure": 50,
+			"Hydrogen Pure": 50,
+			"Catalyst 5": 1
+		}
+	},
+	"Silumin": {
+		"tier": 1,
+		"type": "Product",
+		"mass": 3,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 150,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Smelter M"
+		],
+		"input": {
+			"Aluminium Pure": 100,
+			"Silicon Pure": 50
+		}
+	},
+	"Steel": {
+		"tier": 1,
+		"type": "Product",
+		"mass": 8.05,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 150,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Smelter M"
+		],
+		"input": {
+			"Iron Pure": 100,
+			"Carbon Pure": 50
+		}
+	},
+	"Wood": {
+		"tier": 1,
+		"type": "Product",
+		"mass": 0.6,
+		"volume": 1,
+		"outputQuantity": 75,
+		"time": 150,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Refiner M"
+		],
+		"input": {
+			"Carbon Pure": 50,
+			"Oxygen Pure": 50
+		}
+	},
+	"Basic Component": {
+		"tier": 1,
+		"type": "Intermediary Part",
+		"mass": 2.25,
+		"volume": 0.5,
+		"outputQuantity": 20,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 20
+		}
+	},
+	"Uncommon Component": {
+		"tier": 2,
+		"type": "Intermediary Part",
+		"mass": 2.34,
+		"volume": 0.5,
+		"outputQuantity": 10,
+		"time": 480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 5,
+			"Calcium Reinforced Copper": 5
+		}
+	},
+	"Advanced Component": {
+		"tier": 3,
+		"type": "Intermediary Part",
+		"mass": 2.51,
+		"volume": 0.5,
+		"outputQuantity": 10,
+		"time": 1920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 3,
+			"Calcium Reinforced Copper": 3,
+			"Cu-Ag Alloy": 4
+		}
+	},
+	"Basic Connector": {
+		"tier": 1,
+		"type": "Intermediary Part",
+		"mass": 3.75,
+		"volume": 0.8,
+		"outputQuantity": 20,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 20
+		}
+	},
+	"Uncommon Connector": {
+		"tier": 2,
+		"type": "Intermediary Part",
+		"mass": 3.9,
+		"volume": 0.8,
+		"outputQuantity": 10,
+		"time": 480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 5,
+			"Calcium Reinforced Copper": 5
+		}
+	},
+	"Advanced Connector": {
+		"tier": 3,
+		"type": "Intermediary Part",
+		"mass": 4.18,
+		"volume": 0.8,
+		"outputQuantity": 10,
+		"time": 1920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 3,
+			"Calcium Reinforced Copper": 3,
+			"Cu-Ag Alloy": 4
+		}
+	},
+	"Basic Fixation": {
+		"tier": 1,
+		"type": "Intermediary Part",
+		"mass": 1.12,
+		"volume": 1,
+		"outputQuantity": 10,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 10
+		}
+	},
+	"Uncommon Fixation": {
+		"tier": 2,
+		"type": "Intermediary Part",
+		"mass": 1.16,
+		"volume": 1,
+		"outputQuantity": 10,
+		"time": 120,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 5,
+			"Polycalcite Plastic": 5
+		}
+	},
+	"Advanced Fixation": {
+		"tier": 3,
+		"type": "Intermediary Part",
+		"mass": 1.21,
+		"volume": 1,
+		"outputQuantity": 10,
+		"time": 1920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 5,
+			"Polycalcite Plastic": 5,
+			"Polysulfide Plastic": 5
+		}
+	},
+	"Basic LED": {
+		"tier": 1,
+		"type": "Intermediary Part",
+		"mass": 1.25,
+		"volume": 1,
+		"outputQuantity": 10,
+		"time": 120,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Glass Furnace M"
+		],
+		"input": {
+			"Glass": 10
+		}
+	},
+	"Uncommon LED": {
+		"tier": 2,
+		"type": "Intermediary Part",
+		"mass": 1.27,
+		"volume": 1,
+		"outputQuantity": 10,
+		"time": 480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Glass": 5,
+			"Advanced Glass": 5
+		}
+	},
+	"Advanced LED": {
+		"tier": 3,
+		"type": "Intermediary Part",
+		"mass": 1.32,
+		"volume": 1,
+		"outputQuantity": 10,
+		"time": 1920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Glass": 3,
+			"Advanced Glass": 3,
+			"Ag-Li Reinforced Glass": 4
+		}
+	},
+	"Basic Pipe": {
+		"tier": 1,
+		"type": "Intermediary Part",
+		"mass": 2.4,
+		"volume": 1,
+		"outputQuantity": 20,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 20
+		}
+	},
+	"Uncommon Pipe": {
+		"tier": 2,
+		"type": "Intermediary Part",
+		"mass": 2.32,
+		"volume": 1,
+		"outputQuantity": 10,
+		"time": 480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 5,
+			"Duralumin": 5
+		}
+	},
+	"Advanced Pipe": {
+		"tier": 3,
+		"type": "Intermediary Part",
+		"mass": 2.19,
+		"volume": 1,
+		"outputQuantity": 10,
+		"time": 1920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 3,
+			"Duralumin": 3,
+			"Al-Li Alloy": 4
+		}
+	},
+	"Basic Screw": {
+		"tier": 1,
+		"type": "Intermediary Part",
+		"mass": 8.05,
+		"volume": 1,
+		"outputQuantity": 20,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 20
+		}
+	},
+	"Uncommon Screw": {
+		"tier": 2,
+		"type": "Intermediary Part",
+		"mass": 7.9,
+		"volume": 1,
+		"outputQuantity": 10,
+		"time": 480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 5,
+			"Stainless Steel": 5
+		}
+	},
+	"Advanced Screw": {
+		"tier": 3,
+		"type": "Intermediary Part",
+		"mass": 8.14,
+		"volume": 1,
+		"outputQuantity": 10,
+		"time": 1920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 3,
+			"Stainless Steel": 3,
+			"Inconel": 4
+		}
+	},
+	"Basic Anti-Matter Capsule": {
+		"tier": 1,
+		"type": "Complex Part",
+		"mass": 24,
+		"volume": 4.6,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Glass Furnace M"
+		],
+		"input": {
+			"Glass": 6,
+			"Basic Connector": 4
+		}
+	},
+	"Uncommon Anti-Matter Capsule": {
+		"tier": 2,
+		"type": "Complex Part",
+		"mass": 24.32,
+		"volume": 4.6,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Glass": 2,
+			"Basic Connector": 4,
+			"Advanced Glass": 4
+		}
+	},
+	"Advanced Anti-Matter Capsule": {
+		"tier": 3,
+		"type": "Complex Part",
+		"mass": 24.88,
+		"volume": 4.6,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Glass": 2,
+			"Basic Connector": 2,
+			"Advanced Glass": 2,
+			"Uncommon Connector": 2,
+			"Ag-Li Reinforced Glass": 2
+		}
+	},
+	"Rare Anti-Matter Capsule": {
+		"tier": 4,
+		"type": "Complex Part",
+		"mass": 25.8,
+		"volume": 4.6,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Advanced Glass": 2,
+			"Uncommon Connector": 3,
+			"Ag-Li Reinforced Glass": 2,
+			"Gold Coated Glass": 2
+		}
+	},
+	"Exotic Anti-Matter Capsule": {
+		"tier": 5,
+		"type": "Complex Part",
+		"mass": 26.73,
+		"volume": 4.6,
+		"outputQuantity": 1,
+		"time": 15360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Uncommon Connector": 1,
+			"Ag-Li Reinforced Glass": 2,
+			"Advanced Connector": 2,
+			"Gold Coated Glass": 2,
+			"Manganese Reinforced Glass": 2
+		}
+	},
+	"Basic Burner": {
+		"tier": 1,
+		"type": "Complex Part",
+		"mass": 50.2,
+		"volume": 10,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 18,
+			"Basic Screw": 12
+		}
+	},
+	"Uncommon Burner": {
+		"tier": 2,
+		"type": "Complex Part",
+		"mass": 49.4,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 2,
+			"Basic Screw": 4,
+			"Duralumin": 4
+		}
+	},
+	"Advanced Burner": {
+		"tier": 3,
+		"type": "Complex Part",
+		"mass": 48.5,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 2,
+			"Basic Screw": 2,
+			"Duralumin": 2,
+			"Uncommon Screw": 2,
+			"Al-Li Alloy": 2
+		}
+	},
+	"Basic Electronics": {
+		"tier": 1,
+		"type": "Complex Part",
+		"mass": 5.22,
+		"volume": 4,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Electronics Industry M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 18,
+			"Basic Component": 12
+		}
+	},
+	"Uncommon Electronics": {
+		"tier": 2,
+		"type": "Complex Part",
+		"mass": 5.34,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 2,
+			"Basic Component": 4,
+			"Polycalcite Plastic": 4
+		}
+	},
+	"Advanced Electronics": {
+		"tier": 3,
+		"type": "Complex Part",
+		"mass": 5.45,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 2,
+			"Basic Component": 2,
+			"Polycalcite Plastic": 2,
+			"Uncommon Component": 2,
+			"Polysulfide Plastic": 2
+		}
+	},
+	"Rare Electronics": {
+		"tier": 4,
+		"type": "Complex Part",
+		"mass": 5.63,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Polycalcite Plastic": 2,
+			"Uncommon Component": 3,
+			"Polysulfide Plastic": 2,
+			"Fluoropolymer": 2
+		}
+	},
+	"Exotic Electronics": {
+		"tier": 5,
+		"type": "Complex Part",
+		"mass": 5.77,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 15360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Polysulfide Plastic": 2,
+			"Advanced Component": 2,
+			"Fluoropolymer": 2,
+			"Vanamer": 2
+		}
+	},
+	"Basic Explosive Module": {
+		"tier": 1,
+		"type": "Complex Part",
+		"mass": 18.72,
+		"volume": 4.6,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Chemical Industry M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 6,
+			"Basic Connector": 4
+		}
+	},
+	"Uncommon Explosive Module": {
+		"tier": 2,
+		"type": "Complex Part",
+		"mass": 19.04,
+		"volume": 4.6,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Chemical Industry M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 2,
+			"Basic Connector": 4,
+			"Polycalcite Plastic": 4
+		}
+	},
+	"Advanced Explosive Module": {
+		"tier": 3,
+		"type": "Complex Part",
+		"mass": 19.04,
+		"volume": 4.6,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Chemical Industry M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 2,
+			"Basic Connector": 2,
+			"Polycalcite Plastic": 2,
+			"Uncommon Connector": 2,
+			"Polysulfide Plastic": 2
+		}
+	},
+	"Basic Hydraulics": {
+		"tier": 1,
+		"type": "Complex Part",
+		"mass": 28.95,
+		"volume": 10,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 18,
+			"Basic Pipe": 12
+		}
+	},
+	"Uncommon Hydraulics": {
+		"tier": 2,
+		"type": "Complex Part",
+		"mass": 28.35,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 2,
+			"Basic Pipe": 4,
+			"Stainless Steel": 4
+		}
+	},
+	"Advanced Hydraulics": {
+		"tier": 3,
+		"type": "Complex Part",
+		"mass": 29.02,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 2,
+			"Basic Pipe": 2,
+			"Stainless Steel": 2,
+			"Uncommon Pipe": 2,
+			"Inconel": 2
+		}
+	},
+	"Basic Injector": {
+		"tier": 1,
+		"type": "Complex Part",
+		"mass": 20.3,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 6,
+			"Basic Screw": 4
+		}
+	},
+	"Uncommon Injector": {
+		"tier": 2,
+		"type": "Complex Part",
+		"mass": 20.5,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 2,
+			"Polycalcite Plastic": 4,
+			"Basic Screw": 4
+		}
+	},
+	"Advanced Injector": {
+		"tier": 3,
+		"type": "Complex Part",
+		"mass": 20.45,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 2,
+			"Basic Screw": 2,
+			"Polycalcite Plastic": 2,
+			"Uncommon Screw": 4,
+			"Polysulfide Plastic": 2
+		}
+	},
+	"Basic Magnet": {
+		"tier": 1,
+		"type": "Complex Part",
+		"mass": 63.3,
+		"volume": 7.36,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 18,
+			"Basic Connector": 12
+		}
+	},
+	"Uncommon Magnet": {
+		"tier": 2,
+		"type": "Complex Part",
+		"mass": 62.1,
+		"volume": 7.36,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 2,
+			"Basic Connector": 4,
+			"Stainless Steel": 4
+		}
+	},
+	"Advanced Magnet": {
+		"tier": 3,
+		"type": "Complex Part",
+		"mass": 63.89,
+		"volume": 7.36,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 2,
+			"Basic Connector": 2,
+			"Stainless Steel": 2,
+			"Uncommon Connector": 2,
+			"Inconel": 2
+		}
+	},
+	"Rare Magnet": {
+		"tier": 4,
+		"type": "Complex Part",
+		"mass": 64.4,
+		"volume": 7.36,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Stainless Steel": 2,
+			"Uncommon Connector": 3,
+			"Inconel": 2,
+			"Maraging Steel": 2
+		}
+	},
+	"Exotic Magnet": {
+		"tier": 5,
+		"type": "Complex Part",
+		"mass": 65.13,
+		"volume": 7.36,
+		"outputQuantity": 1,
+		"time": 15360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Uncommon Connector": 1,
+			"Inconel": 2,
+			"Advanced Connector": 2,
+			"Maraging Steel": 2,
+			"Mangalloy": 2
+		}
+	},
+	"Basic Optics": {
+		"tier": 1,
+		"type": "Complex Part",
+		"mass": 9.74,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Glass Furnace M"
+		],
+		"input": {
+			"Glass": 6,
+			"Basic Fixation": 4
+		}
+	},
+	"Uncommon Optics": {
+		"tier": 2,
+		"type": "Complex Part",
+		"mass": 9.94,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Glass": 2,
+			"Basic Fixation": 4,
+			"Advanced Glass": 4
+		}
+	},
+	"Advanced Optics": {
+		"tier": 3,
+		"type": "Complex Part",
+		"mass": 10.18,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Glass": 2,
+			"Basic Fixation": 2,
+			"Advanced Glass": 2,
+			"Uncommon Fixation": 2,
+			"Ag-Li Reinforced Glass": 2
+		}
+	},
+	"Rare Optics": {
+		"tier": 4,
+		"type": "Complex Part",
+		"mass": 10.7,
+		"volume": 10,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Basic Fixation": 1,
+			"Advanced Glass": 2,
+			"Uncommon Fixation": 3,
+			"Ag-Li Reinforced Glass": 2,
+			"Gold Coated Glass": 2
+		}
+	},
+	"Basic Power System": {
+		"tier": 1,
+		"type": "Complex Part",
+		"mass": 60,
+		"volume": 9.2,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 18,
+			"Basic Connector": 12
+		}
+	},
+	"Uncommon Power System": {
+		"tier": 2,
+		"type": "Complex Part",
+		"mass": 62.4,
+		"volume": 9.2,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 2,
+			"Basic Connector": 4,
+			"Calcium Reinforced Copper": 4
+		}
+	},
+	"Advanced Power System": {
+		"tier": 3,
+		"type": "Complex Part",
+		"mass": 64.9,
+		"volume": 9.2,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 2,
+			"Basic Connector": 2,
+			"Calcium Reinforced Copper": 2,
+			"Uncommon Connector": 2,
+			"Cu-Ag Alloy": 2
+		}
+	},
+	"Rare Power System": {
+		"tier": 4,
+		"type": "Complex Part",
+		"mass": 78.31,
+		"volume": 9.2,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Calcium Reinforced Copper": 2,
+			"Uncommon Connector": 3,
+			"Cu-Ag Alloy": 2,
+			"Red Gold": 2
+		}
+	},
+	"Exotic Power System": {
+		"tier": 5,
+		"type": "Complex Part",
+		"mass": 82.87,
+		"volume": 9.2,
+		"outputQuantity": 1,
+		"time": 15360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Uncommon Connector": 1,
+			"Cu-Ag Alloy": 2,
+			"Advanced Connector": 2,
+			"Red Gold": 2,
+			"Ti-Nb Supraconductor": 2
+		}
+	},
+	"Basic Processor": {
+		"tier": 1,
+		"type": "Complex Part",
+		"mass": 14.84,
+		"volume": 5,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 18,
+			"Basic Fixation": 12
+		}
+	},
+	"Uncommon Processor": {
+		"tier": 2,
+		"type": "Complex Part",
+		"mass": 15.56,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 2,
+			"Basic Fixation": 4,
+			"Calcium Reinforced Copper": 4
+		}
+	},
+	"Advanced Processor": {
+		"tier": 3,
+		"type": "Complex Part",
+		"mass": 16.25,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 2,
+			"Basic Fixation": 2,
+			"Calcium Reinforced Copper": 2,
+			"Uncommon Fixation": 2,
+			"Cu-Ag Alloy": 2
+		}
+	},
+	"Exotic Processor": {
+		"tier": 5,
+		"type": "Complex Part",
+		"mass": 21.47,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 15360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Fixation": 1,
+			"Uncommon Fixation": 1,
+			"Cu-Ag Alloy": 2,
+			"Advanced Fixation": 2,
+			"Red Gold": 2,
+			"Ti-Nb Supraconductor": 2
+		}
+	},
+	"Basic Quantum Core": {
+		"tier": 1,
+		"type": "Complex Part",
+		"mass": 10.72,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 6,
+			"Basic LED": 4
+		}
+	},
+	"Uncommon Quantum Core": {
+		"tier": 2,
+		"type": "Complex Part",
+		"mass": 11.04,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 2,
+			"Basic LED": 4,
+			"Polycalcite Plastic": 4
+		}
+	},
+	"Advanced Quantum Core": {
+		"tier": 3,
+		"type": "Complex Part",
+		"mass": 11.24,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 2,
+			"Basic LED": 2,
+			"Polycalcite Plastic": 2,
+			"Uncommon LED": 2,
+			"Polysulfide Plastic": 2
+		}
+	},
+	"Rare Quantum Core": {
+		"tier": 4,
+		"type": "Complex Part",
+		"mass": 11.66,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Basic LED": 1,
+			"Polycalcite Plastic": 2,
+			"Uncommon LED": 3,
+			"Polysulfide Plastic": 2,
+			"Fluoropolymer": 2
+		}
+	},
+	"Exotic Quantum Core": {
+		"tier": 5,
+		"type": "Complex Part",
+		"mass": 11.66,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 15360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Basic LED": 1,
+			"Uncommon LED": 1,
+			"Polysulfide Plastic": 2,
+			"Advanced LED": 2,
+			"Fluoropolymer": 2,
+			"Vanamer": 2
+		}
+	},
+	"Basic Singularity Container": {
+		"tier": 1,
+		"type": "Complex Part",
+		"mass": 45.36,
+		"volume": 4,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 18,
+			"Basic Component": 12
+		}
+	},
+	"Uncommon Singularity Container": {
+		"tier": 2,
+		"type": "Complex Part",
+		"mass": 44.88,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 2,
+			"Basic Component": 4,
+			"Stainless Steel": 4
+		}
+	},
+	"Advanced Singularity Container": {
+		"tier": 3,
+		"type": "Complex Part",
+		"mass": 46.22,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 2,
+			"Basic Component": 2,
+			"Stainless Steel": 2,
+			"Uncommon Component": 2,
+			"Inconel": 2
+		}
+	},
+	"Rare Singularity Container": {
+		"tier": 4,
+		"type": "Complex Part",
+		"mass": 46.58,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 3840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Stainless Steel": 2,
+			"Uncommon Component": 3,
+			"Inconel": 2,
+			"Maraging Steel": 2
+		}
+	},
+	"Exotic Singularity Container": {
+		"tier": 5,
+		"type": "Complex Part",
+		"mass": 46.98,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 15360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Inconel": 2,
+			"Advanced Component": 2,
+			"Maraging Steel": 2,
+			"Mangalloy": 2
+		}
+	},
+	"Uncommon Solid Warhead": {
+		"tier": 2,
+		"type": "Complex Part",
+		"mass": 45.36,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 6,
+			"Basic Pipe": 4,
+			"Stainless Steel": 6
+		}
+	},
+	"Advanced Solid Warhead": {
+		"tier": 3,
+		"type": "Complex Part",
+		"mass": 46.43,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 2,
+			"Basic Pipe": 2,
+			"Stainless Steel": 2,
+			"Uncommon Pipe": 2,
+			"Inconel": 2
+		}
+	},
+	"Advanced Anti-Gravity Core": {
+		"tier": 3,
+		"type": "Exceptional Part",
+		"mass": 117.05,
+		"volume": 20,
+		"outputQuantity": 1,
+		"time": 3780,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Silumin": 5,
+			"Basic Component": 10,
+			"Basic Singularity Container": 3,
+			"Duralumin": 5,
+			"Uncommon Singularity Container": 1,
+			"Al-Li Alloy": 5,
+			"Advanced Singularity Container": 1
+		}
+	},
+	"Rare Anti-Gravity Core": {
+		"tier": 4,
+		"type": "Exceptional Part",
+		"mass": 123.22,
+		"volume": 22.5,
+		"outputQuantity": 1,
+		"time": 18780,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Silumin": 5,
+			"Basic Component": 5,
+			"Basic Singularity Container": 2,
+			"Duralumin": 5,
+			"Uncommon Component": 5,
+			"Uncommon Singularity Container": 1,
+			"Al-Li Alloy": 5,
+			"Advanced Singularity Container": 1,
+			"Sc-Al Alloy": 5,
+			"Rare Singularity Container": 1
+		}
+	},
+	"Exotic Anti-Gravity Core": {
+		"tier": 5,
+		"type": "Exceptional Part",
+		"mass": 133.06,
+		"volume": 25,
+		"outputQuantity": 1,
+		"time": 93780,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Silumin": 5,
+			"Basic Singularity Container": 1,
+			"Duralumin": 5,
+			"Uncommon Component": 5,
+			"Uncommon Singularity Container": 1,
+			"Al-Li Alloy": 5,
+			"Advanced Component": 5,
+			"Advanced Singularity Container": 1,
+			"Sc-Al Alloy": 5,
+			"Rare Singularity Container": 1,
+			"Grade 5 Titanium Alloy": 5,
+			"Exotic Singularity Container": 1
+		}
+	},
+	"Advanced Quantum Alignment Unit": {
+		"tier": 3,
+		"type": "Exceptional Part",
+		"mass": 35.78,
+		"volume": 25,
+		"outputQuantity": 1,
+		"time": 3780,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 5,
+			"Basic LED": 10,
+			"Basic Quantum Core": 3,
+			"Polycalcite Plastic": 5,
+			"Uncommon Quantum Core": 1,
+			"Polysulfide Plastic": 5,
+			"Advanced Quantum Core": 1
+		}
+	},
+	"Exotic Quantum Alignment Unit": {
+		"tier": 5,
+		"type": "Exceptional Part",
+		"mass": 43.24,
+		"volume": 30,
+		"outputQuantity": 1,
+		"time": 93780,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 5,
+			"Basic Quantum Core": 1,
+			"Polycalcite Plastic": 5,
+			"Uncommon LED": 5,
+			"Uncommon Quantum Core": 1,
+			"Polysulfide Plastic": 5,
+			"Advanced LED": 5,
+			"Advanced Quantum Core": 1,
+			"Fluoropolymer": 5,
+			"Rare Quantum Core": 1,
+			"Vanamer": 5,
+			"Exotic Quantum Core": 1
+		}
+	},
+	"Advanced Quantum Barrier": {
+		"tier": 3,
+		"type": "Exceptional Part",
+		"mass": 43.38,
+		"volume": 25,
+		"outputQuantity": 1,
+		"time": 3780,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Silumin": 5,
+			"Basic LED": 10,
+			"Basic Quantum Core": 3,
+			"Duralumin": 5,
+			"Uncommon Quantum Core": 1,
+			"Al-Li Alloy": 5,
+			"Advanced Quantum Core": 1
+		}
+	},
+	"Advanced Anti-Matter Core Unit": {
+		"tier": 3,
+		"type": "Exceptional Part",
+		"mass": 107.08,
+		"volume": 21.5,
+		"outputQuantity": 1,
+		"time": 3780,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 5,
+			"Basic Component": 10,
+			"Basic Anti-Matter Capsule": 3,
+			"Calcium Reinforced Copper": 5,
+			"Uncommon Anti-Matter Capsule": 1,
+			"Cu-Ag Alloy": 5,
+			"Advanced Anti-Matter Capsule": 1
+		}
+	},
+	"Exotic Anti-Matter Core Unit": {
+		"tier": 5,
+		"type": "Exceptional Part",
+		"mass": 158.05,
+		"volume": 26.5,
+		"outputQuantity": 1,
+		"time": 93780,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 5,
+			"Basic Anti-Matter Capsule": 1,
+			"Calcium Reinforced Copper": 5,
+			"Uncommon Component": 5,
+			"Uncommon Anti-Matter Capsule": 1,
+			"Cu-Ag Alloy": 5,
+			"Advanced Component": 5,
+			"Advanced Anti-Matter Capsule": 1,
+			"Red Gold": 5,
+			"Rare Anti-Matter Capsule": 1,
+			"Ti-Nb Supraconductor": 5,
+			"Exotic Anti-Matter Capsule": 1
+		}
+	},
+	"Basic Antenna XS": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 60.44,
+		"volume": 8.96,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 3,
+			"Basic Screw": 3
+		}
+	},
+	"Basic Antenna S": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 314.2,
+		"volume": 46.4,
+		"outputQuantity": 1,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 7,
+			"Basic Screw": 5
+		}
+	},
+	"Uncommon Antenna XS": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 117.16,
+		"volume": 17.12,
+		"outputQuantity": 1,
+		"time": 168,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Power System": 1,
+			"Calcium Reinforced Copper": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Power System": 1
+		}
+	},
+	"Uncommon Antenna S": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 379.2,
+		"volume": 54.56,
+		"outputQuantity": 1,
+		"time": 720,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Screw": 2,
+			"Basic Power System": 2,
+			"Calcium Reinforced Copper": 7,
+			"Uncommon Screw": 4,
+			"Uncommon Power System": 4
+		}
+	},
+	"Uncommon Antenna M": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 1770,
+		"volume": 251.36,
+		"outputQuantity": 1,
+		"time": 2160,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Screw": 8,
+			"Basic Power System": 8,
+			"Calcium Reinforced Copper": 49,
+			"Uncommon Screw": 18,
+			"Uncommon Power System": 18
+		}
+	},
+	"Uncommon Antenna L": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 9240,
+		"volume": 1302.56,
+		"outputQuantity": 1,
+		"time": 6480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Screw": 38,
+			"Basic Power System": 38,
+			"Calcium Reinforced Copper": 343,
+			"Uncommon Screw": 88,
+			"Uncommon Power System": 88
+		}
+	},
+	"Advanced Antenna S": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 389.74,
+		"volume": 54.56,
+		"outputQuantity": 1,
+		"time": 2016,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Screw": 2,
+			"Basic Power System": 2,
+			"Uncommon Screw": 2,
+			"Uncommon Power System": 2,
+			"Cu-Ag Alloy": 7,
+			"Advanced Screw": 2,
+			"Advanced Power System": 2
+		}
+	},
+	"Exotic Antenna M": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 2140,
+		"volume": 250.56,
+		"outputQuantity": 1,
+		"time": 138240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Advanced Screw": 25,
+			"Advanced Power System": 8,
+			"Rare Power System": 8,
+			"Ti-Nb Supraconductor": 49,
+			"Exotic Power System": 10
+		}
+	},
+	"Exotic Antenna L": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 11250,
+		"volume": 1301.76,
+		"outputQuantity": 1,
+		"time": 414000,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Advanced Screw": 125,
+			"Advanced Power System": 38,
+			"Rare Power System": 38,
+			"Ti-Nb Supraconductor": 343,
+			"Exotic Power System": 50
+		}
+	},
+	"Exotic Antenna XL": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 61580,
+		"volume": 7028.16,
+		"outputQuantity": 1,
+		"time": 1245600,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Advanced Screw": 625,
+			"Advanced Power System": 188,
+			"Rare Power System": 188,
+			"Ti-Nb Supraconductor": 2401,
+			"Exotic Power System": 250
+		}
+	},
+	"Basic Chemical Container XS": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 8.13,
+		"volume": 4.8,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 3,
+			"Basic Screw": 3
+		}
+	},
+	"Basic Chemical Container S": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 43.67,
+		"volume": 25.6,
+		"outputQuantity": 1,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 7,
+			"Basic Screw": 5
+		}
+	},
+	"Basic Chemical Container M": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 239.38,
+		"volume": 139.2,
+		"outputQuantity": 1,
+		"time": 540,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 49,
+			"Basic Screw": 25
+		}
+	},
+	"Basic Chemical Container L": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 1340,
+		"volume": 774.4,
+		"outputQuantity": 1,
+		"time": 1620,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 343,
+			"Basic Screw": 125
+		}
+	},
+	"Basic Chemical Container XL": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 7750,
+		"volume": 4420.8,
+		"outputQuantity": 1,
+		"time": 4860,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 2401,
+			"Basic Screw": 625
+		}
+	},
+	"Advanced Chemical Container S": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 48.85,
+		"volume": 29.6,
+		"outputQuantity": 1,
+		"time": 2880,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 2,
+			"Basic Electronics": 2,
+			"Uncommon Screw": 2,
+			"Uncommon Electronics": 2,
+			"Al-Li Alloy": 7,
+			"Advanced Screw": 2,
+			"Advanced Electronics": 2
+		}
+	},
+	"Advanced Chemical Container M": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 235.25,
+		"volume": 143.2,
+		"outputQuantity": 1,
+		"time": 8640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 8,
+			"Basic Electronics": 8,
+			"Uncommon Screw": 8,
+			"Uncommon Electronics": 8,
+			"Al-Li Alloy": 49,
+			"Advanced Screw": 10,
+			"Advanced Electronics": 10
+		}
+	},
+	"Advanced Chemical Container L": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 1270,
+		"volume": 778.4,
+		"outputQuantity": 1,
+		"time": 25920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 38,
+			"Basic Electronics": 38,
+			"Uncommon Screw": 38,
+			"Uncommon Electronics": 38,
+			"Al-Li Alloy": 343,
+			"Advanced Screw": 50,
+			"Advanced Electronics": 50
+		}
+	},
+	"Advanced Chemical Container XL": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 7190,
+		"volume": 4424.8,
+		"outputQuantity": 1,
+		"time": 77760,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 188,
+			"Basic Electronics": 188,
+			"Uncommon Screw": 188,
+			"Uncommon Electronics": 188,
+			"Al-Li Alloy": 2401,
+			"Advanced Screw": 250,
+			"Advanced Electronics": 250
+		}
+	},
+	"Basic Combustion Chamber XS": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 60.65,
+		"volume": 9.6,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 3,
+			"Basic Pipe": 3
+		}
+	},
+	"Basic Combustion Chamber S": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 319.35,
+		"volume": 49.6,
+		"outputQuantity": 1,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 7,
+			"Basic Pipe": 5
+		}
+	},
+	"Basic Combustion Chamber M": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 1710,
+		"volume": 259.2,
+		"outputQuantity": 1,
+		"time": 540,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 49,
+			"Basic Pipe": 25
+		}
+	},
+	"Basic Combustion Chamber L": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 9340,
+		"volume": 1374.4,
+		"outputQuantity": 1,
+		"time": 1620,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 343,
+			"Basic Pipe": 125
+		}
+	},
+	"Uncommon Combustion Chamber XS": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 112.07,
+		"volume": 18.4,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 1,
+			"Basic Burner": 1,
+			"Stainless Steel": 1,
+			"Uncommon Burner": 1,
+			"Uncommon Pipe": 1
+		}
+	},
+	"Uncommon Combustion Chamber S": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 366.33,
+		"volume": 58.4,
+		"outputQuantity": 1,
+		"time": 720,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 2,
+			"Basic Burner": 2,
+			"Stainless Steel": 7,
+			"Uncommon Burner": 4,
+			"Uncommon Pipe": 4
+		}
+	},
+	"Uncommon Combustion Chamber M": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 1730,
+		"volume": 268,
+		"outputQuantity": 1,
+		"time": 2160,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 8,
+			"Basic Burner": 8,
+			"Stainless Steel": 49,
+			"Uncommon Burner": 18,
+			"Uncommon Pipe": 18
+		}
+	},
+	"Uncommon Combustion Chamber L": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 9210,
+		"volume": 1383.2,
+		"outputQuantity": 1,
+		"time": 6480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 38,
+			"Basic Burner": 38,
+			"Stainless Steel": 343,
+			"Uncommon Burner": 88,
+			"Uncommon Pipe": 88
+		}
+	},
+	"Advanced Combustion Chamber XS": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 163.51,
+		"volume": 27.2,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 1,
+			"Basic Burner": 1,
+			"Uncommon Pipe": 1,
+			"Uncommon Burner": 1,
+			"Inconel": 1,
+			"Advanced Pipe": 1,
+			"Advanced Burner": 1
+		}
+	},
+	"Advanced Combustion Chamber S": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 369.5,
+		"volume": 58.4,
+		"outputQuantity": 1,
+		"time": 2880,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 2,
+			"Basic Burner": 2,
+			"Uncommon Pipe": 2,
+			"Uncommon Burner": 2,
+			"Inconel": 7,
+			"Advanced Pipe": 2,
+			"Advanced Burner": 2
+		}
+	},
+	"Advanced Combustion Chamber M": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 1760,
+		"volume": 268,
+		"outputQuantity": 1,
+		"time": 8640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 8,
+			"Basic Burner": 8,
+			"Uncommon Pipe": 8,
+			"Uncommon Burner": 8,
+			"Inconel": 49,
+			"Advanced Pipe": 10,
+			"Advanced Burner": 10
+		}
+	},
+	"Basic Control System XS": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 9.25,
+		"volume": 5.2,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Electronics Industry M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 3,
+			"Basic Component": 3
+		}
+	},
+	"Basic Control System S": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 47.63,
+		"volume": 27.6,
+		"outputQuantity": 1,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Electronics Industry M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Component": 5
+		}
+	},
+	"Basic Control System M": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 247.97,
+		"volume": 149.2,
+		"outputQuantity": 1,
+		"time": 540,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Electronics Industry M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 49,
+			"Basic Component": 25
+		}
+	},
+	"Advanced Control System S": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 59.35,
+		"volume": 32,
+		"outputQuantity": 1,
+		"time": 2880,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Component": 2,
+			"Basic Processor": 2,
+			"Uncommon Component": 2,
+			"Uncommon Processor": 2,
+			"Polysulfide Plastic": 7,
+			"Advanced Component": 2,
+			"Advanced Processor": 2
+		}
+	},
+	"Advanced Control System M": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 272.97,
+		"volume": 153.6,
+		"outputQuantity": 1,
+		"time": 8640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Component": 8,
+			"Basic Processor": 8,
+			"Uncommon Component": 8,
+			"Uncommon Processor": 8,
+			"Polysulfide Plastic": 49,
+			"Advanced Component": 10,
+			"Advanced Processor": 10
+		}
+	},
+	"Advanced Control System L": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 1410,
+		"volume": 828.8,
+		"outputQuantity": 1,
+		"time": 25920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Component": 38,
+			"Basic Processor": 38,
+			"Uncommon Component": 38,
+			"Uncommon Processor": 38,
+			"Polysulfide Plastic": 343,
+			"Advanced Component": 50,
+			"Advanced Processor": 50
+		}
+	},
+	"Basic Core System XS": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 4.43,
+		"volume": 4.4,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 3,
+			"Basic Component": 3
+		}
+	},
+	"Basic Core System S": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 23.57,
+		"volume": 23.6,
+		"outputQuantity": 1,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Electronics Industry M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Component": 5
+		}
+	},
+	"Uncommon Core System S": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 28.08,
+		"volume": 27.2,
+		"outputQuantity": 1,
+		"time": 720,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Component": 2,
+			"Basic Electronics": 2,
+			"Polycalcite Plastic": 7,
+			"Uncommon Component": 4,
+			"Uncommon Electronics": 4
+		}
+	},
+	"Uncommon Core System M": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 135.75,
+		"volume": 132.8,
+		"outputQuantity": 1,
+		"time": 2160,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Component": 8,
+			"Basic Electronics": 8,
+			"Polycalcite Plastic": 49,
+			"Uncommon Component": 18,
+			"Uncommon Electronics": 18
+		}
+	},
+	"Uncommon Core System L": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 737.1,
+		"volume": 728,
+		"outputQuantity": 1,
+		"time": 6480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Component": 38,
+			"Basic Electronics": 38,
+			"Polycalcite Plastic": 343,
+			"Uncommon Component": 88,
+			"Uncommon Electronics": 88
+		}
+	},
+	"Advanced Core System M": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 139.61,
+		"volume": 132.8,
+		"outputQuantity": 1,
+		"time": 8640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Component": 8,
+			"Basic Electronics": 8,
+			"Uncommon Component": 8,
+			"Uncommon Electronics": 8,
+			"Polysulfide Plastic": 49,
+			"Advanced Component": 10,
+			"Advanced Electronics": 10
+		}
+	},
+	"Rare Core System L": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 783.65,
+		"volume": 728,
+		"outputQuantity": 1,
+		"time": 103680,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Uncommon Component": 38,
+			"Uncommon Electronics": 38,
+			"Advanced Component": 88,
+			"Advanced Electronics": 38,
+			"Fluoropolymer": 343,
+			"Rare Electronics": 50
+		}
+	},
+	"Exotic Core System S": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 28.62,
+		"volume": 26.8,
+		"outputQuantity": 1,
+		"time": 46080,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Advanced Component": 5,
+			"Advanced Electronics": 2,
+			"Rare Electronics": 2,
+			"Vanamer": 7,
+			"Exotic Electronics": 2
+		}
+	},
+	"Basic Electric Engine S": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 377.75,
+		"volume": 39.04,
+		"outputQuantity": 1,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 7,
+			"Basic Screw": 5
+		}
+	},
+	"Basic Electric Engine M": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 1930,
+		"volume": 206.4,
+		"outputQuantity": 1,
+		"time": 540,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 49,
+			"Basic Screw": 25
+		}
+	},
+	"Uncommon Electric Engine XL": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 50800,
+		"volume": 6107.49,
+		"outputQuantity": 1,
+		"time": 19440,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Screw": 188,
+			"Basic Magnet": 188,
+			"Duralumin": 2401,
+			"Uncommon Screw": 438,
+			"Uncommon Magnet": 438
+		}
+	},
+	"Basic Firing System XS": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 60.65,
+		"volume": 9.6,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 3,
+			"Basic Pipe": 3
+		}
+	},
+	"Advanced Firing System XS": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 163.51,
+		"volume": 27.2,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 1,
+			"Basic Burner": 1,
+			"Uncommon Pipe": 1,
+			"Uncommon Burner": 1,
+			"Inconel": 1,
+			"Advanced Pipe": 1,
+			"Advanced Burner": 1
+		}
+	},
+	"Advanced Firing System S": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 369.5,
+		"volume": 58.4,
+		"outputQuantity": 1,
+		"time": 2880,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 2,
+			"Basic Burner": 2,
+			"Uncommon Pipe": 2,
+			"Uncommon Burner": 2,
+			"Inconel": 7,
+			"Advanced Pipe": 2,
+			"Advanced Burner": 2
+		}
+	},
+	"Advanced Firing System M": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 1760,
+		"volume": 268,
+		"outputQuantity": 1,
+		"time": 8640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 8,
+			"Basic Burner": 8,
+			"Uncommon Pipe": 8,
+			"Uncommon Burner": 8,
+			"Inconel": 49,
+			"Advanced Pipe": 10,
+			"Advanced Burner": 10
+		}
+	},
+	"Advanced Firing System L": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 9410,
+		"volume": 1383.2,
+		"outputQuantity": 1,
+		"time": 25920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 38,
+			"Basic Burner": 38,
+			"Uncommon Pipe": 38,
+			"Uncommon Burner": 38,
+			"Inconel": 343,
+			"Advanced Pipe": 50,
+			"Advanced Burner": 50
+		}
+	},
+	"Basic Gas Cylinder XS": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 15.68,
+		"volume": 9.6,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 3,
+			"Basic Screw": 3
+		}
+	},
+	"Basic Gas Cylinder S": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 81.38,
+		"volume": 49.6,
+		"outputQuantity": 1,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 7,
+			"Basic Screw": 5
+		}
+	},
+	"Basic Gas Cylinder M": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 427.88,
+		"volume": 259.2,
+		"outputQuantity": 1,
+		"time": 540,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 49,
+			"Basic Screw": 25
+		}
+	},
+	"Basic Ionic Chamber XS": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 75.1,
+		"volume": 7.33,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 3,
+			"Basic Connector": 3
+		}
+	},
+	"Basic Ionic Chamber S": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 391.6,
+		"volume": 38.24,
+		"outputQuantity": 1,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 7,
+			"Basic Connector": 5
+		}
+	},
+	"Basic Ionic Chamber M": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 2070,
+		"volume": 202.4,
+		"outputQuantity": 1,
+		"time": 540,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 49,
+			"Basic Connector": 25
+		}
+	},
+	"Basic Ionic Chamber L": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 1620,
+		"volume": 1090.4,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 343,
+			"Basic Connector": 125
+		}
+	},
+	"Basic Ionic Chamber XL": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 61230,
+		"volume": 6000.8,
+		"outputQuantity": 1,
+		"time": 4860,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 2401,
+			"Basic Connector": 625
+		}
+	},
+	"Uncommon Ionic Chamber XS": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 140.8,
+		"volume": 13.86,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Basic Magnet": 1,
+			"Stainless Steel": 1,
+			"Uncommon Connector": 1,
+			"Uncommon Magnet": 1
+		}
+	},
+	"Uncommon Ionic Chamber S": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 452.35,
+		"volume": 44.77,
+		"outputQuantity": 1,
+		"time": 720,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Connector": 2,
+			"Basic Magnet": 2,
+			"Stainless Steel": 7,
+			"Uncommon Connector": 4,
+			"Uncommon Magnet": 4
+		}
+	},
+	"Uncommon Ionic Chamber M": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 2100,
+		"volume": 208.93,
+		"outputQuantity": 1,
+		"time": 2160,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Connector": 8,
+			"Basic Magnet": 8,
+			"Stainless Steel": 49,
+			"Uncommon Connector": 18,
+			"Uncommon Magnet": 18
+		}
+	},
+	"Uncommon Ionic Chamber L": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 11010,
+		"volume": 1096.93,
+		"outputQuantity": 1,
+		"time": 6480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Connector": 38,
+			"Basic Magnet": 38,
+			"Stainless Steel": 343,
+			"Uncommon Connector": 88,
+			"Uncommon Magnet": 88
+		}
+	},
+	"Uncommon Ionic Chamber XL": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 60120,
+		"volume": 6007.33,
+		"outputQuantity": 1,
+		"time": 19440,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Connector": 188,
+			"Basic Magnet": 188,
+			"Stainless Steel": 2401,
+			"Uncommon Connector": 438,
+			"Uncommon Magnet": 438
+		}
+	},
+	"Advanced Ionic Chamber M": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 8640,
+		"volume": 208.93,
+		"outputQuantity": 1,
+		"time": 7200,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Connector": 8,
+			"Basic Magnet": 8,
+			"Uncommon Connector": 8,
+			"Uncommon Magnet": 8,
+			"Inconel": 49,
+			"Advanced Connector": 10,
+			"Advanced Magnet": 10
+		}
+	},
+	"Advanced Ionic Chamber L": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 11370,
+		"volume": 1096.93,
+		"outputQuantity": 1,
+		"time": 15540,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Connector": 38,
+			"Basic Magnet": 38,
+			"Uncommon Connector": 38,
+			"Uncommon Magnet": 38,
+			"Inconel": 343,
+			"Advanced Connector": 50,
+			"Advanced Magnet": 50
+		}
+	},
+	"Advanced Ionic Chamber XL": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 62430,
+		"volume": 6007.33,
+		"outputQuantity": 1,
+		"time": 15540,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Connector": 188,
+			"Basic Magnet": 188,
+			"Uncommon Connector": 188,
+			"Uncommon Magnet": 188,
+			"Inconel": 2401,
+			"Advanced Connector": 250,
+			"Advanced Magnet": 250
+		}
+	},
+	"Uncommon Laser Chamber XS": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 24.8,
+		"volume": 18.4,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Basic LED": 1,
+			"Basic Optics": 1,
+			"Advanced Glass": 1,
+			"Uncommon LED": 1,
+			"Uncommon Optics": 1
+		}
+	},
+	"Advanced Laser Chamber XS": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 36.51,
+		"volume": 27.2,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Basic LED": 1,
+			"Basic Optics": 1,
+			"Uncommon LED": 1,
+			"Uncommon Optics": 1,
+			"Ag-Li Reinforced Glass": 1,
+			"Advanced LED": 1,
+			"Advanced Optics": 1
+		}
+	},
+	"Advanced Laser Chamber S": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 87.02,
+		"volume": 58.4,
+		"outputQuantity": 1,
+		"time": 2880,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Basic LED": 2,
+			"Basic Optics": 2,
+			"Uncommon LED": 2,
+			"Uncommon Optics": 2,
+			"Ag-Li Reinforced Glass": 7,
+			"Advanced LED": 2,
+			"Advanced Optics": 2
+		}
+	},
+	"Advanced Laser Chamber M": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 429.89,
+		"volume": 268,
+		"outputQuantity": 1,
+		"time": 8640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Basic LED": 8,
+			"Basic Optics": 8,
+			"Uncommon LED": 8,
+			"Uncommon Optics": 8,
+			"Ag-Li Reinforced Glass": 49,
+			"Advanced LED": 10,
+			"Advanced Optics": 10
+		}
+	},
+	"Advanced Laser Chamber L": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 2380,
+		"volume": 1383.2,
+		"outputQuantity": 1,
+		"time": 25920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Basic LED": 38,
+			"Basic Optics": 38,
+			"Uncommon LED": 38,
+			"Uncommon Optics": 38,
+			"Ag-Li Reinforced Glass": 343,
+			"Advanced LED": 50,
+			"Advanced Optics": 50
+		}
+	},
+	"Rare Laser Chamber S": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 90.49,
+		"volume": 58.4,
+		"outputQuantity": 1,
+		"time": 11520,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Uncommon LED": 2,
+			"Uncommon Optics": 2,
+			"Advanced LED": 2,
+			"Advanced Optics": 2,
+			"Gold Coated Glass": 7,
+			"Rare Optics": 2
+		}
+	},
+	"Uncommon Light XS": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 7.84,
+		"volume": 8.8,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic LED": 1,
+			"Basic Electronics": 1,
+			"Advanced Glass": 1,
+			"Uncommon LED": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"Uncommon Light S": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 28.8,
+		"volume": 29.6,
+		"outputQuantity": 1,
+		"time": 720,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic LED": 2,
+			"Basic Electronics": 2,
+			"Advanced Glass": 7,
+			"Uncommon LED": 4,
+			"Uncommon Electronics": 4
+		}
+	},
+	"Advanced Magnetic Rail XS": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 204.7,
+		"volume": 20.86,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 1,
+			"Basic Magnet": 1,
+			"Uncommon Pipe": 1,
+			"Uncommon Magnet": 1,
+			"Inconel": 1,
+			"Advanced Pipe": 1,
+			"Advanced Magnet": 1
+		}
+	},
+	"Advanced Magnetic Rail S": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 451.89,
+		"volume": 45.73,
+		"outputQuantity": 1,
+		"time": 2880,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 2,
+			"Basic Magnet": 2,
+			"Uncommon Pipe": 2,
+			"Uncommon Magnet": 2,
+			"Inconel": 7,
+			"Advanced Pipe": 2,
+			"Advanced Magnet": 2
+		}
+	},
+	"Advanced Magnetic Rail M": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 2120,
+		"volume": 213.09,
+		"outputQuantity": 1,
+		"time": 8640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 8,
+			"Basic Magnet": 8,
+			"Uncommon Pipe": 8,
+			"Uncommon Magnet": 8,
+			"Inconel": 49,
+			"Advanced Pipe": 10,
+			"Advanced Magnet": 10
+		}
+	},
+	"Advanced Magnetic Rail L": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 11160,
+		"volume": 1117.09,
+		"outputQuantity": 1,
+		"time": 25920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 38,
+			"Basic Magnet": 38,
+			"Uncommon Pipe": 38,
+			"Uncommon Magnet": 38,
+			"Inconel": 343,
+			"Advanced Pipe": 50,
+			"Advanced Magnet": 50
+		}
+	},
+	"Basic Mechanical Sensor XS": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 35.96,
+		"volume": 7.49,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Electronics Industry M"
+		],
+		"input": {
+			"Al-Fe Alloy": 3,
+			"Basic Fixation": 3
+		}
+	},
+	"Advanced Mechanical Sensor XS": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 100.99,
+		"volume": 20.86,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Fixation": 1,
+			"Basic Magnet": 1,
+			"Uncommon Fixation": 1,
+			"Uncommon Magnet": 1,
+			"Cu-Ag Alloy": 1,
+			"Advanced Fixation": 1,
+			"Advanced Magnet": 1
+		}
+	},
+	"Exotic Mechanical Sensor XS": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 102.37,
+		"volume": 19.26,
+		"outputQuantity": 1,
+		"time": 15360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Advanced Fixation": 1,
+			"Advanced Magnet": 1,
+			"Rare Magnet": 1,
+			"Ti-Nb Supraconductor": 1,
+			"Exotic Magnet": 1
+		}
+	},
+	"Advanced Missile Silo XS": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 157.51,
+		"volume": 27.2,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 1,
+			"Basic Burner": 1,
+			"Uncommon Pipe": 1,
+			"Uncommon Burner": 1,
+			"Al-Li Alloy": 1,
+			"Advanced Pipe": 1,
+			"Advanced Burner": 1
+		}
+	},
+	"Advanced Missile Silo S": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 327.52,
+		"volume": 58.4,
+		"outputQuantity": 1,
+		"time": 2880,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 2,
+			"Basic Burner": 2,
+			"Uncommon Pipe": 2,
+			"Uncommon Burner": 2,
+			"Al-Li Alloy": 7,
+			"Advanced Pipe": 2,
+			"Advanced Burner": 2
+		}
+	},
+	"Advanced Missile Silo M": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 1460,
+		"volume": 268,
+		"outputQuantity": 1,
+		"time": 8640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 8,
+			"Basic Burner": 8,
+			"Uncommon Pipe": 8,
+			"Uncommon Burner": 8,
+			"Al-Li Alloy": 49,
+			"Advanced Pipe": 10,
+			"Advanced Burner": 10
+		}
+	},
+	"Advanced Missile Silo L": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 7360,
+		"volume": 1383.2,
+		"outputQuantity": 1,
+		"time": 25920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Basic Pipe": 38,
+			"Basic Burner": 38,
+			"Uncommon Pipe": 38,
+			"Uncommon Burner": 38,
+			"Al-Li Alloy": 343,
+			"Advanced Pipe": 50,
+			"Advanced Burner": 50
+		}
+	},
+	"Basic Mobile Panel XS": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 20,
+		"volume": 9.6,
+		"outputQuantity": 3,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 3,
+			"Basic Screw": 3
+		}
+	},
+	"Basic Mobile Panel S": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 103,
+		"volume": 49.6,
+		"outputQuantity": 1,
+		"time": 180,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 7,
+			"Basic Screw": 5
+		}
+	},
+	"Basic Mobile Panel M": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 536,
+		"volume": 259.2,
+		"outputQuantity": 1,
+		"time": 540,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 49,
+			"Basic Screw": 25
+		}
+	},
+	"Basic Mobile Panel L": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 2830,
+		"volume": 1374.4,
+		"outputQuantity": 1,
+		"time": 1620,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 343,
+			"Basic Screw": 125
+		}
+	},
+	"Basic Mobile Panel XL": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 15160,
+		"volume": 7420.8,
+		"outputQuantity": 1,
+		"time": 4860,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 2401,
+			"Basic Screw": 625
+		}
+	},
+	"Advanced Motherboard M": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 109.19,
+		"volume": 96,
+		"outputQuantity": 1,
+		"time": 8640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Component": 8,
+			"Basic Processor": 8,
+			"Uncommon Component": 8,
+			"Uncommon Processor": 8,
+			"Polysulfide Plastic": 49,
+			"Advanced Component": 10,
+			"Advanced Processor": 10
+		}
+	},
+	"Uncommon Ore Scanner XL": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 1870,
+		"volume": 2702.9,
+		"outputQuantity": 1,
+		"time": 19440,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Connector": 188,
+			"Basic Electronics": 188,
+			"Polycalcite Plastic": 2401,
+			"Uncommon Connector": 438,
+			"Uncommon Electronics": 438
+		}
+	},
+	"Basic Power Transformer M": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 1020,
+		"volume": 196.4,
+		"outputQuantity": 1,
+		"time": 540,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Electronics Industry M"
+		],
+		"input": {
+			"Steel": 49,
+			"Basic Component": 25
+		}
+	},
+	"Uncommon Power Transformer S": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 221.56,
+		"volume": 43.33,
+		"outputQuantity": 1,
+		"time": 540,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Component": 2,
+			"Basic Magnet": 2,
+			"Stainless Steel": 7,
+			"Uncommon Component": 4,
+			"Uncommon Magnet": 4
+		}
+	},
+	"Uncommon Power Transformer M": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 1030,
+		"volume": 202.69,
+		"outputQuantity": 1,
+		"time": 1512,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Electronics Industry M"
+		],
+		"input": {
+			"Basic Component": 8,
+			"Basic Magnet": 8,
+			"Stainless Steel": 49,
+			"Uncommon Component": 18,
+			"Uncommon Magnet": 18
+		}
+	},
+	"Rare Power Transformer L": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 5570,
+		"volume": 1066.69,
+		"outputQuantity": 1,
+		"time": 103680,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Uncommon Component": 38,
+			"Uncommon Magnet": 38,
+			"Advanced Component": 88,
+			"Advanced Magnet": 38,
+			"Maraging Steel": 343,
+			"Rare Magnet": 50
+		}
+	},
+	"Rare Power Transformer XL": {
+		"tier": 4,
+		"type": "Functional Part",
+		"mass": 30540,
+		"volume": 5857.09,
+		"outputQuantity": 1,
+		"time": 311040,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Uncommon Component": 188,
+			"Uncommon Magnet": 188,
+			"Advanced Component": 438,
+			"Advanced Magnet": 188,
+			"Maraging Steel": 343,
+			"Rare Magnet": 250
+		}
+	},
+	"Exotic Power Transformer L": {
+		"tier": 5,
+		"type": "Functional Part",
+		"mass": 5570,
+		"volume": 1066.29,
+		"outputQuantity": 1,
+		"time": 414720,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Electronics Industry M"
+		],
+		"input": {
+			"Advanced Component": 125,
+			"Advanced Magnet": 38,
+			"Rare Magnet": 38,
+			"Mangalloy": 343,
+			"Exotic Magnet": 50
+		}
+	},
+	"Basic Robotic Arm M": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 927,
+		"volume": 249.2,
+		"outputQuantity": 1,
+		"time": 540,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 49,
+			"Basic Component": 25
+		}
+	},
+	"Basic Robotic Arm L": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 4930,
+		"volume": 1324.4,
+		"outputQuantity": 1,
+		"time": 1620,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 343,
+			"Basic Component": 125
+		}
+	},
+	"Basic Robotic Arm XL": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 26700,
+		"volume": 7170.8,
+		"outputQuantity": 1,
+		"time": 4860,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 2401,
+			"Basic Component": 625
+		}
+	},
+	"Basic Screen S": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 21.07,
+		"volume": 25.6,
+		"outputQuantity": 1,
+		"time": 63,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic LED": 5
+		}
+	},
+	"Basic Screen M": {
+		"tier": 1,
+		"type": "Functional Part",
+		"mass": 115.17,
+		"volume": 139.2,
+		"outputQuantity": 1,
+		"time": 540,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 49,
+			"Basic LED": 25
+		}
+	},
+	"Uncommon Screen XS": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 7.29,
+		"volume": 8.8,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Basic LED": 1,
+			"Basic Electronics": 1,
+			"Polycalcite Plastic": 1,
+			"Uncommon LED": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"Uncommon Screen L": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 671.24,
+		"volume": 778.4,
+		"outputQuantity": 1,
+		"time": 4536,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Basic LED": 38,
+			"Basic Electronics": 38,
+			"Polycalcite Plastic": 343,
+			"Uncommon LED": 88,
+			"Uncommon Electronics": 88
+		}
+	},
+	"Uncommon Screen XL": {
+		"tier": 2,
+		"type": "Functional Part",
+		"mass": 3860,
+		"volume": 4424.8,
+		"outputQuantity": 1,
+		"time": 19440,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Basic LED": 188,
+			"Basic Electronics": 188,
+			"Polycalcite Plastic": 2401,
+			"Uncommon LED": 438,
+			"Uncommon Electronics": 438
+		}
+	},
+	"Advanced Screen XS": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 10.73,
+		"volume": 12.8,
+		"outputQuantity": 1,
+		"time": 960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Basic LED": 1,
+			"Basic Electronics": 1,
+			"Uncommon LED": 1,
+			"Uncommon Electronics": 1,
+			"Polysulfide Plastic": 1,
+			"Advanced LED": 1,
+			"Advanced Electronics": 1
+		}
+	},
+	"Advanced Screen XL": {
+		"tier": 3,
+		"type": "Functional Part",
+		"mass": 4000,
+		"volume": 4424.8,
+		"outputQuantity": 1,
+		"time": 54420,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Basic LED": 188,
+			"Basic Electronics": 188,
+			"Uncommon LED": 188,
+			"Uncommon Electronics": 188,
+			"Polysulfide Plastic": 2401,
+			"Advanced LED": 250,
+			"Advanced Electronics": 250
+		}
+	},
+	"Basic Casing XS": {
+		"tier": 1,
+		"type": "Structural Part",
+		"mass": 1.4,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 40,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 2
+		}
+	},
+	"Basic Casing S": {
+		"tier": 1,
+		"type": "Structural Part",
+		"mass": 7.7,
+		"volume": 11,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 11
+		}
+	},
+	"Uncommon Casing XS": {
+		"tier": 2,
+		"type": "Structural Part",
+		"mass": 1.45,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 160,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 1,
+			"Polycalcite Plastic": 1
+		}
+	},
+	"Uncommon Casing S": {
+		"tier": 2,
+		"type": "Structural Part",
+		"mass": 8.05,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 4,
+			"Polycalcite Plastic": 7
+		}
+	},
+	"Uncommon Casing M": {
+		"tier": 2,
+		"type": "Structural Part",
+		"mass": 54.25,
+		"volume": 74,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 25,
+			"Polycalcite Plastic": 49
+		}
+	},
+	"Uncommon Casing XL": {
+		"tier": 2,
+		"type": "Structural Part",
+		"mass": 2640,
+		"volume": 3602,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 1201,
+			"Polycalcite Plastic": 2401
+		}
+	},
+	"Advanced Casing XS": {
+		"tier": 3,
+		"type": "Structural Part",
+		"mass": 1.5,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 1,
+			"Polysulfide Plastic": 1
+		}
+	},
+	"Advanced Casing S": {
+		"tier": 3,
+		"type": "Structural Part",
+		"mass": 8.4,
+		"volume": 1,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 4,
+			"Polysulfide Plastic": 7
+		}
+	},
+	"Advanced Casing M": {
+		"tier": 3,
+		"type": "Structural Part",
+		"mass": 56.7,
+		"volume": 74,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 25,
+			"Polysulfide Plastic": 49
+		}
+	},
+	"Advanced Casing L": {
+		"tier": 3,
+		"type": "Structural Part",
+		"mass": 394.8,
+		"volume": 515,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 172,
+			"Polysulfide Plastic": 343
+		}
+	},
+	"Advanced Casing XL": {
+		"tier": 3,
+		"type": "Structural Part",
+		"mass": 2760,
+		"volume": 3602,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 1201,
+			"Polysulfide Plastic": 2401
+		}
+	},
+	"Rare Casing XS": {
+		"tier": 4,
+		"type": "Structural Part",
+		"mass": 1.52,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 2560,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 1,
+			"Fluoropolymer": 1
+		}
+	},
+	"Rare Casing S": {
+		"tier": 4,
+		"type": "Structural Part",
+		"mass": 8.57,
+		"volume": 11,
+		"outputQuantity": 1,
+		"time": 7680,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 4,
+			"Fluoropolymer": 7
+		}
+	},
+	"Exotic Casing S": {
+		"tier": 5,
+		"type": "Structural Part",
+		"mass": 8.29,
+		"volume": 11,
+		"outputQuantity": 1,
+		"time": 30720,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"3D Printer M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 4,
+			"Vanamer": 7
+		}
+	},
+	"Basic Reinforced Frame XS": {
+		"tier": 1,
+		"type": "Structural Part",
+		"mass": 12.88,
+		"volume": 2,
+		"outputQuantity": 5,
+		"time": 200,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 10
+		}
+	},
+	"Basic Reinforced Frame S": {
+		"tier": 1,
+		"type": "Structural Part",
+		"mass": 70.84,
+		"volume": 11,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 11
+		}
+	},
+	"Basic Reinforced Frame M": {
+		"tier": 1,
+		"type": "Structural Part",
+		"mass": 476,
+		"volume": 74,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 74
+		}
+	},
+	"Basic Reinforced Frame L": {
+		"tier": 1,
+		"type": "Structural Part",
+		"mass": 3320,
+		"volume": 515,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 515
+		}
+	},
+	"Basic Reinforced Frame XL": {
+		"tier": 1,
+		"type": "Structural Part",
+		"mass": 23200,
+		"volume": 3602,
+		"outputQuantity": 1,
+		"time": 3240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 3602
+		}
+	},
+	"Uncommon Reinforced Frame XS": {
+		"tier": 2,
+		"type": "Structural Part",
+		"mass": 12.64,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 160,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 1,
+			"Stainless Steel": 1
+		}
+	},
+	"Uncommon Reinforced Frame S": {
+		"tier": 2,
+		"type": "Structural Part",
+		"mass": 69.16,
+		"volume": 11,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 4,
+			"Stainless Steel": 7
+		}
+	},
+	"Uncommon Reinforced Frame M": {
+		"tier": 2,
+		"type": "Structural Part",
+		"mass": 464.8,
+		"volume": 74,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 25,
+			"Stainless Steel": 49
+		}
+	},
+	"Uncommon Reinforced Frame L": {
+		"tier": 2,
+		"type": "Structural Part",
+		"mass": 3230,
+		"volume": 515,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 172,
+			"Stainless Steel": 343
+		}
+	},
+	"Uncommon Reinforced Frame XL": {
+		"tier": 2,
+		"type": "Structural Part",
+		"mass": 22620,
+		"volume": 3602,
+		"outputQuantity": 1,
+		"time": 12960,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 1201,
+			"Stainless Steel": 2401
+		}
+	},
+	"Advanced Reinforced Frame XS": {
+		"tier": 3,
+		"type": "Structural Part",
+		"mass": 13.24,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 1,
+			"Inconel": 1
+		}
+	},
+	"Advanced Reinforced Frame S": {
+		"tier": 3,
+		"type": "Structural Part",
+		"mass": 73.34,
+		"volume": 11,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 4,
+			"Inconel": 7
+		}
+	},
+	"Advanced Reinforced Frame M": {
+		"tier": 3,
+		"type": "Structural Part",
+		"mass": 494.08,
+		"volume": 74,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 25,
+			"Inconel": 49
+		}
+	},
+	"Advanced Reinforced Frame L": {
+		"tier": 3,
+		"type": "Structural Part",
+		"mass": 3440,
+		"volume": 515,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 172,
+			"Inconel": 343
+		}
+	},
+	"Advanced Reinforced Frame XL": {
+		"tier": 3,
+		"type": "Structural Part",
+		"mass": 24060,
+		"volume": 3602,
+		"outputQuantity": 1,
+		"time": 51840,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 1201,
+			"Inconel": 2401
+		}
+	},
+	"Rare Reinforced Frame L": {
+		"tier": 4,
+		"type": "Structural Part",
+		"mass": 3370,
+		"volume": 515,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 172,
+			"Maraging Steel": 343
+		}
+	},
+	"Rare Reinforced Frame XL": {
+		"tier": 4,
+		"type": "Structural Part",
+		"mass": 23540,
+		"volume": 3602,
+		"outputQuantity": 1,
+		"time": 207360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 1201,
+			"Maraging Steel": 2401
+		}
+	},
+	"Exotic Reinforced Frame M": {
+		"tier": 5,
+		"type": "Structural Part",
+		"mass": 468.05,
+		"volume": 74,
+		"outputQuantity": 1,
+		"time": 92160,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 25,
+			"Mangalloy": 49
+		}
+	},
+	"Exotic Reinforced Frame L": {
+		"tier": 5,
+		"type": "Structural Part",
+		"mass": 3260,
+		"volume": 515,
+		"outputQuantity": 1,
+		"time": 276480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 172,
+			"Mangalloy": 343
+		}
+	},
+	"Exotic Reinforced Frame XL": {
+		"tier": 5,
+		"type": "Structural Part",
+		"mass": 22780,
+		"volume": 3602,
+		"outputQuantity": 1,
+		"time": 829440,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Steel": 1201,
+			"Mangalloy": 2401
+		}
+	},
+	"Basic Standard Frame XS": {
+		"tier": 1,
+		"type": "Structural Part",
+		"mass": 4.2,
+		"volume": 2,
+		"outputQuantity": 5,
+		"time": 200,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 10
+		}
+	},
+	"Basic Standard Frame S": {
+		"tier": 1,
+		"type": "Structural Part",
+		"mass": 23.1,
+		"volume": 11,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 11
+		}
+	},
+	"Basic Standard Frame M": {
+		"tier": 1,
+		"type": "Structural Part",
+		"mass": 155.4,
+		"volume": 74,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 74
+		}
+	},
+	"Basic Standard Frame L": {
+		"tier": 1,
+		"type": "Structural Part",
+		"mass": 1080,
+		"volume": 515,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 515
+		}
+	},
+	"Uncommon Standard Frame XS": {
+		"tier": 2,
+		"type": "Structural Part",
+		"mass": 4.06,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 160,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 1,
+			"Duralumin": 1
+		}
+	},
+	"Uncommon Standard Frame S": {
+		"tier": 2,
+		"type": "Structural Part",
+		"mass": 22.12,
+		"volume": 11,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 4,
+			"Duralumin": 7
+		}
+	},
+	"Uncommon Standard Frame M": {
+		"tier": 2,
+		"type": "Structural Part",
+		"mass": 148.54,
+		"volume": 74,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 25,
+			"Duralumin": 49
+		}
+	},
+	"Uncommon Standard Frame L": {
+		"tier": 2,
+		"type": "Structural Part",
+		"mass": 1030,
+		"volume": 515,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 172,
+			"Duralumin": 343
+		}
+	},
+	"Advanced Standard Frame XS": {
+		"tier": 3,
+		"type": "Structural Part",
+		"mass": 3.85,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 640,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 1,
+			"Al-Li Alloy": 1
+		}
+	},
+	"Advanced Standard Frame S": {
+		"tier": 3,
+		"type": "Structural Part",
+		"mass": 20.65,
+		"volume": 11,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 4,
+			"Al-Li Alloy": 7
+		}
+	},
+	"Advanced Standard Frame M": {
+		"tier": 3,
+		"type": "Structural Part",
+		"mass": 138.25,
+		"volume": 74,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 25,
+			"Al-Li Alloy": 49
+		}
+	},
+	"Advanced Standard Frame L": {
+		"tier": 3,
+		"type": "Structural Part",
+		"mass": 961.45,
+		"volume": 515,
+		"outputQuantity": 1,
+		"time": 17280,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 172,
+			"Al-Li Alloy": 343
+		}
+	},
+	"Advanced Standard Frame XL": {
+		"tier": 3,
+		"type": "Structural Part",
+		"mass": 6720,
+		"volume": 3602,
+		"outputQuantity": 1,
+		"time": 36300,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 1201,
+			"Al-Li Alloy": 2401
+		}
+	},
+	"Rare Standard Frame L": {
+		"tier": 4,
+		"type": "Structural Part",
+		"mass": 1050,
+		"volume": 515,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 172,
+			"Sc-Al Alloy": 343
+		}
+	},
+	"Exotic Standard Frame XS": {
+		"tier": 5,
+		"type": "Structural Part",
+		"mass": 5.2,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 10240,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 1,
+			"Grade 5 Titanium Alloy": 1
+		}
+	},
+	"Exotic Standard Frame L": {
+		"tier": 5,
+		"type": "Structural Part",
+		"mass": 1420,
+		"volume": 515,
+		"outputQuantity": 1,
+		"time": 276480,
+		"skill": "",
+		"byproducts": {},
+		"industries": [
+			"Metalwork Industry M"
+		],
+		"input": {
+			"Silumin": 172,
+			"Grade 5 Titanium Alloy": 343
+		}
+	},
+	"Dynamic Core XS": {
+		"tier": 1,
+		"type": "Core Unit",
+		"mass": 70.89,
+		"volume": 16.1,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Basic Power System": 1,
+			"Basic Core System XS": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Dynamic Core S": {
+		"tier": 2,
+		"type": "Core Unit",
+		"mass": 375.97,
+		"volume": 87.2,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Component": 3,
+			"Uncommon Component": 3,
+			"Uncommon Power System": 5,
+			"Uncommon Core System S": 1,
+			"Uncommon Standard Frame S": 1
+		}
+	},
+	"Dynamic Core M": {
+		"tier": 3,
+		"type": "Core Unit",
+		"mass": 1980,
+		"volume": 454.8,
+		"outputQuantity": 1,
+		"time": 21600,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Component": 36,
+			"Advanced Power System": 25,
+			"Advanced Core System M": 1,
+			"Advanced Standard Frame M": 1
+		}
+	},
+	"Dynamic Core L": {
+		"tier": 4,
+		"type": "Core Unit",
+		"mass": 12140,
+		"volume": 2501,
+		"outputQuantity": 1,
+		"time": 259200,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Component": 108,
+			"Advanced Component": 108,
+			"Rare Power System": 125,
+			"Rare Core System L": 1,
+			"Rare Standard Frame L": 1
+		}
+	},
+	"Static Core XS": {
+		"tier": 1,
+		"type": "Core Unit",
+		"mass": 70.89,
+		"volume": 16.1,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Basic Power System": 1,
+			"Basic Core System XS": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Static Core S": {
+		"tier": 1,
+		"type": "Core Unit",
+		"mass": 360.18,
+		"volume": 83.6,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Component": 6,
+			"Basic Power System": 5,
+			"Basic Core System S": 1,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Static Core M": {
+		"tier": 2,
+		"type": "Core Unit",
+		"mass": 1930,
+		"volume": 454.8,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Component": 18,
+			"Uncommon Component": 18,
+			"Uncommon Power System": 25,
+			"Uncommon Core System M": 1,
+			"Uncommon Standard Frame M": 1
+		}
+	},
+	"Static Core L": {
+		"tier": 2,
+		"type": "Core Unit",
+		"mass": 10700,
+		"volume": 2501,
+		"outputQuantity": 1,
+		"time": 21600,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Component": 108,
+			"Uncommon Component": 108,
+			"Uncommon Power System": 125,
+			"Uncommon Core System L": 1,
+			"Uncommon Standard Frame L": 1
+		}
+	},
+	"Space Core XS": {
+		"tier": 1,
+		"type": "Core Unit",
+		"mass": 38.99,
+		"volume": 14,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Basic Power System": 1,
+			"Basic Core System XS": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Space Core S": {
+		"tier": 2,
+		"type": "Core Unit",
+		"mass": 459.57,
+		"volume": 120,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Component": 3,
+			"Uncommon Component": 3,
+			"Uncommon Power System": 5,
+			"Uncommon Core System S": 1,
+			"Uncommon Standard Frame S": 1
+		}
+	},
+	"Space Core M": {
+		"tier": 3,
+		"type": "Core Unit",
+		"mass": 3040,
+		"volume": 420,
+		"outputQuantity": 1,
+		"time": 21600,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Component": 36,
+			"Advanced Power System": 25,
+			"Advanced Core System M": 1,
+			"Advanced Anti-Gravity Core": 16,
+			"Advanced Standard Frame M": 1
+		}
+	},
+	"Space Core L": {
+		"tier": 4,
+		"type": "Core Unit",
+		"mass": 7680,
+		"volume": 1383,
+		"outputQuantity": 1,
+		"time": 259200,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Component": 108,
+			"Advanced Component": 108,
+			"Rare Power System": 125,
+			"Rare Core System L": 1,
+			"Rare Anti-Gravity Core": 64,
+			"Rare Standard Frame L": 1
+		}
+	},
+	"Territory Unit": {
+		"tier": 5,
+		"type": "Core Unit",
+		"mass": 20050,
+		"volume": 4118.29,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Fixation": 18,
+			"Uncommon Fixation": 18,
+			"Uncommon Processor": 25,
+			"Uncommon Power Transformer M": 1,
+			"Uncommon Standard Frame M": 1
+		}
+	},
+	"Container Hub": {
+		"tier": 1,
+		"type": "Container",
+		"mass": 55.8,
+		"volume": 44.3,
+		"outputQuantity": 1,
+		"time": 1380,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Component": 1,
+			"Advanced Electronics": 1,
+			"Advanced Screen XS": 1,
+			"Advanced Quantum Alignment Unit": 1,
+			"Advanced Casing XS": 1
+		}
+	},
+	"Container XS": {
+		"tier": 1,
+		"type": "Container",
+		"mass": 229.09,
+		"volume": 64,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Component": 6,
+			"Basic Hydraulics": 5,
+			"Basic Reinforced Frame S": 1
+		}
+	},
+	"Container S": {
+		"tier": 1,
+		"type": "Container",
+		"mass": 1281.31,
+		"volume": 342,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Component": 36,
+			"Basic Hydraulics": 25,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Container M": {
+		"tier": 1,
+		"type": "Container",
+		"mass": 7421.35,
+		"volume": 1873,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Component": 216,
+			"Basic Hydraulics": 125,
+			"Basic Reinforced Frame L": 1
+		}
+	},
+	"Container L": {
+		"tier": 1,
+		"type": "Container",
+		"mass": 14842.7,
+		"volume": 3746,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Component": 432,
+			"Basic Hydraulics": 250,
+			"Basic Reinforced Frame L": 2
+		}
+	},
+	"Dispenser": {
+		"tier": 1,
+		"type": "Container",
+		"mass": 2060,
+		"volume": 479.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Power System": 25,
+			"Basic Screen M": 1,
+			"Basic Standard Frame M": 1
+		}
+	},
+	"Heavy Dispenser": {
+		"tier": 3,
+		"type": "Container",
+		"mass": 61520,
+		"volume": 15070,
+		"outputQuantity": 1,
+		"time": 277200,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Uncommon Screw": 1296,
+			"Advanced Power System": 625,
+			"Advanced Screen XL": 1,
+			"Advanced Standard Frame XL": 1
+		}
+	},
+	"Medium Dispenser": {
+		"tier": 2,
+		"type": "Container",
+		"mass": 11230,
+		"volume": 2659.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Power System": 125,
+			"Uncommon Screen L": 1,
+			"Uncommon Standard Frame L": 1
+		}
+	},
+	"Atmospheric Fuel-Tank XS": {
+		"tier": 1,
+		"type": "Piloting",
+		"mass": 35.03,
+		"volume": 17.8,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Pipe": 1,
+			"Basic Injector": 1,
+			"Basic Chemical Container XS": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Atmospheric Fuel-Tank S": {
+		"tier": 1,
+		"type": "Piloting",
+		"mass": 182.67,
+		"volume": 92.6,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Pipe": 6,
+			"Basic Injector": 5,
+			"Basic Chemical Container S": 1,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Atmospheric Fuel-Tank M": {
+		"tier": 1,
+		"type": "Piloting",
+		"mass": 988.67,
+		"volume": 499.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 36,
+			"Basic Injector": 25,
+			"Basic Chemical Container M": 1,
+			"Basic Standard Frame M": 1
+		}
+	},
+	"Atmospheric Fuel-Tank L": {
+		"tier": 1,
+		"type": "Container",
+		"mass": 5480,
+		"volume": 2755.4,
+		"outputQuantity": 1,
+		"time": 7200,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Pipe": 216,
+			"Basic Injector": 125,
+			"Basic Chemical Container L": 1,
+			"Basic Standard Frame L": 1
+		}
+	},
+	"Space Fuel-Tank S": {
+		"tier": 2,
+		"type": "Container",
+		"mass": 182.67,
+		"volume": 92.6,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Pipe": 6,
+			"Basic Injector": 5,
+			"Basic Chemical Container S": 1,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Space Fuel-Tank M": {
+		"tier": 2,
+		"type": "Container",
+		"mass": 988.67,
+		"volume": 499.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 36,
+			"Basic Injector": 25,
+			"Basic Chemical Container M": 1,
+			"Basic Standard Frame M": 1
+		}
+	},
+	"Space Fuel-Tank L": {
+		"tier": 2,
+		"type": "Container",
+		"mass": 5480,
+		"volume": 2755.4,
+		"outputQuantity": 1,
+		"time": 7200,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Pipe": 216,
+			"Basic Injector": 125,
+			"Basic Chemical Container L": 1,
+			"Basic Standard Frame L": 1
+		}
+	},
+	"Rocket Fuel-Tank XS": {
+		"tier": 3,
+		"type": "Container",
+		"mass": 173.42,
+		"volume": 96.6,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Pipe": 6,
+			"Advanced Injector": 5,
+			"Advanced Chemical Container S": 1,
+			"Advanced Casing S": 1
+		}
+	},
+	"Rocket Fuel-Tank S": {
+		"tier": 3,
+		"type": "Container",
+		"mass": 886.72,
+		"volume": 503.2,
+		"outputQuantity": 1,
+		"time": 18000,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Pipe": 36,
+			"Advanced Injector": 25,
+			"Advanced Chemical Container M": 1,
+			"Advanced Casing M": 1
+		}
+	},
+	"Rocket Fuel-Tank M": {
+		"tier": 3,
+		"type": "Container",
+		"mass": 6231,
+		"volume": 6400,
+		"outputQuantity": 1,
+		"time": 68400,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Pipe": 216,
+			"Advanced Injector": 125,
+			"Advanced Chemical Container L": 1,
+			"Advanced Casing L": 1
+		}
+	},
+	"Rocket Fuel-Tank L": {
+		"tier": 3,
+		"type": "Container",
+		"mass": 25740,
+		"volume": 15570,
+		"outputQuantity": 1,
+		"time": 259200,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Uncommon Pipe": 1296,
+			"Advanced Injector": 625,
+			"Advanced Chemical Container XL": 1,
+			"Advanced Casing XL": 1
+		}
+	},
+	"Ammo Container XS": {
+		"tier": 1,
+		"type": "Container",
+		"mass": 216.15,
+		"volume": 67,
+		"outputQuantity": 1,
+		"time": 720,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 6,
+			"Basic Hydraulics": 5,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Ammo Container S": {
+		"tier": 1,
+		"type": "Container",
+		"mass": 1170,
+		"volume": 360,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Hydraulics": 25,
+			"Basic Standard Frame M": 1
+		}
+	},
+	"Ammo Container M": {
+		"tier": 1,
+		"type": "Container",
+		"mass": 6440,
+		"volume": 1981,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 216,
+			"Basic Hydraulics": 125,
+			"Basic Standard Frame L": 1
+		}
+	},
+	"Ammo Container L": {
+		"tier": 1,
+		"type": "Container",
+		"mass": 12880,
+		"volume": 3962,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 432,
+			"Basic Hydraulics": 250,
+			"Basic Standard Frame L": 2
+		}
+	},
+	"Assembly Line XS": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 100.93,
+		"volume": 21.8,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Power System": 1,
+			"Basic Mobile Panel XS": 1,
+			"Basic Reinforced Frame XS": 1
+		}
+	},
+	"Assembly Line S": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 522.14,
+		"volume": 112.6,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 6,
+			"Basic Power System": 5,
+			"Basic Mobile Panel S": 1,
+			"Basic Reinforced Frame S": 1
+		}
+	},
+	"Assembly Line M": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 2800,
+		"volume": 599.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S",
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Power System": 25,
+			"Basic Mobile Panel M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Assembly Line L": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 15380,
+		"volume": 3255.4,
+		"outputQuantity": 1,
+		"time": 7200,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M",
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 216,
+			"Basic Power System": 125,
+			"Basic Mobile Panel L": 1,
+			"Basic Reinforced Frame L": 1
+		}
+	},
+	"Assembly Line XL": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 86290,
+		"volume": 18070,
+		"outputQuantity": 1,
+		"time": 32400,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L",
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 1296,
+			"Basic Power System": 625,
+			"Basic Mobile Panel XL": 1,
+			"Basic Reinforced Frame XL": 1
+		}
+	},
+	"3D Printer M": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 2000,
+		"volume": 609.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 36,
+			"Basic Injector": 25,
+			"Basic Robotic Arm M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Chemical Industry M": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 2300,
+		"volume": 479.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 36,
+			"Basic Power System": 25,
+			"Basic Chemical Container M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Electronics Industry M": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 1620,
+		"volume": 459.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 36,
+			"Basic Electronics": 25,
+			"Basic Robotic Arm M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Glass Furnace M": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 2830,
+		"volume": 556.4,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 36,
+			"Basic Burner": 25,
+			"Basic Power Transformer M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Honeycomb Refinery M": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 2990,
+		"volume": 589.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 36,
+			"Basic Power System": 25,
+			"Basic Robotic Arm M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Metalwork Industry M": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 2600,
+		"volume": 599.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 36,
+			"Basic Power System": 25,
+			"Basic Mobile Panel M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Recycler M": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 2350,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 36,
+			"Basic Burner": 25,
+			"Basic Mobile Panel M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Refiner M": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 2300,
+		"volume": 479.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 36,
+			"Basic Power System": 25,
+			"Basic Chemical Container M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Smelter M": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 2060,
+		"volume": 499.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 36,
+			"Basic Burner": 25,
+			"Basic Chemical Container M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Transfer Unit": {
+		"tier": 1,
+		"type": "Industry",
+		"mass": 10150,
+		"volume": 3305.4,
+		"outputQuantity": 1,
+		"time": 7200,
+		"skill": "InIn",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Pipe": 216,
+			"Basic Hydraulics": 125,
+			"Basic Robotic Arm L": 1,
+			"Basic Standard Frame L": 1
+		}
+	},
+	"Retro-Rocket Brake S": {
+		"tier": 1,
+		"type": "Space Brake",
+		"mass": 137.55,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Burner": 1,
+			"Basic Ionic Chamber XS": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Retro-Rocket Brake M": {
+		"tier": 1,
+		"type": "Space Brake",
+		"mass": 714,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 6,
+			"Basic Burner": 5,
+			"Basic Ionic Chamber S": 1,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Retro-Rocket Brake L": {
+		"tier": 1,
+		"type": "Space Brake",
+		"mass": 3770,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Burner": 25,
+			"Basic Ionic Chamber M": 1,
+			"Basic Standard Frame M": 1
+		}
+	},
+	"Atmospheric Airbrake S": {
+		"tier": 1,
+		"type": "Airbrake",
+		"mass": 55.55,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Pipe": 1,
+			"Basic Hydraulics": 1,
+			"Basic Mobile Panel XS": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Atmospheric Airbrake M": {
+		"tier": 1,
+		"type": "Airbrake",
+		"mass": 285.25,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Pipe": 6,
+			"Basic Hydraulics": 5,
+			"Basic Mobile Panel S": 1,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Atmospheric Airbrake L": {
+		"tier": 1,
+		"type": "Airbrake",
+		"mass": 1500,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 36,
+			"Basic Hydraulics": 25,
+			"Basic Mobile Panel M": 1,
+			"Basic Standard Frame M": 1
+		}
+	},
+	"Compact Aileron XS": {
+		"tier": 1,
+		"type": "Aileron",
+		"mass": 61.2,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Hydraulics": 1,
+			"Basic Mobile Panel XS": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Compact Aileron S": {
+		"tier": 1,
+		"type": "Aileron",
+		"mass": 319.15,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 6,
+			"Basic Hydraulics": 5,
+			"Basic Mobile Panel S": 1,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Compact Aileron M": {
+		"tier": 1,
+		"type": "Aileron",
+		"mass": 1705,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Hydraulics": 25,
+			"Basic Mobile Panel M": 1,
+			"Basic Standard Frame M": 1
+		}
+	},
+	"Aileron XS": {
+		"tier": 1,
+		"type": "Aileron",
+		"mass": 122.4,
+		"volume": 45.2,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 2,
+			"Basic Hydraulics": 2,
+			"Basic Mobile Panel XS": 2,
+			"Basic Standard Frame XS": 2
+		}
+	},
+	"Aileron S": {
+		"tier": 1,
+		"type": "Aileron",
+		"mass": 638.3,
+		"volume": 233.2,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 12,
+			"Basic Hydraulics": 10,
+			"Basic Mobile Panel S": 2,
+			"Basic Standard Frame S": 2
+		}
+	},
+	"Aileron M": {
+		"tier": 1,
+		"type": "Aileron",
+		"mass": 3410,
+		"volume": 1238.4,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 72,
+			"Basic Hydraulics": 50,
+			"Basic Mobile Panel M": 2,
+			"Basic Standard Frame M": 2
+		}
+	},
+	"Stabilizer XS": {
+		"tier": 1,
+		"type": "Stabilizer",
+		"mass": 69.88,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Hydraulics": 1,
+			"Basic Mobile Panel XS": 1,
+			"Basic Reinforced Frame XS": 1
+		}
+	},
+	"Stabilizer S": {
+		"tier": 1,
+		"type": "Stabilizer",
+		"mass": 366.89,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 6,
+			"Basic Hydraulics": 5,
+			"Basic Mobile Panel S": 1,
+			"Basic Reinforced Frame S": 1
+		}
+	},
+	"Stabilizer M": {
+		"tier": 1,
+		"type": "Stabilizer",
+		"mass": 2030,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Hydraulics": 25,
+			"Basic Mobile Panel M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Stabilizer L": {
+		"tier": 1,
+		"type": "Stabilizer",
+		"mass": 11500,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 7200,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 216,
+			"Basic Hydraulics": 125,
+			"Basic Mobile Panel L": 1,
+			"Basic Reinforced Frame L": 1
+		}
+	},
+	"Wing XS": {
+		"tier": 1,
+		"type": "Wing",
+		"mass": 61.2,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Hydraulics": 1,
+			"Basic Mobile Panel XS": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Wing S": {
+		"tier": 1,
+		"type": "Wing",
+		"mass": 319.15,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 6,
+			"Basic Hydraulics": 5,
+			"Basic Mobile Panel S": 1,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Wing M": {
+		"tier": 1,
+		"type": "Wing",
+		"mass": 1700,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Hydraulics": 35,
+			"Basic Mobile Panel M": 1,
+			"Basic Standard Frame M": 1
+		}
+	},
+	"Wing Variant M": {
+		"tier": 1,
+		"type": "Wing",
+		"mass": 1700,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Hydraulics": 35,
+			"Basic Mobile Panel M": 1,
+			"Basic Standard Frame M": 1
+		}
+	},
+	"Atmospheric Engine XS": {
+		"tier": 1,
+		"type": "Atmospheric Engine",
+		"mass": 101.88,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Injector": 1,
+			"Basic Combustion Chamber XS": 1,
+			"Basic Reinforced Frame XS": 1
+		}
+	},
+	"Atmospheric Engine S": {
+		"tier": 1,
+		"type": "Atmospheric Engine",
+		"mass": 539.99,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 6,
+			"Basic Injector": 5,
+			"Basic Combustion Chamber S": 1,
+			"Basic Reinforced Frame S": 1
+		}
+	},
+	"Atmospheric Engine M": {
+		"tier": 1,
+		"type": "Atmospheric Engine",
+		"mass": 2980,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Injector": 25,
+			"Basic Combustion Chamber M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Atmospheric Engine L": {
+		"tier": 1,
+		"type": "Atmospheric Engine",
+		"mass": 16930,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 7200,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 216,
+			"Basic Injector": 125,
+			"Basic Combustion Chamber L": 1,
+			"Basic Reinforced Frame L": 1
+		}
+	},
+	"Space Engine XS": {
+		"tier": 1,
+		"type": "Space Engine",
+		"mass": 146.23,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Burner": 1,
+			"Basic Ionic Chamber XS": 1,
+			"Basic Reinforced Frame XS": 1
+		}
+	},
+	"Space Engine S": {
+		"tier": 1,
+		"type": "Space Engine",
+		"mass": 761.74,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 6,
+			"Basic Burner": 5,
+			"Basic Ionic Chamber S": 1,
+			"Basic Reinforced Frame S": 1
+		}
+	},
+	"Space Engine M": {
+		"tier": 1,
+		"type": "Space Engine",
+		"mass": 4090,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Burner": 25,
+			"Basic Ionic Chamber M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Space Engine L": {
+		"tier": 1,
+		"type": "Space Engine",
+		"mass": 22470,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 7200,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 216,
+			"Basic Burner": 125,
+			"Basic Ionic Chamber L": 1,
+			"Basic Reinforced Frame L": 1
+		}
+	},
+	"Space Engine XL": {
+		"tier": 1,
+		"type": "Space Engine",
+		"mass": 126240,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 32400,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 1296,
+			"Basic Burner": 625,
+			"Basic Ionic Chamber XL": 1,
+			"Basic Reinforced Frame XL": 1
+		}
+	},
+	"Hover Engine S": {
+		"tier": 1,
+		"type": "Hover Engine",
+		"mass": 56.91,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Injector": 1,
+			"Basic Gas Cylinder XS": 1,
+			"Basic Reinforced Frame XS": 1
+		}
+	},
+	"Hover Engine M": {
+		"tier": 2,
+		"type": "Hover Engine",
+		"mass": 302.02,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 6,
+			"Basic Injector": 5,
+			"Basic Gas Cylinder S": 1,
+			"Basic Reinforced Frame S": 1
+		}
+	},
+	"Hover Engine L": {
+		"tier": 2,
+		"type": "Hover Engine",
+		"mass": 1700,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Injector": 25,
+			"Basic Gas Cylinder M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Flat Hover Engine L": {
+		"tier": 2,
+		"type": "Hover Engine",
+		"mass": 1700,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Injector": 25,
+			"Basic Gas Cylinder M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Adjustor XS": {
+		"tier": 1,
+		"type": "Adjustor",
+		"mass": 22.7,
+		"volume": 11,
+		"outputQuantity": 1,
+		"time": 30,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Pipe": 1,
+			"Basic Injector": 1
+		}
+	},
+	"Adjustor S": {
+		"tier": 1,
+		"type": "Adjustor",
+		"mass": 42.58,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Pipe": 1,
+			"Basic Injector": 1,
+			"Basic Gas Cylinder XS": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Adjustor M": {
+		"tier": 1,
+		"type": "Adjustor",
+		"mass": 220.38,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Pipe": 6,
+			"Basic Injector": 5,
+			"Basic Gas Cylinder S": 1,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Adjustor L": {
+		"tier": 1,
+		"type": "Adjustor",
+		"mass": 1180,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 36,
+			"Basic Injector": 25,
+			"Basic Gas Cylinder M": 1,
+			"Basic Standard Frame M": 1
+		}
+	},
+	"Rocket Engine S": {
+		"tier": 3,
+		"type": "Rocket Engine",
+		"mass": 2223.76,
+		"volume": 40.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Burner": 1,
+			"Advanced Combustion Chamber XS": 1,
+			"Advanced Standard Frame XS": 1
+		}
+	},
+	"Rocket Engine M": {
+		"tier": 3,
+		"type": "Rocket Engine",
+		"mass": 680.05,
+		"volume": 125.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Burner": 5,
+			"Advanced Combustion Chamber S": 1,
+			"Advanced Standard Frame S": 1
+		}
+	},
+	"Rocket Engine L": {
+		"tier": 4,
+		"type": "Rocket Engine",
+		"mass": 3390,
+		"volume": 628,
+		"outputQuantity": 1,
+		"time": 18000,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Burner": 25,
+			"Advanced Combustion Chamber M": 1,
+			"Advanced Standard Frame M": 1
+		}
+	},
+	"Vertical Booster XS": {
+		"tier": 1,
+		"type": "Vertical Booster",
+		"mass": 22.7,
+		"volume": 11,
+		"outputQuantity": 1,
+		"time": 30,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Pipe": 1,
+			"Basic Injector": 1
+		}
+	},
+	"Vertical Booster S": {
+		"tier": 1,
+		"type": "Vertical Booster",
+		"mass": 102,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Pipe": 1,
+			"Basic Injector": 1,
+			"Basic Ionic Chamber XS": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Vertical Booster M": {
+		"tier": 1,
+		"type": "Vertical Booster",
+		"mass": 530.6,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Pipe": 6,
+			"Basic Injector": 5,
+			"Basic Ionic Chamber S": 1,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Vertical Booster L": {
+		"tier": 1,
+		"type": "Vertical Booster",
+		"mass": 2820,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Pipe": 36,
+			"Basic Injector": 25,
+			"Basic Ionic Chamber M": 1,
+			"Basic Standard Frame M": 1
+		}
+	},
+	"Elevator XS": {
+		"tier": 1,
+		"type": "Interactive Element",
+		"mass": 207.86,
+		"volume": 57.56,
+		"outputQuantity": 1,
+		"time": 1380,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Component": 1,
+			"Advanced Power System": 1,
+			"Advanced Mechanical Sensor XS": 1,
+			"Advanced Quantum Alignment Unit": 1,
+			"Advanced Standard Frame XS": 1
+		}
+	},
+	"Landing Gear XS": {
+		"tier": 1,
+		"type": "Landing Gear",
+		"mass": 49.88,
+		"volume": 13,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Hydraulics": 1,
+			"Basic Reinforced Frame XS": 1
+		}
+	},
+	"Landing Gear S": {
+		"tier": 2,
+		"type": "Landing Gear",
+		"mass": 258.76,
+		"volume": 67,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Hydraulics": 5,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Landing Gear M": {
+		"tier": 2,
+		"type": "Landing Gear",
+		"mass": 1460,
+		"volume": 360,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Hydraulics": 25,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Landing Gear L": {
+		"tier": 2,
+		"type": "Landing Gear",
+		"mass": 8500,
+		"volume": 1981,
+		"outputQuantity": 1,
+		"time": 18000,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Hydraulics": 125,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Force Field XS": {
+		"tier": 1,
+		"type": "Force Field",
+		"mass": 207.86,
+		"volume": 57.56,
+		"outputQuantity": 1,
+		"time": 1380,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Component": 1,
+			"Advanced Power System": 1,
+			"Advanced Quantum Barrier": 1
+		}
+	},
+	"Force Field S": {
+		"tier": 3,
+		"type": "Force Field",
+		"mass": 110.62,
+		"volume": 34.7,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Component": 1,
+			"Advanced Power System": 1,
+			"Advanced Quantum Barrier": 1
+		}
+	},
+	"Force Field M": {
+		"tier": 3,
+		"type": "Force Field",
+		"mass": 110.62,
+		"volume": 34.7,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Component": 1,
+			"Advanced Power System": 1,
+			"Advanced Quantum Barrier": 1
+		}
+	},
+	"Force Field L": {
+		"tier": 3,
+		"type": "Force Field",
+		"mass": 110.62,
+		"volume": 34.7,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Component": 1,
+			"Advanced Power System": 1,
+			"Advanced Quantum Barrier": 1
+		}
+	},
+	"Territory Scanner": {
+		"tier": 2,
+		"type": "Instrument",
+		"mass": 66460,
+		"volume": 12700,
+		"outputQuantity": 1,
+		"time": 93600,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Component": 648,
+			"Uncommon Component": 648,
+			"Uncommon Power System": 625,
+			"Uncommon Ore Scanner XL": 1,
+			"Uncommon Reinforced Frame XL": 1
+		}
+	},
+	"Gyroscope": {
+		"tier": 1,
+		"type": "Instrument",
+		"mass": 104.41,
+		"volume": 17.65,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Basic Magnet": 1,
+			"Basic Mechanical Sensor XS": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Telemeter": {
+		"tier": 2,
+		"type": "Instrument",
+		"mass": 40.79,
+		"volume": 31.4,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Optics": 1,
+			"Uncommon Laser Chamber XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Remote Controller": {
+		"tier": 3,
+		"type": "Control Unit",
+		"mass": 7.79,
+		"volume": 4.5,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Component": 1,
+			"Advanced Electronics": 1
+		}
+	},
+	"Hovercraft Seat Controller": {
+		"tier": 1,
+		"type": "Control Unit",
+		"mass": 110.33,
+		"volume": 61.6,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Component": 6,
+			"Basic Electronics": 5,
+			"Basic Control System S": 1,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Emergency Controller": {
+		"tier": 3,
+		"type": "Control Unit",
+		"mass": 9.35,
+		"volume": 4.8,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Electronics": 1
+		}
+	},
+	"Command Seat Controller": {
+		"tier": 1,
+		"type": "Control Unit",
+		"mass": 158.45,
+		"volume": 66.6,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Component": 6,
+			"Basic Processor": 5,
+			"Basic Control System S": 1,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Cockpit Controller": {
+		"tier": 1,
+		"type": "Control Unit",
+		"mass": 1210,
+		"volume": 491.2,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Component": 36,
+			"Basic Hydraulics": 25,
+			"Basic Control System M": 1,
+			"Basic Standard Frame M": 1
+		}
+	},
+	"Programming Board": {
+		"tier": 1,
+		"type": "Control Unit",
+		"mass": 27.74,
+		"volume": 12.7,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Basic Processor": 1,
+			"Basic Control System XS": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Gunner Module S": {
+		"tier": 2,
+		"type": "Control Unit",
+		"mass": 427.9,
+		"volume": 93.8,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 6,
+			"Advanced Power System": 5,
+			"Advanced Control System S": 1,
+			"Advanced Standard Frame S": 1
+		}
+	},
+	"Gunner Module M": {
+		"tier": 2,
+		"type": "Control Unit",
+		"mass": 2170,
+		"volume": 486.4,
+		"outputQuantity": 1,
+		"time": 18000,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 36,
+			"Advanced Power System": 25,
+			"Advanced Control System M": 1,
+			"Advanced Standard Frame M": 1
+		}
+	},
+	"Gunner Module L": {
+		"tier": 2,
+		"type": "Control Unit",
+		"mass": 11320,
+		"volume": 2666.6,
+		"outputQuantity": 1,
+		"time": 68400,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 216,
+			"Advanced Power System": 125,
+			"Advanced Control System L": 1,
+			"Advanced Standard Frame L": 1
+		}
+	},
+	"Anti-Gravity Generator S": {
+		"tier": 4,
+		"type": "Anti-Gravity Generator",
+		"mass": 27130,
+		"volume": 4279.69,
+		"outputQuantity": 1,
+		"time": 259200,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Component": 108,
+			"Advanced Component": 108,
+			"Rare Power System": 125,
+			"Rare Power Transformer L": 1,
+			"Rare Anti-Gravity Core": 64,
+			"Rare Reinforced Frame L": 1
+		}
+	},
+	"Anti-Gravity Generator M": {
+		"tier": 4,
+		"type": "Anti-Gravity Generator",
+		"mass": 137720,
+		"volume": 21620,
+		"outputQuantity": 1,
+		"time": 1036800,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Uncommon Component": 648,
+			"Advanced Component": 648,
+			"Rare Power System": 625,
+			"Rare Power Transformer XL": 1,
+			"Rare Anti-Gravity Core": 256,
+			"Rare Reinforced Frame XL": 1
+		}
+	},
+	"Anti-Gravity Generator L": {
+		"tier": 4,
+		"type": "Anti-Gravity Generator",
+		"mass": 550870,
+		"volume": 86470,
+		"outputQuantity": 1,
+		"time": 1036800,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Uncommon Component": 2592,
+			"Advanced Component": 2592,
+			"Rare Power System": 2500,
+			"Rare Power Transformer XL": 4,
+			"Rare Anti-Gravity Core": 1024,
+			"Rare Reinforced Frame XL": 4
+		}
+	},
+	"Anti-Gravity Pulsor": {
+		"tier": 3,
+		"type": "Anti-Gravity Generator",
+		"mass": 6210,
+		"volume": 804.93,
+		"outputQuantity": 1,
+		"time": 21600,
+		"skill": "Piloting",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Component": 36,
+			"Advanced Magnet": 25,
+			"Advanced Ionic Chamber M": 1,
+			"Advanced Anti-Gravity Core": 16,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Sliding Door S": {
+		"tier": 1,
+		"type": "Door/Gate",
+		"mass": 749.15,
+		"volume": 102.04,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 6,
+			"Basic Power System": 5,
+			"Basic Electric Engine S": 1,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Sliding Door M": {
+		"tier": 1,
+		"type": "Door/Gate",
+		"mass": 1010,
+		"volume": 151.8,
+		"outputQuantity": 1,
+		"time": 1200,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Steel": 49,
+			"Basic Connector": 36,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Reinforced Sliding Door": {
+		"tier": 1,
+		"type": "Door/Gate",
+		"mass": 4200,
+		"volume": 546.4,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Power System": 25,
+			"Basic Electric Engine M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Interior Door": {
+		"tier": 1,
+		"type": "Door/Gate",
+		"mass": 4200,
+		"volume": 546.4,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Power System": 25,
+			"Basic Electric Engine M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Airlock": {
+		"tier": 1,
+		"type": "Door/Gate",
+		"mass": 4200,
+		"volume": 546.4,
+		"outputQuantity": 1,
+		"time": 1920,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 36,
+			"Basic Power System": 25,
+			"Basic Electric Engine M": 1,
+			"Basic Reinforced Frame M": 1
+		}
+	},
+	"Gate XS": {
+		"tier": 2,
+		"type": "Door/Gate",
+		"mass": 122750,
+		"volume": 16760,
+		"outputQuantity": 1,
+		"time": 93600,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 648,
+			"Uncommon Screw": 648,
+			"Uncommon Power System": 625,
+			"Uncommon Electric Engine XL": 1,
+			"Uncommon Reinforced Frame XL": 1
+		}
+	},
+	"Expanded Gate S": {
+		"tier": 2,
+		"type": "Door/Gate",
+		"mass": 122750,
+		"volume": 16760,
+		"outputQuantity": 1,
+		"time": 93600,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 1296,
+			"Uncommon Screw": 1296,
+			"Uncommon Power System": 1250,
+			"Uncommon Electric Engine XL": 2,
+			"Uncommon Reinforced Frame XL": 2
+		}
+	},
+	"Gate M": {
+		"tier": 2,
+		"type": "Door/Gate",
+		"mass": 122750,
+		"volume": 16760,
+		"outputQuantity": 1,
+		"time": 93600,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 2592,
+			"Uncommon Screw": 2592,
+			"Uncommon Power System": 2500,
+			"Uncommon Electric Engine XL": 4,
+			"Uncommon Reinforced Frame XL": 4
+		}
+	},
+	"Expanded Gate L": {
+		"tier": 2,
+		"type": "Door/Gate",
+		"mass": 122750,
+		"volume": 16760,
+		"outputQuantity": 1,
+		"time": 93600,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 3240,
+			"Uncommon Screw": 3240,
+			"Uncommon Power System": 3125,
+			"Uncommon Electric Engine XL": 5,
+			"Uncommon Reinforced Frame XL": 5
+		}
+	},
+	"Gate XL": {
+		"tier": 2,
+		"type": "Door/Gate",
+		"mass": 122750,
+		"volume": 16760,
+		"outputQuantity": 1,
+		"time": 93600,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 5184,
+			"Uncommon Screw": 5184,
+			"Uncommon Power System": 5000,
+			"Uncommon Electric Engine XL": 8,
+			"Uncommon Reinforced Frame XL": 8
+		}
+	},
+	"AND Operator": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 13.27,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 70,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"NOT Operator": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 7.47,
+		"volume": 4.5,
+		"outputQuantity": 1,
+		"time": 70,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"OR Operator": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 7.47,
+		"volume": 4.5,
+		"outputQuantity": 1,
+		"time": 70,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"Relay": {
+		"tier": 1,
+		"type": "Electronics",
+		"mass": 8.87,
+		"volume": 6.5,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Basic Electronics": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Databank": {
+		"tier": 1,
+		"type": "Electronics",
+		"mass": 17.09,
+		"volume": 5.5,
+		"outputQuantity": 1,
+		"time": 30,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Basic Processor": 1
+		}
+	},
+	"2 Counter": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 9.93,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"3 Counter": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 9.93,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"5 Counter": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 9.93,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"7 Counter": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 9.93,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"10 Counter": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 9.93,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"Infra-Red Laser Emitter": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 9.93,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"Laser Emitter": {
+		"tier": 1,
+		"type": "Electronics",
+		"mass": 7.47,
+		"volume": 4.5,
+		"outputQuantity": 1,
+		"time": 30,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Basic Electronics": 1
+		}
+	},
+	"Delay Line": {
+		"tier": 1,
+		"type": "Electronics",
+		"mass": 7.47,
+		"volume": 4.5,
+		"outputQuantity": 1,
+		"time": 30,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Basic Electronics": 1
+		}
+	},
+	"Receiver XS": {
+		"tier": 1,
+		"type": "Electronics",
+		"mass": 13.27,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 30,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Electronics": 1
+		}
+	},
+	"Receiver S": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 475.87,
+		"volume": 91.56,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Electronics": 5,
+			"Uncommon Antenna S": 1,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Receiver M": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 6636.912,
+		"volume": 1500,
+		"outputQuantity": 1,
+		"time": 21600,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Electronics": 125,
+			"Uncommon Antenna L": 1,
+			"Uncommon Standard Frame L": 1
+		}
+	},
+	"Emitter XS": {
+		"tier": 1,
+		"type": "Electronics",
+		"mass": 69.31,
+		"volume": 15.46,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Basic Electronics": 1,
+			"Basic Antenna XS": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Emitter S": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 427.72,
+		"volume": 88.56,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Component": 3,
+			"Uncommon Component": 3,
+			"Uncommon Electronics": 5,
+			"Uncommon Antenna S": 1,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Emitter M": {
+		"tier": 2,
+		"type": "Electronics",
+		"mass": 2040,
+		"volume": 44.36,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Component": 18,
+			"Uncommon Component": 18,
+			"Uncommon Electronics": 25,
+			"Uncommon Antenna M": 1,
+			"Uncommon Casing M": 1
+		}
+	},
+	"Long Light XS": {
+		"tier": 2,
+		"type": "Light",
+		"mass": 70.05,
+		"volume": 10.8,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Uncommon Connector": 1,
+			"Uncommon Power System": 1
+		}
+	},
+	"Long Light S": {
+		"tier": 2,
+		"type": "Light",
+		"mass": 79.34,
+		"volume": 21.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Uncommon Connector": 1,
+			"Uncommon Power System": 1,
+			"Uncommon Light XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Long Light M": {
+		"tier": 2,
+		"type": "Light",
+		"mass": 79.34,
+		"volume": 21.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Uncommon Connector": 1,
+			"Uncommon Power System": 1,
+			"Uncommon Light XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Long Light L": {
+		"tier": 2,
+		"type": "Light",
+		"mass": 79.34,
+		"volume": 21.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Uncommon Connector": 1,
+			"Uncommon Power System": 1,
+			"Uncommon Light XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Square Light XS": {
+		"tier": 2,
+		"type": "Light",
+		"mass": 70.05,
+		"volume": 10.8,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Uncommon Connector": 1,
+			"Uncommon Power System": 1
+		}
+	},
+	"Square Light S": {
+		"tier": 2,
+		"type": "Light",
+		"mass": 79.34,
+		"volume": 21.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Uncommon Connector": 1,
+			"Uncommon Power System": 1,
+			"Uncommon Light XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Square Light M": {
+		"tier": 2,
+		"type": "Light",
+		"mass": 79.34,
+		"volume": 21.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Uncommon Connector": 1,
+			"Uncommon Power System": 1,
+			"Uncommon Light XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Square Light L": {
+		"tier": 2,
+		"type": "Light",
+		"mass": 79.34,
+		"volume": 21.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Uncommon Connector": 1,
+			"Uncommon Power System": 1,
+			"Uncommon Light XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Vertical Light XS": {
+		"tier": 2,
+		"type": "Light",
+		"mass": 70.05,
+		"volume": 10.8,
+		"outputQuantity": 1,
+		"time": 240,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Uncommon Connector": 1,
+			"Uncommon Power System": 1
+		}
+	},
+	"Vertical Light S": {
+		"tier": 2,
+		"type": "Light",
+		"mass": 79.34,
+		"volume": 21.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Uncommon Connector": 1,
+			"Uncommon Power System": 1,
+			"Uncommon Light XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Vertical Light M": {
+		"tier": 2,
+		"type": "Light",
+		"mass": 79.34,
+		"volume": 21.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Uncommon Connector": 1,
+			"Uncommon Power System": 1,
+			"Uncommon Light XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Vertical Light L": {
+		"tier": 2,
+		"type": "Light",
+		"mass": 79.34,
+		"volume": 21.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Connector": 3,
+			"Uncommon Connector": 3,
+			"Uncommon Power System": 5,
+			"Uncommon Light S": 1,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Headlight": {
+		"tier": 2,
+		"type": "Light",
+		"mass": 79.34,
+		"volume": 21.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Connector": 1,
+			"Uncommon Connector": 1,
+			"Uncommon Power System": 1,
+			"Uncommon Light XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Small Atmospheric Radar PvP S": {
+		"tier": 1,
+		"type": "Radar",
+		"mass": 486.72,
+		"volume": 96.56,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic LED": 3,
+			"Uncommon LED": 3,
+			"Uncommon Magnet": 5,
+			"Uncommon Antenna S": 1,
+			"Uncommon Standard Frame S": 1
+		}
+	},
+	"Medium Atmospheric Radar PvP M": {
+		"tier": 2,
+		"type": "Radar",
+		"mass": 1740,
+		"volume": 420,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic LED": 18,
+			"Uncommon LED": 18,
+			"Uncommon Magnet": 25,
+			"Uncommon Antenna M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Large Atmospheric Radar PvP L": {
+		"tier": 2,
+		"type": "Radar",
+		"mass": 6640,
+		"volume": 1500,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic LED": 108,
+			"Uncommon LED": 108,
+			"Uncommon Magnet": 125,
+			"Uncommon Antenna L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Space Radar S": {
+		"tier": 1,
+		"type": "Radar",
+		"mass": 486.72,
+		"volume": 96.56,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic LED": 3,
+			"Uncommon LED": 3,
+			"Uncommon Processor": 5,
+			"Uncommon Antenna S": 1,
+			"Uncommon Standard Frame S": 1
+		}
+	},
+	"Space Radar M": {
+		"tier": 1,
+		"type": "Radar",
+		"mass": 2350,
+		"volume": 486.36,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic LED": 18,
+			"Uncommon LED": 18,
+			"Uncommon Processor": 25,
+			"Uncommon Antenna M": 1,
+			"Uncommon Standard Frame M": 1
+		}
+	},
+	"Space Radar L": {
+		"tier": 1,
+		"type": "Radar",
+		"mass": 12490,
+		"volume": 2658.56,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Combat",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic LED": 108,
+			"Uncommon LED": 108,
+			"Uncommon Processor": 125,
+			"Uncommon Antenna L": 1,
+			"Uncommon Standard Frame L": 1
+		}
+	},
+	"Screen XS": {
+		"tier": 2,
+		"type": "Screen/Sign",
+		"mass": 18.67,
+		"volume": 15.8,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Screen XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Screen S": {
+		"tier": 2,
+		"type": "Screen/Sign",
+		"mass": 18.67,
+		"volume": 15.8,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Screen XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Screen M": {
+		"tier": 2,
+		"type": "Screen/Sign",
+		"mass": 18.67,
+		"volume": 15.8,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Screen XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Screen XL": {
+		"tier": 3,
+		"type": "Screen/Sign",
+		"mass": 12810,
+		"volume": 11170,
+		"outputQuantity": 1,
+		"time": 93600,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Component": 648,
+			"Uncommon Component": 648,
+			"Uncommon Electronics": 625,
+			"Uncommon Screen XL": 1,
+			"Uncommon Casing XL": 1
+		}
+	},
+	"Transparent Screen XS": {
+		"tier": 2,
+		"type": "Screen/Sign",
+		"mass": 18.67,
+		"volume": 15.8,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Screen XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Transparent Screen S": {
+		"tier": 2,
+		"type": "Screen/Sign",
+		"mass": 18.67,
+		"volume": 15.8,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Screen XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Transparent Screen M": {
+		"tier": 2,
+		"type": "Screen/Sign",
+		"mass": 18.67,
+		"volume": 15.8,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Screen XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Transparent Screen L": {
+		"tier": 2,
+		"type": "Screen/Sign",
+		"mass": 18.67,
+		"volume": 15.8,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Screen XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Sign XS": {
+		"tier": 2,
+		"type": "Screen/Sign",
+		"mass": 18.67,
+		"volume": 15.8,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Screen XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Sign S": {
+		"tier": 2,
+		"type": "Screen/Sign",
+		"mass": 18.67,
+		"volume": 15.8,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Screen XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Sign M": {
+		"tier": 2,
+		"type": "Screen/Sign",
+		"mass": 18.67,
+		"volume": 15.8,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Screen XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Sign L": {
+		"tier": 2,
+		"type": "Screen/Sign",
+		"mass": 18.67,
+		"volume": 15.8,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Screen XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Sign Vertical XS": {
+		"tier": 2,
+		"type": "Screen/Sign",
+		"mass": 18.67,
+		"volume": 15.8,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Screen XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Sign Vertical M": {
+		"tier": 2,
+		"type": "Screen/Sign",
+		"mass": 18.67,
+		"volume": 15.8,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Screen XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Sign Vertical L": {
+		"tier": 2,
+		"type": "Screen/Sign",
+		"mass": 18.67,
+		"volume": 15.8,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Screen XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Sensors S": {
+		"tier": 1,
+		"type": "Surrogate Element",
+		"mass": 28,
+		"volume": 27,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic LED": 1,
+			"Uncommon LED": 1,
+			"Uncommon Electronics": 1,
+			"Uncommon Antenna XS": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Office Chair": {
+		"tier": 1,
+		"type": "Chair",
+		"mass": 916.52,
+		"volume": 13,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Fixation": 6
+		}
+	},
+	"Navigator Chair": {
+		"tier": 1,
+		"type": "Chair",
+		"mass": 39.62,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Fixation": 6,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Encampment Chair": {
+		"tier": 1,
+		"type": "Chair",
+		"mass": 2.52,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Polycarbonate Plastic": 1,
+			"Basic Fixation": 1
+		}
+	},
+	"Manual Switch": {
+		"tier": 1,
+		"type": "Sensor",
+		"mass": 13.27,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 22,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Electronics": 1
+		}
+	},
+	"Pressure Tile": {
+		"tier": 1,
+		"type": "Sensor",
+		"mass": 50.63,
+		"volume": 14.49,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Electronics": 1,
+			"Basic Mechanical Sensor XS": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Manual Button XS": {
+		"tier": 1,
+		"type": "Sensor",
+		"mass": 13.27,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 22,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Electronics": 1
+		}
+	},
+	"Manual Button S": {
+		"tier": 1,
+		"type": "Sensor",
+		"mass": 13.27,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 22,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Basic Electronics": 1
+		}
+	},
+	"Laser Receiver": {
+		"tier": 2,
+		"type": "Sensor",
+		"mass": 9.93,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"Infra-Red Laser Receiver": {
+		"tier": 2,
+		"type": "Sensor",
+		"mass": 9.93,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Electronics": 1
+		}
+	},
+	"Detection Zone XS": {
+		"tier": 3,
+		"type": "Sensor",
+		"mass": 7.79,
+		"volume": 4.5,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Component": 1,
+			"Advanced Electronics": 1
+		}
+	},
+	"Detection Zone S": {
+		"tier": 3,
+		"type": "Sensor",
+		"mass": 7.79,
+		"volume": 4.5,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Component": 1,
+			"Advanced Electronics": 1
+		}
+	},
+	"Detection Zone M": {
+		"tier": 3,
+		"type": "Sensor",
+		"mass": 7.79,
+		"volume": 4.5,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Component": 1,
+			"Advanced Electronics": 1
+		}
+	},
+	"Detection Zone L": {
+		"tier": 3,
+		"type": "Sensor",
+		"mass": 7.79,
+		"volume": 4.5,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Component": 1,
+			"Advanced Electronics": 1
+		}
+	},
+	"Keyboard Unit": {
+		"tier": 1,
+		"type": "Decorative",
+		"mass": 24.68,
+		"volume": 3.8,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Steel": 1,
+			"Basic Connector": 1,
+			"Basic Reinforced Frame XS": 1
+		}
+	},
+	"Antenna S": {
+		"tier": 1,
+		"type": "Antenna",
+		"mass": 130.06,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 600,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Al-Fe Alloy": 7,
+			"Basic Fixation": 6,
+			"Basic Reinforced Frame S": 1
+		}
+	},
+	"Antenna M": {
+		"tier": 2,
+		"type": "Antenna",
+		"mass": 902.74,
+		"volume": 159,
+		"outputQuantity": 1,
+		"time": 3600,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Calcium Reinforced Copper": 49,
+			"Basic Fixation": 18,
+			"Uncommon Fixation": 18,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Antenna L": {
+		"tier": 3,
+		"type": "Antenna",
+		"mass": 6850,
+		"volume": 1074,
+		"outputQuantity": 1,
+		"time": 43200,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Cu-Ag Alloy": 343,
+			"Uncommon Fixation": 216,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Barrier Corner": {
+		"tier": 1,
+		"type": "Barrier",
+		"mass": 14.65,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Steel": 1,
+			"Basic Pipe": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Barrier S": {
+		"tier": 1,
+		"type": "Barrier",
+		"mass": 14.65,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Steel": 1,
+			"Basic Screw": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Barrier M": {
+		"tier": 1,
+		"type": "Barrier",
+		"mass": 14.65,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Steel": 1,
+			"Basic Screw": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Sink Unit": {
+		"tier": 1,
+		"type": "Bathroom",
+		"mass": 6.72,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Polycarbonate Plastic": 1,
+			"Basic Fixation": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Shower Unit": {
+		"tier": 1,
+		"type": "Bathroom",
+		"mass": 25.62,
+		"volume": 13,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Injector": 1,
+			"Basic Fixation": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Urinal Unit": {
+		"tier": 1,
+		"type": "Bathroom",
+		"mass": 8.32,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Silumin": 1,
+			"Basic Fixation": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Toilet Unit A": {
+		"tier": 1,
+		"type": "Bathroom",
+		"mass": 6.72,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Polycarbonate Plastic": 1,
+			"Basic Fixation": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Toilet Unit B": {
+		"tier": 1,
+		"type": "Bathroom",
+		"mass": 6.72,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Polycarbonate Plastic": 1,
+			"Basic Fixation": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Cable Model-A S": {
+		"tier": 1,
+		"type": "Cable",
+		"mass": 14.1,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Al-Fe Alloy": 1,
+			"Basic Pipe": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Cable Model-B S": {
+		"tier": 1,
+		"type": "Cable",
+		"mass": 14.1,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Al-Fe Alloy": 1,
+			"Basic Pipe": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Cable Model-C S": {
+		"tier": 1,
+		"type": "Cable",
+		"mass": 14.1,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Al-Fe Alloy": 1,
+			"Basic Pipe": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Cable Model-A M": {
+		"tier": 1,
+		"type": "Cable",
+		"mass": 14.1,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Al-Fe Alloy": 1,
+			"Basic Pipe": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Cable Model-B M": {
+		"tier": 1,
+		"type": "Cable",
+		"mass": 14.1,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Al-Fe Alloy": 1,
+			"Basic Pipe": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Cable Model-C M": {
+		"tier": 1,
+		"type": "Cable",
+		"mass": 14.1,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Al-Fe Alloy": 1,
+			"Basic Pipe": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Corner Cable Model-A": {
+		"tier": 1,
+		"type": "Cable",
+		"mass": 14.1,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Al-Fe Alloy": 1,
+			"Basic Pipe": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Corner Cable Model-B": {
+		"tier": 1,
+		"type": "Cable",
+		"mass": 14.1,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Al-Fe Alloy": 1,
+			"Basic Pipe": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Corner Cable Model-C": {
+		"tier": 1,
+		"type": "Cable",
+		"mass": 14.1,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Al-Fe Alloy": 1,
+			"Basic Pipe": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Dresser": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 8.32,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Silumin": 1,
+			"Basic Fixation": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Bench": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 22.33,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Polycarbonate Plastic": 1,
+			"Basic Screw": 1,
+			"Basic Reinforced Frame XS": 1
+		}
+	},
+	"Wooden Low Table": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 5.92,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Wood": 1,
+			"Basic Fixation": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Sofa": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 39.62,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Fixation": 6,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Wooden Wardrobe": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 39.62,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Fixation": 6,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Table": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 264.32,
+		"volume": 159,
+		"outputQuantity": 1,
+		"time": 1200,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 49,
+			"Basic Fixation": 36,
+			"Basic Standard Frame M": 1
+		}
+	},
+	"Trash": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 6.72,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Polycarbonate Plastic": 1,
+			"Basic Fixation": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Wooden Sofa": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 39.62,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Fixation": 6,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Nightstand": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 6.72,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Polycarbonate Plastic": 1,
+			"Basic Fixation": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Wardrobe": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 39.62,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Fixation": 6,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Wooden Chair": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 2.52,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Polycarbonate Plastic": 1,
+			"Basic Fixation": 1
+		}
+	},
+	"\"HMS Ajax33\" - Artist Unknown": {
+		"tier": 4,
+		"type": "Furniture",
+		"mass": 5.54,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 2040,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Fluoropolymer": 1,
+			"Uncommon Fixation": 1,
+			"Advanced Fixation": 1,
+			"Rare Casing XS": 1
+		}
+	},
+	"\"Parrotos Sanctuary\" - Artist Unknown": {
+		"tier": 4,
+		"type": "Furniture",
+		"mass": 5.54,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 2040,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Fluoropolymer": 1,
+			"Uncommon Fixation": 1,
+			"Advanced Fixation": 1,
+			"Rare Casing XS": 1
+		}
+	},
+	"\"Eye Doll's Workshop\" - Artist Unknown": {
+		"tier": 4,
+		"type": "Furniture",
+		"mass": 5.54,
+		"volume": 5,
+		"outputQuantity": 1,
+		"time": 2040,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Fluoropolymer": 1,
+			"Uncommon Fixation": 1,
+			"Advanced Fixation": 1,
+			"Rare Casing XS": 1
+		}
+	},
+	"Wooden Armchair": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 1.72,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Wood": 1,
+			"Basic Fixation": 1
+		}
+	},
+	"Round Carpet": {
+		"tier": 5,
+		"type": "Furniture",
+		"mass": 2.78,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 6060,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Vanamer": 1,
+			"Advanced Fixation": 1
+		}
+	},
+	"Square Carpet": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 2.52,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Polycarbonate Plastic": 1,
+			"Basic Fixation": 1
+		}
+	},
+	"Wooden Dresser": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 34.02,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Wood": 7,
+			"Basic Fixation": 6,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Wooden Table M": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 34.02,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Wood": 7,
+			"Basic Fixation": 6,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Wooden Table L": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 34.02,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Wood": 7,
+			"Basic Fixation": 6,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Shelf Empty": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 8.32,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Silumin": 1,
+			"Basic Fixation": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Shelf Half Full": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 8.32,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Silumin": 1,
+			"Basic Fixation": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Shelf Full": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 8.32,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Silumin": 1,
+			"Basic Fixation": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Bed": {
+		"tier": 1,
+		"type": "Furniture",
+		"mass": 128.94,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Screw": 6,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Spaceship Hologram S": {
+		"tier": 2,
+		"type": "Hologram",
+		"mass": 112.72,
+		"volume": 9,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Basic Optics": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Spaceship Hologram M": {
+		"tier": 2,
+		"type": "Hologram",
+		"mass": 15.98,
+		"volume": 13,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Uncommon Component": 1,
+			"Uncommon Optics": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Spaceship Hologram L": {
+		"tier": 2,
+		"type": "Hologram",
+		"mass": 14.02,
+		"volume": 12.5,
+		"outputQuantity": 1,
+		"time": 840,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Component": 1,
+			"Uncommon Optics": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Planet Hologram": {
+		"tier": 1,
+		"type": "Hologram",
+		"mass": 13.39,
+		"volume": 12.5,
+		"outputQuantity": 1,
+		"time": 120,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Component": 1,
+			"Basic Optics": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Planet Hologram L": {
+		"tier": 1,
+		"type": "Hologram",
+		"mass": 69.9,
+		"volume": 64,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Component": 6,
+			"Basic Optics": 5,
+			"Basic Casing S": 1
+		}
+	},
+	"Steel Column": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 13.37,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Steel": 1,
+			"Basic Fixation": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Steel Panel": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 13.37,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Steel": 1,
+			"Basic Fixation": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Hull Decorative Element A": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 14.65,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Steel": 1,
+			"Basic Pipe": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Hull Decorative Element B": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 14.65,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Steel": 1,
+			"Basic Pipe": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Hull Decorative Element C": {
+		"tier": 1,
+		"type": "Hull",
+		"mass": 14.65,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Steel": 1,
+			"Basic Pipe": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Pipe A M": {
+		"tier": 1,
+		"type": "Pipe",
+		"mass": 4320,
+		"volume": 1074,
+		"outputQuantity": 1,
+		"time": 4800,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Polycarbonate Plastic": 343,
+			"Basic Pipe": 216,
+			"Basic Reinforced Frame L": 1
+		}
+	},
+	"Pipe B M": {
+		"tier": 1,
+		"type": "Pipe",
+		"mass": 4320,
+		"volume": 1074,
+		"outputQuantity": 1,
+		"time": 4800,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Polycarbonate Plastic": 343,
+			"Basic Pipe": 216,
+			"Basic Reinforced Frame L": 1
+		}
+	},
+	"Pipe C M": {
+		"tier": 1,
+		"type": "Pipe",
+		"mass": 4320,
+		"volume": 1074,
+		"outputQuantity": 1,
+		"time": 4800,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Polycarbonate Plastic": 343,
+			"Basic Pipe": 216,
+			"Basic Reinforced Frame L": 1
+		}
+	},
+	"Pipe D M": {
+		"tier": 1,
+		"type": "Pipe",
+		"mass": 4320,
+		"volume": 1074,
+		"outputQuantity": 1,
+		"time": 4800,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Polycarbonate Plastic": 343,
+			"Basic Pipe": 216,
+			"Basic Reinforced Frame L": 1
+		}
+	},
+	"Pipe Corner M": {
+		"tier": 1,
+		"type": "Pipe",
+		"mass": 4320,
+		"volume": 1074,
+		"outputQuantity": 1,
+		"time": 4800,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Polycarbonate Plastic": 343,
+			"Basic Pipe": 216,
+			"Basic Reinforced Frame L": 1
+		}
+	},
+	"Pipe Connector M": {
+		"tier": 1,
+		"type": "Pipe",
+		"mass": 4320,
+		"volume": 1074,
+		"outputQuantity": 1,
+		"time": 4800,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Polycarbonate Plastic": 343,
+			"Basic Pipe": 216,
+			"Basic Reinforced Frame L": 1
+		}
+	},
+	"Plant Case A": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 21.42,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Biological Matter": 7,
+			"Basic Fixation": 6,
+			"Basic Casing S": 1
+		}
+	},
+	"Plant Case B": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 3.52,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Biological Matter": 1,
+			"Basic Fixation": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Plant Case C": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 3.52,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Biological Matter": 1,
+			"Basic Fixation": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Plant Case D": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 3.52,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Biological Matter": 1,
+			"Basic Fixation": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Plant Case E": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 3.52,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Biological Matter": 1,
+			"Basic Fixation": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Suspended Fruit Plant": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 3.52,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Biological Matter": 1,
+			"Basic Fixation": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Suspended Plant A": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 3.52,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Biological Matter": 1,
+			"Basic Fixation": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Suspended Plant B": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 3.52,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Biological Matter": 1,
+			"Basic Fixation": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Bagged Plant A": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 3.52,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Biological Matter": 1,
+			"Basic Fixation": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Bagged Plant B": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 3.52,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Biological Matter": 1,
+			"Basic Fixation": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Plant": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 3.52,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Biological Matter": 1,
+			"Basic Fixation": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Bonsai": {
+		"tier": 5,
+		"type": "Plant",
+		"mass": 902.04,
+		"volume": 180.6,
+		"outputQuantity": 1,
+		"time": 50400,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Fixation": 6,
+			"Exotic Magnet": 5,
+			"Exotic Core System S": 1,
+			"Exotic Anti-Gravity Core": 4,
+			"Exotic Casing S": 1
+		}
+	},
+	"Eggplant Plant Case": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 31.9,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Pipe": 6,
+			"Basic Casing S": 1
+		}
+	},
+	"Salad Plant Case": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 31.9,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Pipe": 6,
+			"Basic Casing S": 1
+		}
+	},
+	"Squash Plant Case": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 31.9,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Pipe": 6,
+			"Basic Casing S": 1
+		}
+	},
+	"Plant Case S": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 31.9,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Pipe": 6,
+			"Basic Casing S": 1
+		}
+	},
+	"Plant Case M": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 31.9,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Pipe": 6,
+			"Basic Casing S": 1
+		}
+	},
+	"Ficus Plant A": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 31.9,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Pipe": 6,
+			"Basic Casing S": 1
+		}
+	},
+	"Ficus Plant B": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 31.9,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Pipe": 6,
+			"Basic Casing S": 1
+		}
+	},
+	"Foliage Plant Case A": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 31.9,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Pipe": 6,
+			"Basic Casing S": 1
+		}
+	},
+	"Foliage Plant Case B": {
+		"tier": 1,
+		"type": "Plant",
+		"mass": 31.9,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Polycarbonate Plastic": 7,
+			"Basic Pipe": 6,
+			"Basic Casing S": 1
+		}
+	},
+	"Window XS": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 47.32,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Glass": 7,
+			"Basic Fixation": 6,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Window S": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 94.64,
+		"volume": 48,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Glass": 14,
+			"Basic Fixation": 12,
+			"Basic Standard Frame S": 2
+		}
+	},
+	"Window M": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 189.28,
+		"volume": 96,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Glass": 28,
+			"Basic Fixation": 24,
+			"Basic Standard Frame S": 14
+		}
+	},
+	"Window L": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 378.56,
+		"volume": 192,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Glass": 56,
+			"Basic Fixation": 48,
+			"Basic Standard Frame S": 8
+		}
+	},
+	"Armored Window XS": {
+		"tier": 2,
+		"type": "Window",
+		"mass": 47.16,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 900,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Glass": 7,
+			"Basic Fixation": 3,
+			"Uncommon Fixation": 3,
+			"Uncommon Standard Frame S": 1
+		}
+	},
+	"Armored Window S": {
+		"tier": 2,
+		"type": "Window",
+		"mass": 94.32,
+		"volume": 48,
+		"outputQuantity": 1,
+		"time": 900,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Glass": 14,
+			"Basic Fixation": 6,
+			"Uncommon Fixation": 6,
+			"Uncommon Standard Frame S": 2
+		}
+	},
+	"Armored Window M": {
+		"tier": 2,
+		"type": "Window",
+		"mass": 188.64,
+		"volume": 96,
+		"outputQuantity": 1,
+		"time": 900,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Glass": 28,
+			"Basic Fixation": 12,
+			"Uncommon Fixation": 12,
+			"Uncommon Standard Frame S": 4
+		}
+	},
+	"Armored Window L": {
+		"tier": 2,
+		"type": "Window",
+		"mass": 377.28,
+		"volume": 192,
+		"outputQuantity": 1,
+		"time": 900,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Glass": 56,
+			"Basic Fixation": 24,
+			"Uncommon Fixation": 24,
+			"Uncommon Standard Frame S": 8
+		}
+	},
+	"Glass Panel S": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 5.02,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Glass": 1,
+			"Basic Fixation": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Glass Panel M": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 20.08,
+		"volume": 16,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Glass": 4,
+			"Basic Fixation": 4,
+			"Basic Casing XS": 4
+		}
+	},
+	"Glass Panel L": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 31.92,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Glass": 7,
+			"Basic Fixation": 6,
+			"Basic Casing S": 1
+		}
+	},
+	"Bay Window XL": {
+		"tier": 1,
+		"type": "Window",
+		"mass": 5090,
+		"volume": 2544,
+		"outputQuantity": 1,
+		"time": 1200,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Glass": 784,
+			"Basic Fixation": 576,
+			"Basic Standard Frame M": 16
+		}
+	},
+	"Vertical Wing": {
+		"tier": 1,
+		"type": "Winglets",
+		"mass": 20.3,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Steel": 1,
+			"Basic Screw": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Wing Tip S": {
+		"tier": 1,
+		"type": "Winglets",
+		"mass": 20.3,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Steel": 1,
+			"Basic Screw": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Wing Tip M": {
+		"tier": 1,
+		"type": "Winglets",
+		"mass": 20.3,
+		"volume": 4,
+		"outputQuantity": 1,
+		"time": 60,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Steel": 1,
+			"Basic Screw": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Wing Tip L": {
+		"tier": 1,
+		"type": "Winglets",
+		"mass": 127.75,
+		"volume": 24,
+		"outputQuantity": 1,
+		"time": 300,
+		"skill": "Furniture/Appliance",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Steel": 7,
+			"Basic Screw": 6,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Aluminium Scrap": {
+		"tier": 1,
+		"type": "Scrap",
+		"mass": 2.7,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 3,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Recycler M"
+		],
+		"input": {
+			"Aluminium Pure": 50
+		}
+	},
+	"Carbon Scrap": {
+		"tier": 1,
+		"type": "Scrap",
+		"mass": 2.27,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 3,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Recycler M"
+		],
+		"input": {
+			"Carbon Pure": 50
+		}
+	},
+	"Silicon Scrap": {
+		"tier": 1,
+		"type": "Scrap",
+		"mass": 2.33,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 3,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Recycler M"
+		],
+		"input": {
+			"Silicon Pure": 50
+		}
+	},
+	"Iron Scrap": {
+		"tier": 1,
+		"type": "Scrap",
+		"mass": 7.85,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 3,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Recycler M"
+		],
+		"input": {
+			"Iron Pure": 50
+		}
+	},
+	"Calcium Scrap": {
+		"tier": 2,
+		"type": "Scrap",
+		"mass": 1.55,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 12,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Calcium Pure": 50
+		}
+	},
+	"Chromium Scrap": {
+		"tier": 2,
+		"type": "Scrap",
+		"mass": 7.19,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 12,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Chromium Pure": 50
+		}
+	},
+	"Copper Scrap": {
+		"tier": 2,
+		"type": "Scrap",
+		"mass": 8.96,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 12,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Copper Pure": 50
+		}
+	},
+	"Sodium Scrap": {
+		"tier": 2,
+		"type": "Scrap",
+		"mass": 0.97,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 12,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Sodium Pure": 50
+		}
+	},
+	"Lithium Scrap": {
+		"tier": 3,
+		"type": "Scrap",
+		"mass": 0.53,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 48,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Lithium Pure": 50
+		}
+	},
+	"Nickel Scrap": {
+		"tier": 3,
+		"type": "Scrap",
+		"mass": 8.91,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 48,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Nickel Pure": 50
+		}
+	},
+	"Silver Scrap": {
+		"tier": 3,
+		"type": "Scrap",
+		"mass": 10.49,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 48,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Silver Pure": 50
+		}
+	},
+	"Sulfur Scrap": {
+		"tier": 3,
+		"type": "Scrap",
+		"mass": 1.82,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 48,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Sulfur Pure": 50
+		}
+	},
+	"Cobalt Scrap": {
+		"tier": 4,
+		"type": "Scrap",
+		"mass": 8.9,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Cobalt Pure": 50
+		}
+	},
+	"Fluorine Scrap": {
+		"tier": 4,
+		"type": "Scrap",
+		"mass": 1.7,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Fluorine Pure": 50
+		}
+	},
+	"Gold Scrap": {
+		"tier": 4,
+		"type": "Scrap",
+		"mass": 19.3,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Gold Pure": 50
+		}
+	},
+	"Scandium Scrap": {
+		"tier": 4,
+		"type": "Scrap",
+		"mass": 2.98,
+		"volume": 1,
+		"outputQuantity": 50,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Recycler M"
+		],
+		"input": {
+			"Scandium Pure": 50
+		}
+	},
+	"Iron Honeycomb": {
+		"tier": 1,
+		"type": "Pure Honeycomb",
+		"mass": 78.5,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 5,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Iron Pure": 100
+		}
+	},
+	"Aluminium Honeycomb": {
+		"tier": 1,
+		"type": "Pure Honeycomb",
+		"mass": 27,
+		"volume": 5,
+		"outputQuantity": 10,
+		"time": 5,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Aluminium Pure": 100
+		}
+	},
+	"Carbon Honeycomb": {
+		"tier": 1,
+		"type": "Pure Honeycomb",
+		"mass": 22.7,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 5,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Iron Pure": 100
+		}
+	},
+	"Silicon Honeycomb": {
+		"tier": 1,
+		"type": "Pure Honeycomb",
+		"mass": 23.3,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 5,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Silicon Pure": 100
+		}
+	},
+	"Copper Honeycomb": {
+		"tier": 2,
+		"type": "Pure Honeycomb",
+		"mass": 89.6,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 15,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Copper Pure": 100
+		}
+	},
+	"Chromium Honeycomb": {
+		"tier": 2,
+		"type": "Pure Honeycomb",
+		"mass": 71.9,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 15,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Chromium Pure": 100
+		}
+	},
+	"Calcium Honeycomb": {
+		"tier": 2,
+		"type": "Pure Honeycomb",
+		"mass": 15.5,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 15,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Calcium Pure": 100
+		}
+	},
+	"Sodium Honeycomb": {
+		"tier": 2,
+		"type": "Pure Honeycomb",
+		"mass": 9.7,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 15,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Sodium Pure": 100
+		}
+	},
+	"Lithium Honeycomb": {
+		"tier": 3,
+		"type": "Pure Honeycomb",
+		"mass": 5.3,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 45,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Lithium Pure": 100
+		}
+	},
+	"Nickel Honeycomb": {
+		"tier": 3,
+		"type": "Pure Honeycomb",
+		"mass": 89.1,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 45,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Nickel Pure": 100
+		}
+	},
+	"Silver Honeycomb": {
+		"tier": 3,
+		"type": "Pure Honeycomb",
+		"mass": 104.9,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 45,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Silver Pure": 100
+		}
+	},
+	"Sulfur Honeycomb": {
+		"tier": 3,
+		"type": "Pure Honeycomb",
+		"mass": 18.19,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 45,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Sulfur Pure": 100
+		}
+	},
+	"Gold Honeycomb": {
+		"tier": 4,
+		"type": "Pure Honeycomb",
+		"mass": 193,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Gold Pure": 100
+		}
+	},
+	"Cobalt Honeycomb": {
+		"tier": 4,
+		"type": "Pure Honeycomb",
+		"mass": 89,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Cobalt Pure": 100
+		}
+	},
+	"Fluorine Honeycomb": {
+		"tier": 4,
+		"type": "Pure Honeycomb",
+		"mass": 16.96,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Fluorine Pure": 100
+		}
+	},
+	"Scandium Honeycomb": {
+		"tier": 4,
+		"type": "Pure Honeycomb",
+		"mass": 29.85,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Scandium Pure": 100
+		}
+	},
+	"Manganese Honeycomb": {
+		"tier": 5,
+		"type": "Pure Honeycomb",
+		"mass": 72.1,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Manganese Pure": 100
+		}
+	},
+	"Niobium Honeycomb": {
+		"tier": 5,
+		"type": "Pure Honeycomb",
+		"mass": 85.7,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Niobium Pure": 100
+		}
+	},
+	"Titanium Honeycomb": {
+		"tier": 5,
+		"type": "Pure Honeycomb",
+		"mass": 45.1,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Titanium Pure": 100
+		}
+	},
+	"Vanadium Honeycomb": {
+		"tier": 5,
+		"type": "Pure Honeycomb",
+		"mass": 60,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Vanadium Pure": 100
+		}
+	},
+	"Plastic Honeycomb": {
+		"tier": 1,
+		"type": "Product Honeycomb",
+		"mass": 27.57,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 20,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Polycarbonate Plastic": 100
+		}
+	},
+	"Wood Honeycomb": {
+		"tier": 1,
+		"type": "Product Honeycomb",
+		"mass": 27.19,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 10,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Wood": 100
+		}
+	},
+	"Concrete Honeycomb": {
+		"tier": 1,
+		"type": "Product Honeycomb",
+		"mass": 27.57,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 20,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Concrete": 100
+		}
+	},
+	"Carbonfiber Honeycomb": {
+		"tier": 2,
+		"type": "Product Honeycomb",
+		"mass": 27.38,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 20,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Carbon Fiber": 100
+		}
+	},
+	"Brick Honeycomb": {
+		"tier": 1,
+		"type": "Product Honeycomb",
+		"mass": 27.57,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 10,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Brick": 100
+		}
+	},
+	"Steel Honeycomb": {
+		"tier": 2,
+		"type": "Product Honeycomb",
+		"mass": 115.14,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 20,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Steel": 100
+		}
+	},
+	"Marble Honeycomb": {
+		"tier": 2,
+		"type": "Product Honeycomb",
+		"mass": 129.4,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 30,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Honeycomb Refinery M"
+		],
+		"input": {
+			"Marble": 100
+		}
+	},
+	"Luminescent White Glass": {
+		"tier": 1,
+		"type": "Product Honeycomb",
+		"mass": 26,
+		"volume": 10,
+		"outputQuantity": 10,
+		"time": 15,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Advanced Glass": 100,
+			"Uncommon LED": 10
+		}
+	},
+	"Resurrection Node": {
+		"tier": 2,
+		"type": "Resurrection Node",
+		"mass": 728.43,
+		"volume": 203.33,
+		"outputQuantity": 1,
+		"time": 5400,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Component": 3,
+			"Uncommon Component": 3,
+			"Uncommon Power System": 5,
+			"Uncommon Power Transformer S": 1,
+			"Uncommon Standard Frame S": 1
+		}
+	},
+	"Virtual Scaffolding Projector": {
+		"tier": 4,
+		"type": "Virtual Projector",
+		"mass": 167.11,
+		"volume": 122.4,
+		"outputQuantity": 1,
+		"time": 14400,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Component": 3,
+			"Advanced Component": 3,
+			"Rare Optics": 5,
+			"Rare Laser Chamber S": 1,
+			"Rare Casing S": 1
+		}
+	},
+	"Cannon XS": {
+		"tier": 1,
+		"type": "Cannon",
+		"mass": 190.1,
+		"volume": 34.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Electronics": 1,
+			"Advanced Firing System XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Cannon S": {
+		"tier": 2,
+		"type": "Cannon",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Electronics": 5,
+			"Advanced Firing System S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Cannon M": {
+		"tier": 3,
+		"type": "Cannon",
+		"mass": 2670,
+		"volume": 478,
+		"outputQuantity": 1,
+		"time": 18000,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Electronics": 25,
+			"Advanced Firing System M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Cannon L": {
+		"tier": 4,
+		"type": "Cannon",
+		"mass": 15240,
+		"volume": 2614.2,
+		"outputQuantity": 1,
+		"time": 68400,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Electronics": 125,
+			"Advanced Firing System L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Laser XS": {
+		"tier": 1,
+		"type": "Laser",
+		"mass": 118.55,
+		"volume": 39.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Power System": 1,
+			"Advanced Laser Chamber XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Laser S": {
+		"tier": 2,
+		"type": "Laser",
+		"mass": 508.26,
+		"volume": 120.2,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 6,
+			"Advanced Power System": 5,
+			"Advanced Laser Chamber S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Laser M": {
+		"tier": 3,
+		"type": "Laser",
+		"mass": 2690,
+		"volume": 600.8,
+		"outputQuantity": 1,
+		"time": 18000,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 36,
+			"Advanced Power System": 25,
+			"Advanced Laser Chamber M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Laser L": {
+		"tier": 4,
+		"type": "Laser",
+		"mass": 14770,
+		"volume": 3221,
+		"outputQuantity": 1,
+		"time": 68400,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 216,
+			"Advanced Power System": 125,
+			"Advanced Laser Chamber L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Missile XS": {
+		"tier": 1,
+		"type": "Missile",
+		"mass": 207.67,
+		"volume": 40.2,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Hydraulics": 1,
+			"Advanced Missile Silo XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Missile S": {
+		"tier": 2,
+		"type": "Missile",
+		"mass": 593.35,
+		"volume": 125.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Hydraulics": 5,
+			"Advanced Missile Silo S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Missile M": {
+		"tier": 3,
+		"type": "Missile",
+		"mass": 2970,
+		"volume": 628,
+		"outputQuantity": 1,
+		"time": 18000,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Screw": 36,
+			"Advanced Hydraulics": 25,
+			"Advanced Missile Silo M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Missile L": {
+		"tier": 4,
+		"type": "Missile",
+		"mass": 16130,
+		"volume": 3364.2,
+		"outputQuantity": 1,
+		"time": 68400,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Hydraulics": 125,
+			"Advanced Missile Silo L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Railgun XS": {
+		"tier": 1,
+		"type": "Railgun",
+		"mass": 232.02,
+		"volume": 33.66,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Connector": 1,
+			"Advanced Optics": 1,
+			"Advanced Magnetic Rail XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Railgun S": {
+		"tier": 2,
+		"type": "Railgun",
+		"mass": 517.52,
+		"volume": 95.4,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Connector": 6,
+			"Advanced Optics": 5,
+			"Advanced Magnetic Rail S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Railgun M": {
+		"tier": 3,
+		"type": "Railgun",
+		"mass": 3010,
+		"volume": 565.89,
+		"outputQuantity": 1,
+		"time": 18000,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Connector": 36,
+			"Advanced Optics": 25,
+			"Advanced Magnetic Rail M": 1,
+			"Advanced Reinforced Frame M": 1
+		}
+	},
+	"Railgun L": {
+		"tier": 4,
+		"type": "Railgun",
+		"mass": 16720,
+		"volume": 3054.89,
+		"outputQuantity": 1,
+		"time": 68400,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Connector": 216,
+			"Advanced Optics": 125,
+			"Advanced Magnetic Rail L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Cannon Agile Kinetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.61,
+		"volume": 1,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Solid Warhead": 1,
+			"Uncommon Explosive Module": 1,
+			"Al-Li Alloy": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Cannon Defense Kinetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.59,
+		"volume": 1,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Solid Warhead": 1,
+			"Uncommon Explosive Module": 1,
+			"Polysulfide Plastic": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Cannon Heavy Kinetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.73,
+		"volume": 1,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Solid Warhead": 1,
+			"Uncommon Explosive Module": 1,
+			"Inconel": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Cannon Kinetic Ammo XS": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 1.54,
+		"volume": 1,
+		"outputQuantity": 40,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Solid Warhead": 1,
+			"Basic Explosive Module": 1,
+			"Basic Reinforced Frame XS": 1
+		}
+	},
+	"Cannon Precision Kinetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.54,
+		"volume": 1,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Solid Warhead": 1,
+			"Uncommon Explosive Module": 1,
+			"Ag-Li Reinforced Glass": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Cannon Agile Thermic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.07,
+		"volume": 1,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Explosive Module": 1,
+			"Uncommon Explosive Module": 1,
+			"Al-Li Alloy": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Cannon Defense Thermic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.05,
+		"volume": 1,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Explosive Module": 1,
+			"Uncommon Explosive Module": 1,
+			"Polysulfide Plastic": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Cannon Heavy Thermic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.19,
+		"volume": 1,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Explosive Module": 1,
+			"Uncommon Explosive Module": 1,
+			"Inconel": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Cannon Precision Thermic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.08,
+		"volume": 1,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Explosive Module": 1,
+			"Uncommon Explosive Module": 1,
+			"Ag-Li Reinforced Glass": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Cannon Thermic Ammo XS": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 1.01,
+		"volume": 1,
+		"outputQuantity": 40,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Explosive Module": 1,
+			"Basic Explosive Module": 1,
+			"Basic Reinforced Frame XS": 1
+		}
+	},
+	"Cannon Agile Kinetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 4.1,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Solid Warhead": 2,
+			"Uncommon Explosive Module": 2,
+			"Al-Li Alloy": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Cannon Defense Kinetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 4.07,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Solid Warhead": 2,
+			"Uncommon Explosive Module": 2,
+			"Polysulfide Plastic": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Cannon Heavy Kinetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 4.34,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Solid Warhead": 2,
+			"Uncommon Explosive Module": 2,
+			"Inconel": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Cannon Kinetic Ammo S": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 3.98,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Solid Warhead": 2,
+			"Basic Explosive Module": 2,
+			"Basic Reinforced Frame XS": 2
+		}
+	},
+	"Cannon Precision Kinetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 4.11,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Solid Warhead": 2,
+			"Uncommon Explosive Module": 2,
+			"Ag-Li Reinforced Glass": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Cannon Agile Thermic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 3.2,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Explosive Module": 2,
+			"Uncommon Explosive Module": 2,
+			"Al-Li Alloy": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Cannon Defense Thermic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 2.99,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Explosive Module": 2,
+			"Uncommon Explosive Module": 2,
+			"Polysulfide Plastic": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Cannon Heavy Thermic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 3.28,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Explosive Module": 2,
+			"Uncommon Explosive Module": 2,
+			"Inconel": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Cannon Precision Thermic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 3.2,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Explosive Module": 2,
+			"Uncommon Explosive Module": 2,
+			"Ag-Li Reinforced Glass": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Cannon Thermic Ammo S": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 2.93,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Explosive Module": 2,
+			"Basic Explosive Module": 2,
+			"Basic Reinforced Frame XS": 2
+		}
+	},
+	"Cannon Agile Kinetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 14.73,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Solid Warhead": 4,
+			"Uncommon Explosive Module": 4,
+			"Al-Li Alloy": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Cannon Defense Kinetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 14.66,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Solid Warhead": 4,
+			"Uncommon Explosive Module": 4,
+			"Polysulfide Plastic": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Cannon Heavy Kinetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 15.21,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Solid Warhead": 4,
+			"Uncommon Explosive Module": 4,
+			"Inconel": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Cannon Kinetic Ammo M": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 14.66,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Solid Warhead": 4,
+			"Basic Explosive Module": 4,
+			"Basic Reinforced Frame S": 1
+		}
+	},
+	"Cannon Precision Kinetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 14.76,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Solid Warhead": 4,
+			"Uncommon Explosive Module": 4,
+			"Ag-Li Reinforced Glass": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Cannon Agile Thermic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 12.57,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Explosive Module": 4,
+			"Uncommon Explosive Module": 4,
+			"Al-Li Alloy": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Cannon Defense Thermic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 12.5,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Explosive Module": 4,
+			"Uncommon Explosive Module": 4,
+			"Polysulfide Plastic": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Cannon Heavy Thermic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 13.05,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Explosive Module": 4,
+			"Uncommon Explosive Module": 4,
+			"Inconel": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Cannon Precision Thermic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 12.6,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Explosive Module": 4,
+			"Uncommon Explosive Module": 4,
+			"Ag-Li Reinforced Glass": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Cannon Thermic Ammo M": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 12.55,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Explosive Module": 4,
+			"Basic Explosive Module": 4,
+			"Basic Reinforced Frame S": 1
+		}
+	},
+	"Cannon Agile Kinetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 75.56,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Solid Warhead": 8,
+			"Uncommon Explosive Module": 8,
+			"Al-Li Alloy": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Cannon Defense Kinetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 75.42,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Solid Warhead": 8,
+			"Uncommon Explosive Module": 8,
+			"Polysulfide Plastic": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Cannon Heavy Kinetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 76.52,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Solid Warhead": 8,
+			"Uncommon Explosive Module": 8,
+			"Inconel": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Cannon Kinetic Ammo L": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 76.58,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Solid Warhead": 8,
+			"Basic Explosive Module": 8,
+			"Basic Reinforced Frame S": 2
+		}
+	},
+	"Cannon Precision Kinetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 75.61,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Solid Warhead": 8,
+			"Uncommon Explosive Module": 8,
+			"Ag-Li Reinforced Glass": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Cannon Agile Thermic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 71.24,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Explosive Module": 8,
+			"Uncommon Explosive Module": 8,
+			"Al-Li Alloy": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Cannon Defense Thermic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 71.1,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Explosive Module": 8,
+			"Uncommon Explosive Module": 8,
+			"Polysulfide Plastic": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Cannon Heavy Thermic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 72.2,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Explosive Module": 8,
+			"Uncommon Explosive Module": 8,
+			"Inconel": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Cannon Precision Thermic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 71.29,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Explosive Module": 8,
+			"Uncommon Explosive Module": 8,
+			"Ag-Li Reinforced Glass": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Cannon Thermic Ammo L": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 72.37,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Explosive Module": 8,
+			"Basic Explosive Module": 8,
+			"Basic Reinforced Frame S": 2
+		}
+	},
+	"Laser Agile Electromagnetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 31.56,
+		"volume": 2,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Magnet": 1,
+			"Uncommon Optics": 1,
+			"Al-Li Alloy": 1,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Defense Electromagnetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.54,
+		"volume": 2,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Magnet": 1,
+			"Uncommon Optics": 1,
+			"Polysulfide Plastic": 1,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Electromagnetic Ammo XS": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 1.46,
+		"volume": 2,
+		"outputQuantity": 40,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Magnet": 1,
+			"Basic Optics": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Laser Heavy Electromagnetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.68,
+		"volume": 2,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Magnet": 1,
+			"Uncommon Optics": 1,
+			"Inconel": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Laser Precision Electromagnetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.56,
+		"volume": 2,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Magnet": 1,
+			"Uncommon Optics": 1,
+			"Ag-Li Reinforced Glass": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Laser Agile Thermic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 0.67,
+		"volume": 2,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Explosive Module": 1,
+			"Uncommon Optics": 1,
+			"Al-Li Alloy": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Laser Defense Thermic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 0.65,
+		"volume": 2,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Explosive Module": 1,
+			"Uncommon Optics": 1,
+			"Polysulfide Plastic": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Laser Heavy Thermic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 0.79,
+		"volume": 2,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Explosive Module": 1,
+			"Uncommon Optics": 1,
+			"Inconel": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Laser Precision Thermic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 0.67,
+		"volume": 2,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Explosive Module": 1,
+			"Uncommon Optics": 1,
+			"Ag-Li Reinforced Glass": 1,
+			"Uncommon Casing XS": 1
+		}
+	},
+	"Laser Thermic Ammo XS": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 0.6,
+		"volume": 2,
+		"outputQuantity": 40,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Explosive Module": 1,
+			"Basic Optics": 1,
+			"Basic Casing XS": 1
+		}
+	},
+	"Laser Agile Electromagnetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 3.21,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Magnet": 2,
+			"Uncommon Optics": 2,
+			"Al-Li Alloy": 2,
+			"Uncommon Casing XS": 2
+		}
+	},
+	"Laser Defense Electromagnetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 3.18,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Magnet": 2,
+			"Uncommon Optics": 2,
+			"Polysulfide Plastic": 2,
+			"Uncommon Casing XS": 2
+		}
+	},
+	"Laser Electromagnetic Ammo S": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 3.03,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Magnet": 2,
+			"Basic Optics": 2,
+			"Basic Casing XS": 2
+		}
+	},
+	"Laser Heavy Electromagnetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 3.45,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Magnet": 2,
+			"Uncommon Optics": 2,
+			"Inconel": 2,
+			"Uncommon Casing XS": 2
+		}
+	},
+	"Laser Precision Electromagnetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 3.23,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Magnet": 2,
+			"Uncommon Optics": 2,
+			"Ag-Li Reinforced Glass": 2,
+			"Uncommon Casing XS": 2
+		}
+	},
+	"Laser Agile Thermic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.44,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Explosive Module": 2,
+			"Uncommon Optics": 2,
+			"Al-Li Alloy": 2,
+			"Uncommon Casing XS": 2
+		}
+	},
+	"Laser Defense Thermic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.4,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Explosive Module": 2,
+			"Uncommon Optics": 2,
+			"Polysulfide Plastic": 2,
+			"Uncommon Casing XS": 2
+		}
+	},
+	"Laser Heavy Thermic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.68,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Explosive Module": 2,
+			"Uncommon Optics": 2,
+			"Inconel": 2,
+			"Uncommon Casing XS": 2
+		}
+	},
+	"Laser Precision Thermic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.45,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Explosive Module": 2,
+			"Uncommon Optics": 2,
+			"Ag-Li Reinforced Glass": 2,
+			"Uncommon Casing XS": 2
+		}
+	},
+	"Laser Thermic Ammo S": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 1.31,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Explosive Module": 2,
+			"Basic Optics": 2,
+			"Basic Casing XS": 2
+		}
+	},
+	"Laser Agile Electromagnetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 7.19,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Magnet": 4,
+			"Uncommon Optics": 4,
+			"Al-Li Alloy": 4,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Defense Electromagnetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 7.12,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Magnet": 4,
+			"Uncommon Optics": 4,
+			"Polysulfide Plastic": 4,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Electromagnetic Ammo M": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 6.78,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Magnet": 4,
+			"Basic Optics": 4,
+			"Basic Casing S": 1
+		}
+	},
+	"Laser Heavy Electromagnetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 7.67,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Magnet": 4,
+			"Uncommon Optics": 4,
+			"Inconel": 4,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Precision Electromagnetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 7.22,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Magnet": 4,
+			"Uncommon Optics": 4,
+			"Ag-Li Reinforced Glass": 4,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Agile Thermic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 3.64,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Explosive Module": 4,
+			"Uncommon Optics": 4,
+			"Al-Li Alloy": 4,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Defense Thermic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 3.56,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Explosive Module": 4,
+			"Uncommon Optics": 4,
+			"Polysulfide Plastic": 4,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Heavy Thermic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 3.56,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Explosive Module": 4,
+			"Uncommon Optics": 4,
+			"Inconel": 4,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Precision Thermic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 4.12,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Explosive Module": 4,
+			"Uncommon Optics": 4,
+			"Ag-Li Reinforced Glass": 4,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Thermic Ammo M": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 3.34,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Explosive Module": 4,
+			"Basic Optics": 4,
+			"Basic Casing S": 1
+		}
+	},
+	"Laser Agile Electromagnetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 19.77,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Magnet": 8,
+			"Uncommon Optics": 8,
+			"Al-Li Alloy": 8,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Defense Electromagnetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 19.62,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Magnet": 8,
+			"Uncommon Optics": 8,
+			"Polysulfide Plastic": 8,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Electromagnetic Ammo L": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 18.7,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Magnet": 8,
+			"Basic Optics": 8,
+			"Basic Casing S": 1
+		}
+	},
+	"Laser Heavy Electromagnetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 20.73,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Magnet": 8,
+			"Uncommon Optics": 8,
+			"Inconel": 8,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Precision Electromagnetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 19.81,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Magnet": 8,
+			"Uncommon Optics": 8,
+			"Ag-Li Reinforced Glass": 8,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Agile Thermic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 12.65,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Explosive Module": 8,
+			"Uncommon Optics": 8,
+			"Al-Li Alloy": 8,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Defense Thermic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 12.51,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Explosive Module": 8,
+			"Uncommon Optics": 8,
+			"Polysulfide Plastic": 8,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Heavy Thermic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 13.61,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Explosive Module": 8,
+			"Uncommon Optics": 8,
+			"Inconel": 8,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Precision Thermic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 12.7,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Explosive Module": 8,
+			"Uncommon Optics": 8,
+			"Ag-Li Reinforced Glass": 8,
+			"Uncommon Casing S": 1
+		}
+	},
+	"Laser Thermic Ammo L": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 11.81,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Explosive Module": 8,
+			"Basic Optics": 8,
+			"Basic Casing S": 1
+		}
+	},
+	"Missile Agile Antimatter Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 0.94,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 1,
+			"Uncommon Processor": 1,
+			"Al-Li Alloy": 1,
+			"Uncommon Standard Frame XS": 1
+		}
+	},
+	"Missile Antimatter Ammo XS": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 0.87,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Anti-Matter Capsule": 1,
+			"Basic Processor": 1,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Missile Defense Antimatter Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 0.92,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 1,
+			"Uncommon Processor": 1,
+			"Polysulfide Plastic": 1,
+			"Uncommon Standard Frame XS": 1
+		}
+	},
+	"Missile Heavy Antimatter Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.06,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 1,
+			"Uncommon Processor": 1,
+			"Inconel": 1,
+			"Uncommon Standard Frame XS": 1
+		}
+	},
+	"Missile Precision Antimatter Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 0.95,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 1,
+			"Uncommon Processor": 1,
+			"Ag-Li Reinforced Glass": 1,
+			"Uncommon Standard Frame XS": 1
+		}
+	},
+	"Missile Agile Kinetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.37,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Solid Warhead": 1,
+			"Uncommon Processor": 1,
+			"Al-Li Alloy": 1,
+			"Uncommon Standard Frame XS": 1
+		}
+	},
+	"Missile Defense Kinetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.35,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Solid Warhead": 1,
+			"Uncommon Processor": 1,
+			"Polysulfide Plastic": 1,
+			"Uncommon Standard Frame XS": 1
+		}
+	},
+	"Missile Heavy Kinetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.49,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Solid Warhead": 1,
+			"Uncommon Processor": 1,
+			"Inconel": 1,
+			"Uncommon Standard Frame XS": 1
+		}
+	},
+	"Missile Kinetic Ammo XS": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 1.29,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Solid Warhead": 1,
+			"Basic Processor": 2,
+			"Basic Standard Frame XS": 1
+		}
+	},
+	"Missile Precision Kinetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 1.38,
+		"volume": 5,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Solid Warhead": 1,
+			"Uncommon Processor": 1,
+			"Ag-Li Reinforced Glass": 1,
+			"Uncommon Standard Frame XS": 1
+		}
+	},
+	"Missile Agile Antimatter Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 2.16,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 2,
+			"Uncommon Processor": 2,
+			"Al-Li Alloy": 2,
+			"Uncommon Standard Frame XS": 2
+		}
+	},
+	"Missile Antimatter Ammo S": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 2.16,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Anti-Matter Capsule": 2,
+			"Basic Processor": 2,
+			"Basic Standard Frame XS": 2
+		}
+	},
+	"Missile Defense Antimatter Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 2.12,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 2,
+			"Uncommon Processor": 2,
+			"Polysulfide Plastic": 2,
+			"Uncommon Standard Frame XS": 2
+		}
+	},
+	"Missile Heavy Antimatter Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 2.4,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 2,
+			"Uncommon Processor": 2,
+			"Inconel": 2,
+			"Uncommon Standard Frame XS": 2
+		}
+	},
+	"Missile Precision Antimatter Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 2.17,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 2,
+			"Uncommon Processor": 2,
+			"Ag-Li Reinforced Glass": 2,
+			"Uncommon Standard Frame XS": 2
+		}
+	},
+	"Missile Agile Kinetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 3.02,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Solid Warhead": 2,
+			"Uncommon Processor": 2,
+			"Al-Li Alloy": 2,
+			"Uncommon Standard Frame XS": 2
+		}
+	},
+	"Missile Defense Kinetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 2.99,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Solid Warhead": 2,
+			"Uncommon Processor": 2,
+			"Polysulfide Plastic": 2,
+			"Uncommon Standard Frame XS": 2
+		}
+	},
+	"Missile Heavy Kinetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 3.26,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Solid Warhead": 2,
+			"Uncommon Processor": 2,
+			"Inconel": 2,
+			"Uncommon Standard Frame XS": 2
+		}
+	},
+	"Missile Kinetic Ammo S": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 2.87,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Solid Warhead": 2,
+			"Basic Processor": 2,
+			"Basic Standard Frame XS": 2
+		}
+	},
+	"Missile Precision Kinetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 3.03,
+		"volume": 25,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Solid Warhead": 2,
+			"Uncommon Processor": 2,
+			"Ag-Li Reinforced Glass": 2,
+			"Uncommon Standard Frame XS": 2
+		}
+	},
+	"Missile Agile Antimatter Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 6.41,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 4,
+			"Uncommon Processor": 4,
+			"Al-Li Alloy": 4,
+			"Uncommon Standard Frame S": 1
+		}
+	},
+	"Missile Antimatter Ammo M": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 6.24,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Anti-Matter Capsule": 4,
+			"Basic Processor": 4,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Missile Defense Antimatter Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 6.33,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 4,
+			"Uncommon Processor": 4,
+			"Polysulfide Plastic": 4,
+			"Uncommon Standard Frame S": 1
+		}
+	},
+	"Missile Heavy Antimatter Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 6.89,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 4,
+			"Uncommon Processor": 4,
+			"Inconel": 4,
+			"Uncommon Standard Frame S": 1
+		}
+	},
+	"Missile Precision Antimatter Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 6.43,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 4,
+			"Uncommon Processor": 4,
+			"Ag-Li Reinforced Glass": 4,
+			"Uncommon Standard Frame S": 1
+		}
+	},
+	"Missile Agile Kinetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 8.13,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Solid Warhead": 4,
+			"Uncommon Processor": 4,
+			"Al-Li Alloy": 4,
+			"Uncommon Standard Frame S": 1
+		}
+	},
+	"Missile Defense Kinetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 8.06,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Solid Warhead": 4,
+			"Uncommon Processor": 4,
+			"Polysulfide Plastic": 4,
+			"Uncommon Standard Frame S": 1
+		}
+	},
+	"Missile Heavy Kinetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 8.61,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Solid Warhead": 4,
+			"Uncommon Processor": 4,
+			"Inconel": 4,
+			"Uncommon Standard Frame S": 1
+		}
+	},
+	"Missile Kinetic Ammo M": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 7.92,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Solid Warhead": 4,
+			"Basic Processor": 4,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Missile Precision Kinetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 8.15,
+		"volume": 125,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Solid Warhead": 4,
+			"Uncommon Processor": 4,
+			"Ag-Li Reinforced Glass": 4,
+			"Uncommon Standard Frame S": 1
+		}
+	},
+	"Missile Agile Antimatter Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 27.54,
+		"volume": 625,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 8,
+			"Uncommon Processor": 8,
+			"Al-Li Alloy": 8,
+			"Uncommon Standard Frame S": 2
+		}
+	},
+	"Missile Antimatter Ammo L": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 27.9,
+		"volume": 625,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Anti-Matter Capsule": 8,
+			"Basic Processor": 8,
+			"Basic Standard Frame S": 2
+		}
+	},
+	"Missile Defense Antimatter Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 6.33,
+		"volume": 625,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 8,
+			"Uncommon Processor": 8,
+			"Polysulfide Plastic": 8,
+			"Uncommon Standard Frame S": 2
+		}
+	},
+	"Missile Heavy Antimatter Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 27.4,
+		"volume": 625,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 8,
+			"Uncommon Processor": 8,
+			"Inconel": 8,
+			"Uncommon Standard Frame S": 2
+		}
+	},
+	"Missile Precision Antimatter Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 27.59,
+		"volume": 625,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 8,
+			"Uncommon Processor": 8,
+			"Ag-Li Reinforced Glass": 8,
+			"Uncommon Standard Frame S": 2
+		}
+	},
+	"Missile Agile Kinetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 30.99,
+		"volume": 625,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Solid Warhead": 8,
+			"Uncommon Processor": 8,
+			"Al-Li Alloy": 8,
+			"Uncommon Standard Frame S": 2
+		}
+	},
+	"Missile Defense Kinetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 30.84,
+		"volume": 625,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Solid Warhead": 8,
+			"Uncommon Processor": 8,
+			"Polysulfide Plastic": 8,
+			"Uncommon Standard Frame S": 2
+		}
+	},
+	"Missile Heavy Kinetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 31.95,
+		"volume": 625,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Solid Warhead": 8,
+			"Uncommon Processor": 8,
+			"Inconel": 8,
+			"Uncommon Standard Frame S": 2
+		}
+	},
+	"Missile Kinetic Ammo L": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 31.26,
+		"volume": 625,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Solid Warhead": 8,
+			"Basic Processor": 8,
+			"Basic Standard Frame S": 2
+		}
+	},
+	"Missile Precision Kinetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 31.04,
+		"volume": 625,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Solid Warhead": 8,
+			"Uncommon Processor": 8,
+			"Ag-Li Reinforced Glass": 8,
+			"Uncommon Standard Frame S": 2
+		}
+	},
+	"Railgun Agile Antimatter Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 2.04,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 1,
+			"Uncommon Magnet": 1,
+			"Al-Li Alloy": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Railgun Antimatter Ammo XS": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 2.01,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Anti-Matter Capsule": 1,
+			"Basic Magnet": 1,
+			"Basic Reinforced Frame XS": 1
+		}
+	},
+	"Railgun Defense Antimatter Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 2.02,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 1,
+			"Uncommon Magnet": 1,
+			"Polysulfide Plastic": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Railgun Heavy Antimatter Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 2.16,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 1,
+			"Uncommon Magnet": 1,
+			"Inconel": 2,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Railgun Precision Antimatter Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 2.05,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 1,
+			"Uncommon Magnet": 1,
+			"Ag-Li Reinforced Glass": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Railgun Agile Electromagnetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 2.77,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Magnet": 1,
+			"Uncommon Magnet": 1,
+			"Al-Li Alloy": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Railgun Defense Electromagnetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 2.8,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Magnet": 1,
+			"Uncommon Magnet": 1,
+			"Polysulfide Plastic": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Railgun Electromagnetic Ammo XS": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 6.43,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Magnet": 1,
+			"Basic Magnet": 1,
+			"Basic Reinforced Frame XS": 1
+		}
+	},
+	"Railgun Heavy Electromagnetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 2.94,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Magnet": 1,
+			"Uncommon Magnet": 1,
+			"Inconel": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Railgun Precision Electromagnetic Ammo XS": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 2.83,
+		"volume": 10,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Advanced Magnet": 1,
+			"Uncommon Magnet": 1,
+			"Ag-Li Reinforced Glass": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Railgun Agile Antimatter Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 4.96,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 2,
+			"Uncommon Magnet": 2,
+			"Al-Li Alloy": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Railgun Antimatter Ammo S": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 4.92,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Anti-Matter Capsule": 2,
+			"Basic Magnet": 2,
+			"Basic Reinforced Frame XS": 2
+		}
+	},
+	"Railgun Defense Antimatter Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 4.93,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 2,
+			"Uncommon Magnet": 2,
+			"Polysulfide Plastic": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Railgun Heavy Antimatter Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 5.2,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 2,
+			"Uncommon Magnet": 2,
+			"Inconel": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Railgun Precision Antimatter Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 4.97,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 2,
+			"Uncommon Magnet": 2,
+			"Ag-Li Reinforced Glass": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Railgun Agile Electromagnetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 6.52,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Magnet": 2,
+			"Uncommon Magnet": 2,
+			"Al-Li Alloy": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Railgun Defense Electromagnetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 6.49,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Magnet": 2,
+			"Uncommon Magnet": 2,
+			"Polysulfide Plastic": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Railgun Electromagnetic Ammo S": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 6.43,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 420,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Magnet": 2,
+			"Basic Magnet": 2,
+			"Basic Reinforced Frame XS": 2
+		}
+	},
+	"Railgun Heavy Electromagnetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 6.76,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Magnet": 2,
+			"Uncommon Magnet": 2,
+			"Inconel": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Railgun Precision Electromagnetic Ammo S": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 6.53,
+		"volume": 50,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Advanced Magnet": 2,
+			"Uncommon Magnet": 2,
+			"Ag-Li Reinforced Glass": 2,
+			"Uncommon Reinforced Frame XS": 2
+		}
+	},
+	"Railgun Agile Antimatter Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 16.45,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 4,
+			"Uncommon Magnet": 4,
+			"Al-Li Alloy": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Railgun Antimatter Ammo M": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 16.54,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Anti-Matter Capsule": 4,
+			"Basic Magnet": 4,
+			"Basic Reinforced Frame S": 1
+		}
+	},
+	"Railgun Defense Antimatter Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 16.38,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 4,
+			"Uncommon Magnet": 4,
+			"Polysulfide Plastic": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Railgun Heavy Antimatter Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 16.93,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 4,
+			"Uncommon Magnet": 4,
+			"Inconel": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Railgun Precision Antimatter Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 16.48,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 4,
+			"Uncommon Magnet": 4,
+			"Ag-Li Reinforced Glass": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Railgun Agile Electromagnetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 19.58,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Magnet": 4,
+			"Uncommon Magnet": 4,
+			"Al-Li Alloy": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Railgun Defense Electromagnetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 19.5,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Magnet": 4,
+			"Uncommon Magnet": 4,
+			"Polysulfide Plastic": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Railgun Electromagnetic Ammo M": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 19.56,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 780,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Uncommon Magnet": 4,
+			"Basic Magnet": 4,
+			"Basic Reinforced Frame S": 1
+		}
+	},
+	"Railgun Heavy Electromagnetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 20.06,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Magnet": 4,
+			"Uncommon Magnet": 4,
+			"Inconel": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Railgun Precision Electromagnetic Ammo M": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 19.6,
+		"volume": 250,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Advanced Magnet": 4,
+			"Uncommon Magnet": 4,
+			"Ag-Li Reinforced Glass": 4,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Railgun Agile Antimatter Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 79,
+		"volume": 1250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 8,
+			"Uncommon Magnet": 8,
+			"Al-Li Alloy": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Railgun Antimatter Ammo L": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 80.35,
+		"volume": 1250,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Anti-Matter Capsule": 8,
+			"Basic Magnet": 8,
+			"Basic Reinforced Frame S": 2
+		}
+	},
+	"Railgun Defense Antimatter Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 78.86,
+		"volume": 1250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 8,
+			"Uncommon Magnet": 8,
+			"Polysulfide Plastic": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Railgun Heavy Antimatter Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 79.96,
+		"volume": 1250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 8,
+			"Uncommon Magnet": 8,
+			"Inconel": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Railgun Precision Antimatter Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 79.05,
+		"volume": 1250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Anti-Matter Capsule": 8,
+			"Uncommon Magnet": 8,
+			"Ag-Li Reinforced Glass": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Railgun Agile Electromagnetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 85.24,
+		"volume": 1250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Magnet": 8,
+			"Uncommon Magnet": 8,
+			"Al-Li Alloy": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Railgun Defense Electromagnetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 85.1,
+		"volume": 1250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Magnet": 8,
+			"Uncommon Magnet": 8,
+			"Polysulfide Plastic": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Railgun Electromagnetic Ammo L": {
+		"tier": 2,
+		"type": "Uncommon Ammo",
+		"mass": 86.4,
+		"volume": 1250,
+		"outputQuantity": 40,
+		"time": 1620,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Magnet": 8,
+			"Basic Magnet": 8,
+			"Basic Reinforced Frame S": 2
+		}
+	},
+	"Railgun Heavy Electromagnetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 86.2,
+		"volume": 1250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Magnet": 8,
+			"Uncommon Magnet": 8,
+			"Inconel": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Railgun Precision Electromagnetic Ammo L": {
+		"tier": 3,
+		"type": "Advanced Ammo",
+		"mass": 85.29,
+		"volume": 1250,
+		"outputQuantity": 40,
+		"time": 3180,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Advanced Magnet": 8,
+			"Uncommon Magnet": 8,
+			"Ag-Li Reinforced Glass": 8,
+			"Uncommon Reinforced Frame S": 2
+		}
+	},
+	"Warp Cell": {
+		"tier": 3,
+		"type": "Warp Cell",
+		"mass": 100,
+		"volume": 40,
+		"outputQuantity": 1,
+		"time": 3000,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Glass Furnace M"
+		],
+		"input": {
+			"Advanced Quantum Alignment Unit": 1,
+			"Advanced Anti-Matter Core Unit": 1
+		}
+	},
+	"Warp Drive L": {
+		"tier": 1,
+		"type": "Warp Drive Unit",
+		"mass": 31360,
+		"volume": 75,
+		"outputQuantity": 1,
+		"time": 86400,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Magnet": 125,
+			"Advanced Ionic Chamber L": 1,
+			"Advanced Anti-Matter Core Unit": 64,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Warp Beacon XL": {
+		"tier": 5,
+		"type": "Warp Beacon Unit",
+		"mass": 148940,
+		"volume": 25360,
+		"outputQuantity": 1,
+		"time": 3110400,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Advanced LED": 1296,
+			"Exotic Power System": 625,
+			"Exotic Antenna XL": 1,
+			"Exotic Quantum Alignment Unit": 256,
+			"Exotic Reinforced Frame XL": 1
+		}
+	},
+	"Hatch S": {
+		"tier": 1,
+		"type": "Door/Gate",
+		"mass": 229.09,
+		"volume": 64,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Silumin": 7,
+			"Basic Fixation": 6,
+			"Basic Reinforced Frame S": 1
+		}
+	},
+	"Fuel Intake XS": {
+		"tier": 1,
+		"type": "Door/Gate",
+		"mass": 4.12,
+		"volume": 2,
+		"outputQuantity": 1,
+		"time": 18,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line XS"
+		],
+		"input": {
+			"Silumin": 2,
+			"Basic Fixation": 1
+		}
+	},
+	"Freight Atmospheric Engine XS": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 101.88,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Injector": 1,
+			"Uncommon Combustion Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Safe Atmospheric Engine XS": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 101.88,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Injector": 1,
+			"Uncommon Combustion Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Maneuver Atmospheric Engine XS": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 101.88,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Injector": 1,
+			"Uncommon Combustion Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Military Atmospheric Engine XS": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 101.88,
+		"volume": 22.6,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Injector": 1,
+			"Uncommon Combustion Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Freight Atmospheric Engine S": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 539.99,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Injector": 5,
+			"Uncommon Combustion Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Maneuver Atmospheric Engine S": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 539.99,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Injector": 5,
+			"Uncommon Combustion Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Military Atmospheric Engine S": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 539.99,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Injector": 5,
+			"Uncommon Combustion Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Safe Atmospheric Engine S": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 539.99,
+		"volume": 116.6,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Injector": 5,
+			"Uncommon Combustion Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Freight Atmospheric Engine M": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 2980,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Injector": 25,
+			"Uncommon Combustion Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Maneuver Atmospheric Engine M": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 2980,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Injector": 25,
+			"Uncommon Combustion Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Military Atmospheric Engine M": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 2980,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Injector": 25,
+			"Uncommon Combustion Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Safe Atmospheric Engine M": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 2980,
+		"volume": 619.2,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Injector": 25,
+			"Uncommon Combustion Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Freight Atmospheric Engine L": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 16930,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Injector": 125,
+			"Uncommon Combustion Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Maneuver Atmospheric Engine L": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 16930,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Injector": 125,
+			"Uncommon Combustion Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Military Atmospheric Engine L": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 16930,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Injector": 125,
+			"Uncommon Combustion Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Safe Atmospheric Engine L": {
+		"tier": 2,
+		"type": "Atmospheric Engine",
+		"mass": 16930,
+		"volume": 3355.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Injector": 125,
+			"Uncommon Combustion Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Freight Space Engine XS": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 146.23,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Burner": 1,
+			"Uncommon Ionic Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Maneuver Space Engine XS": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 146.23,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Burner": 1,
+			"Uncommon Ionic Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Military Space Engine XS": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 146.23,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Burner": 1,
+			"Uncommon Ionic Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Safe Space Engine XS": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 146.23,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 360,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Basic Screw": 1,
+			"Uncommon Screw": 1,
+			"Uncommon Burner": 1,
+			"Uncommon Ionic Chamber XS": 1,
+			"Uncommon Reinforced Frame XS": 1
+		}
+	},
+	"Freight Space Engine S": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 761.74,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Burner": 5,
+			"Uncommon Ionic Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Maneuver Space Engine S": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 761.74,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Burner": 5,
+			"Uncommon Ionic Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Military Space Engine S": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 761.74,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Burner": 5,
+			"Uncommon Ionic Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Safe Space Engine S": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 761.74,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 1440,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Screw": 3,
+			"Uncommon Screw": 3,
+			"Uncommon Burner": 5,
+			"Uncommon Ionic Chamber S": 1,
+			"Uncommon Reinforced Frame S": 1
+		}
+	},
+	"Freight Space Engine M": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 4090,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Burner": 25,
+			"Uncommon Ionic Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Maneuver Space Engine M": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 4090,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Burner": 25,
+			"Uncommon Ionic Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Military Space Engine M": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 4090,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Burner": 25,
+			"Uncommon Ionic Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Safe Space Engine M": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 4090,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 5760,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line M"
+		],
+		"input": {
+			"Basic Screw": 18,
+			"Uncommon Screw": 18,
+			"Uncommon Burner": 25,
+			"Uncommon Ionic Chamber M": 1,
+			"Uncommon Reinforced Frame M": 1
+		}
+	},
+	"Freight Space Engine L": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 22470,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Burner": 125,
+			"Uncommon Ionic Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Maneuver Space Engine L": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 22470,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Burner": 125,
+			"Uncommon Ionic Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Military Space Engine L": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 22470,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Burner": 125,
+			"Uncommon Ionic Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Safe Space Engine L": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 22470,
+		"volume": 3071.4,
+		"outputQuantity": 1,
+		"time": 23040,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Basic Screw": 108,
+			"Uncommon Screw": 108,
+			"Uncommon Burner": 125,
+			"Uncommon Ionic Chamber L": 1,
+			"Uncommon Reinforced Frame L": 1
+		}
+	},
+	"Freight Space Engine XL": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 126240,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 92160,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 648,
+			"Uncommon Screw": 648,
+			"Uncommon Burner": 625,
+			"Uncommon Ionic Chamber XL": 1,
+			"Uncommon Reinforced Frame XL": 1
+		}
+	},
+	"Maneuver Space Engine XL": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 126240,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 92160,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 648,
+			"Uncommon Screw": 648,
+			"Uncommon Burner": 625,
+			"Uncommon Ionic Chamber XL": 1,
+			"Uncommon Reinforced Frame XL": 1
+		}
+	},
+	"Military Space Engine XL": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 126240,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 92160,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 648,
+			"Uncommon Screw": 648,
+			"Uncommon Burner": 625,
+			"Uncommon Ionic Chamber XL": 1,
+			"Uncommon Reinforced Frame XL": 1
+		}
+	},
+	"Safe Space Engine XL": {
+		"tier": 2,
+		"type": "Space Engine",
+		"mass": 126240,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 92160,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Basic Screw": 648,
+			"Uncommon Screw": 648,
+			"Uncommon Burner": 625,
+			"Uncommon Ionic Chamber XL": 1,
+			"Uncommon Reinforced Frame XL": 1
+		}
+	},
+	"Advanced Space Engine XS": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 146.23,
+		"volume": 20.33,
+		"outputQuantity": 1,
+		"time": 1080,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XS"
+		],
+		"input": {
+			"Uncommon Screw": 1,
+			"Advanced Burner": 1,
+			"Advanced Ionic Chamber XS": 1,
+			"Advanced Reinforced Frame XS": 1
+		}
+	},
+	"Advanced Space Engine S": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 761.74,
+		"volume": 105.24,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Burner": 5,
+			"Advanced Ionic Chamber S": 1,
+			"Advanced Reinforced Frame S": 1
+		}
+	},
+	"Advanced Space Engine M": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 4090,
+		"volume": 562.4,
+		"outputQuantity": 1,
+		"time": 69120,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Screw": 216,
+			"Advanced Burner": 125,
+			"Advanced Ionic Chamber L": 1,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Advanced Space Engine XL": {
+		"tier": 3,
+		"type": "Space Engine",
+		"mass": 126240,
+		"volume": 17150,
+		"outputQuantity": 1,
+		"time": 259500,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line XL"
+		],
+		"input": {
+			"Uncommon Screw": 1296,
+			"Advanced Burner": 625,
+			"Advanced Ionic Chamber XL": 1,
+			"Advanced Reinforced Frame XL": 1
+		}
+	},
+	"Repair Unit": {
+		"tier": 1,
+		"type": "Combat Element",
+		"mass": 400,
+		"volume": 0,
+		"outputQuantity": 1,
+		"time": 86400,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line L"
+		],
+		"input": {
+			"Uncommon Component": 216,
+			"Advanced Hydraulics": 125,
+			"Advanced Magnetic Rail L": 1,
+			"Advanced Anti-Matter Core Unit": 64,
+			"Advanced Reinforced Frame L": 1
+		}
+	},
+	"Surrogate Pod Station": {
+		"tier": 1,
+		"type": "Surrogate Element",
+		"mass": 569.52,
+		"volume": 360,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Component": 6,
+			"Advanced Hydraulics": 5,
+			"Advanced Antenna S": 1,
+			"Advanced Standard Frame S": 1
+		}
+	},
+	"Surrogate VR Station": {
+		"tier": 1,
+		"type": "Surrogate Element",
+		"mass": 742.42,
+		"volume": 360.2,
+		"outputQuantity": 1,
+		"time": 480,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Nanopack",
+			"Assembly Line S"
+		],
+		"input": {
+			"Basic Component": 6,
+			"Basic Processor": 5,
+			"Basic Screen S": 1,
+			"Basic Standard Frame S": 1
+		}
+	},
+	"Transponder": {
+		"tier": 3,
+		"type": "Radar",
+		"mass": 340,
+		"volume": 97,
+		"outputQuantity": 1,
+		"time": 4320,
+		"skill": "Systems",
+		"byproducts": {},
+		"industries": [
+			"Assembly Line S"
+		],
+		"input": {
+			"Uncommon Screw": 6,
+			"Advanced Processor": 5,
+			"Advanced Antenna S": 1,
+			"Advanced Standard Frame S": 1
+		}
+	}
 }

--- a/data/skillsAccordion.json
+++ b/data/skillsAccordion.json
@@ -1,1424 +1,2651 @@
 [
-  {
-    "name": "Basic Ore/Pure",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Pure",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Aluminium Pure",
-			  "Carbon Pure",
-			  "Iron Pure",
-			  "Silicon Pure"
-			],
-			"targets":[
-				{"type":"Time","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Pure",
-			"subject":"Recipe",
-			"data": [
-			  "Aluminium Pure",
-			  "Carbon Pure",
-			  "Iron Pure",
-			  "Silicon Pure"
-			],
-			"targets":[
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Uncommon Ore/Pure",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Pure",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Calcium Pure",
-			  "Chromium Pure",
-			  "Copper Pure",
-			  "Sodium Pure"
-			],
-			"targets":[
-				{"type":"Time","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Pure",
-			"subject":"Recipe",
-			"data": [
-			  "Calcium Pure",
-			  "Chromium Pure",
-			  "Copper Pure",
-			  "Sodium Pure"
-			],
-			"targets":[
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Advanced Ore/Pure",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Pure",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Lithium Pure",
-			  "Nickel Pure",
-			  "Silver Pure",
-			  "Sulfur Pure"
-			],
-			"targets":[
-				{"type":"Time","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Pure",
-			"subject":"Recipe",
-			"data": [
-			  "Lithium Pure",
-			  "Nickel Pure",
-			  "Silver Pure",
-			  "Sulfur Pure"
-			],
-			"targets":[
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Rare Ore/Pure",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Pure",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Cobalt Pure",
-			  "Fluorine Pure",
-			  "Gold Pure",
-			  "Scandium Pure"
-			],
-			"targets":[
-				{"type":"Time","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Pure",
-			"subject":"Recipe",
-			"data": [
-			  "Cobalt Pure",
-			  "Fluorine Pure",
-			  "Gold Pure",
-			  "Scandium Pure"
-			],
-			"targets":[
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Exotic Ore/Pure",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Pure",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Manganese Pure",
-			  "Niobium Pure",
-			  "Titanium Pure",
-			  "Vanadium Pure"
-			],
-			"targets":[
-				{"type":"Time","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Pure",
-			"subject":"Recipe",
-			"data": [
-			  "Manganese Pure",
-			  "Niobium Pure",
-			  "Titanium Pure",
-			  "Vanadium Pure"
-			],
-			"targets":[
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true}
-			]
-		}
-	]
-  },
-  {
-	"name": "Basic Product",
-	"data":[
-		{
-			"name":"Refining",
-			"target": "Product",
-			"data":[
-				"Efficiency",
-				"Al-Fe Alloy",
-				"Polycarbonate Plastic",
-				"Silumin",
-				"Steel",
-				"Glass"
-			],
-			"targets":[
-				{"type":"Time","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"data":[
-				"Al-Fe Alloy",
-				"Polycarbonate Plastic",
-				"Silumin",
-				"Steel",
-				"Glass"
-			],
-			"targets":[
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true}
-			]
-		}
-	]
-  },
-  {
-	"name": "Uncommon Product",
-	"data":[
-		{
-			"name":"Refining",
-			"target": "Product",
-			"data":[
-				"Efficiency",
-				"Calcium Reinforced Copper",
-				"Duralumin",
-				"Stainless Steel",
-				"Polycalcite Plastic",
-				"Advanced Glass"
-			],
-			"targets":[
-				{"type":"Time","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"data":[
-				"Calcium Reinforced Copper",
-				"Duralumin",
-				"Stainless Steel",
-				"Polycalcite Plastic",
-				"Advanced Glass"
-			],
-			"targets":[
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true}
-			]
-		}
-	]
-  },
-  {
-	"name": "Advanced Product",
-	"data":[
-		{
-			"name":"Refining",
-			"target": "Product",
-			"data":[
-				"Efficiency",
-				"Cu-Ag Alloy",
-				"Al-Li Alloy",
-				"Inconel",
-				"Polysulfide Plastic",
-				"Ag-Li Reinforced Glass"
-			],
-			"targets":[
-				{"type":"Time","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"data":[
-				"Cu-Ag Alloy",
-				"Al-Li Alloy",
-				"Inconel",
-				"Polysulfide Plastic",
-				"Ag-Li Reinforced Glass"
-			],
-			"targets":[
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true}
-			]
-		}
-	]
-  },
-  {
-	"name": "Rare Product",
-	"data":[
-		{
-			"name":"Refining",
-			"target": "Product",
-			"data":[
-				"Efficiency",
-				"Red Gold",
-				"Fluoropolymer",
-				"Sc-Al Alloy",
-				"Maraging Steel",
-				"Gold Coated Glass"
-			],
-			"targets":[
-				{"type":"Time","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"data":[
-				"Red Gold",
-				"Fluoropolymer",
-				"Sc-Al Alloy",
-				"Maraging Steel",
-				"Gold Coated Glass"
-			],
-			"targets":[
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true}
-			]
-		}
-	]
-  },
-  {
-	"name": "Exotic Product",
-	"data":[
-		{
-			"name":"Refining",
-			"target": "Product",
-			"data":[
-				"Efficiency",
-				"Ti-Nb Supraconductor",
-				"Vanamer",
-				"Grade 5 Titanium Alloy",
-				"Mangalloy",
-				"Manganese Reinforced Glass"
-			],
-			"targets":[
-				{"type":"Time","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"data":[
-				"Ti-Nb Supraconductor",
-				"Vanamer",
-				"Grade 5 Titanium Alloy",
-				"Mangalloy",
-				"Manganese Reinforced Glass"
-			],
-			"targets":[
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true},
-				{"type":"Output","amount":0.03,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Intermediary Part",
-    "data": [
-		{
-			"name":"Productivity",
-			"target":"Intermediary Part",
-			"subject":"Recipe",
-			"data":[
-				"Basic",
-				"Uncommon",
-				"Advanced"
-			],
-			"targets":[
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false}
-			]
-		},
-		{
-			"name":"Manufacturer",
-			"target":"Intermediary Part",
-			"subject":"Recipe",
-			"data":[
-				"Basic",
-				"Uncommon",
-				"Advanced"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Complex Part",
-    "data": [
-		{
-			"name":"Manufacturer",
-			"target":"Complex Part",
-			"subject":"Recipe",
-			"data":[
-				"Basic",
-				"Uncommon",
-				"Advanced",
-				"Rare",
-				"Exotic"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Exceptional Part",
-    "data": [
-		{
-			"name":"Manufacturer",
-			"target":"Exceptional Part",
-			"subject":"Recipe",
-			"data":[
-				"Advanced",
-				"Rare",
-				"Exotic"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Functional Part",
-    "data": [
-		{
-			"name":"Manufacturer",
-			"target":"Functional Part",
-			"subject":"Recipe",
-			"data":[
-				"Basic",
-				"Uncommon",
-				"Advanced",
-				"Rare",
-				"Exotic"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Structural Part",
-    "data": [
-		{
-			"name":"Manufacturer",
-			"target":"Structural Part",
-			"subject":"Recipe",
-			"data":[
-				"Basic",
-				"Uncommon",
-				"Advanced",
-				"Rare",
-				"Exotic"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Time","amount":0.1,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Uncommon Ammo",
-    "data": [
-		{
-			"name":"Productivity",
-			"target":"Uncommon Ammo",
-			"subject":"Recipe",
-			"data":[
-				"Efficiency",
-				"XS",
-				"S",
-				"M",
-				"L"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false}
-			]
-		}
-	]
-  },
-  {
-    "name": "Advanced Ammo",
-    "data": [
-		{
-			"name":"Productivity",
-			"target":"Advanced Ammo",
-			"subject":"Recipe",
-			"data":[
-				"Efficiency",
-				"XS",
-				"S",
-				"M",
-				"L"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false}
-			]
-		}
-	]
-  },
-  {
-    "name": "Fuel",
-    "data": [
-		{
-			"name":"Refining",
-			"target":"Fuel",
-			"subject":"Recipe",
-			"data":[
-				"Efficiency",
-				"Refinery",
-				"Nitron",
-				"Kergon",
-				"Xeron"
-			],
-			"targets":[
-				{"type":"Speed","amount":0.1,"relative":true},
-				{"type":"Input","amount":0.02,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true},
-				{"type":"Input","amount":0.03,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Fuel",
-			"subject":"Recipe",
-			"data":[
-				"Nitron",
-				"Kergon",
-				"Xeron"
-			],
-			"targets":[
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Basic Pure Honeycomb",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Pure Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Aluminium",
-			  "Carbon",
-			  "Iron",
-			  "Silicon"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Pure Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Aluminium",
-			  "Carbon",
-			  "Iron",
-			  "Silicon"
-			],
-			"targets":[
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Uncommon Pure Honeycomb",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Pure Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Calcium",
-			  "Chromium",
-			  "Copper",
-			  "Sodium"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Pure Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Calcium",
-			  "Chromium",
-			  "Copper",
-			  "Sodium"
-			],
-			"targets":[
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Advanced Pure Honeycomb",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Pure Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Lithium",
-			  "Nickel",
-			  "Silver",
-			  "Sulfur"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Pure Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Lithium",
-			  "Nickel",
-			  "Silver",
-			  "Sulfur"
-			],
-			"targets":[
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Rare Pure Honeycomb",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Pure Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Cobalt",
-			  "Fluorine",
-			  "Gold",
-			  "Scandium"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Pure Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Cobalt",
-			  "Fluorine",
-			  "Gold",
-			  "Scandium"
-			],
-			"targets":[
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Exotic Pure Honeycomb",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Pure Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Manganese",
-			  "Niobium",
-			  "Titanium",
-			  "Vanadium"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Pure Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Manganese",
-			  "Niobium",
-			  "Titanium",
-			  "Vanadium"
-			],
-			"targets":[
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Basic Product Honeycomb",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Product Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Polycarbonate",
-			  "Silumin",
-			  "Steel"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Product Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Polycarbonate",
-			  "Silumin",
-			  "Steel"
-			],
-			"targets":[
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Uncommon Product Honeycomb",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Product Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Polycalcite",
-			  "Duralumin",
-			  "Stainless Steel"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Product Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Polycalcite",
-			  "Duralumin",
-			  "Stainless Steel"
-			],
-			"targets":[
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Advanced Product Honeycomb",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Product Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Polysulfide",
-			  "Al-Li",
-			  "Inconel"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Product Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Polysulfide",
-			  "Al-Li",
-			  "Inconel"
-			],
-			"targets":[
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Rare Product Honeycomb",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Product Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Fluoropolymer",
-			  "Sc-Al",
-			  "Maraging Steel"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Product Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Fluoropolymer",
-			  "Sc-Al",
-			  "Maraging Steel"
-			],
-			"targets":[
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true}
-			]
-		}
-	]
-  },
-  {
-    "name": "Exotic Product Honeycomb",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Product Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Vanamer",
-			  "Grade 5 Titanium Alloy",
-			  "Mangalloy"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true},
-				{"type":"Input","amount":0.05,"relative":true}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Product Honeycomb",
-			"subject":"Recipe",
-			"data": [
-			  "Vanamer",
-			  "Grade 5 Titanium Alloy",
-			  "Mangalloy"
-			],
-			"targets":[
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true},
-				{"type":"Output","amount":0.05,"relative":true}
-			]
-		}
-	]
-  },
-  {
-	"name": "Industry",
-	"data":[
-		{
-			"name": "Assembly Line XS",
-			"target":"Assembly Line XS",
-			"subject":"Industry",
-			"data":[
-				"Efficiency",
-				"Handling"
-			],
-			"targets":[
-				{"type":"Time","amount":0.02,"relative":true},
-				{"type":"Time","amount":0.02,"relative":true}
-			]
-		},
-		{
-			"name": "Assembly Line S",
-			"target":"Assembly Line S",
-			"subject":"Industry",
-			"data":[
-				"Efficiency",
-				"Handling"
-			],
-			"targets":[
-				{"type":"Time","amount":0.02,"relative":true},
-				{"type":"Time","amount":0.02,"relative":true}
-			]
-		},
-		{
-			"name": "Assembly Line M",
-			"target":"Assembly Line M",
-			"subject":"Industry",
-			"data":[
-				"Efficiency",
-				"Handling"
-			],
-			"targets":[
-				{"type":"Time","amount":0.02,"relative":true},
-				{"type":"Time","amount":0.02,"relative":true}
-			]
-		},
-		{
-			"name": "Assembly Line L",
-			"target":"Assembly Line L",
-			"subject":"Industry",
-			"data":[
-				"Efficiency",
-				"Handling"
-			],
-			"targets":[
-				{"type":"Time","amount":0.02,"relative":true},
-				{"type":"Time","amount":0.02,"relative":true}
-			]
-		},
-		{
-			"name": "Assembly Line XL",
-			"target":"Assembly Line XL",
-			"subject":"Industry",
-			"data":[
-				"Efficiency",
-				"Handling"
-			],
-			"targets":[
-				{"type":"Time","amount":0.02,"relative":true},
-				{"type":"Time","amount":0.02,"relative":true}
-			]
-		},
-		{
-			"name": "Chemical",
-			"target":"Chemical Industry M",
-			"subject":"Industry",
-			"data":[
-				"Efficiency",
-				"Handling"
-			],
-			"targets":[
-				{"type":"Time","amount":0.02,"relative":true},
-				{"type":"Time","amount":0.02,"relative":true}
-			]
-		},
-		{
-			"name": "3D Printer",
-			"target":"3D Printer M",
-			"subject":"Industry",
-			"data":[
-				"Efficiency",
-				"Handling"
-			],
-			"targets":[
-				{"type":"Time","amount":0.02,"relative":true},
-				{"type":"Time","amount":0.02,"relative":true}
-			]
-		},
-		{
-			"name": "Glass Furnace",
-			"target":"Glass Furnace M",
-			"subject":"Industry",
-			"data":[
-				"Efficiency",
-				"Handling"
-			],
-			"targets":[
-				{"type":"Time","amount":0.02,"relative":true},
-				{"type":"Time","amount":0.02,"relative":true}
-			]
-		},
-		{
-			"name": "Metalworks",
-			"target":"Metalworks M",
-			"subject":"Industry",
-			"data":[
-				"Efficiency",
-				"Handling"
-			],
-			"targets":[
-				{"type":"Time","amount":0.02,"relative":true},
-				{"type":"Time","amount":0.02,"relative":true}
-			]
-		},
-		{
-			"name": "Electronics",
-			"target":"Electronics Industry M",
-			"subject":"Industry",
-			"data":[
-				"Efficiency",
-				"Handling"
-			],
-			"targets":[
-				{"type":"Time","amount":0.02,"relative":true},
-				{"type":"Time","amount":0.02,"relative":true}
-			]
-		}
-	]
-  },
-  {
-	"name": "Combat Element Efficiency",
-	"target":"Combat",
-	"subject":"Recipe",
-	"data":[
-		"Basic",
-		"Uncommon",
-		"Advanced",
-		"Rare",
-		"Exotic"
-	],
-	"targets":[
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true}
-	]
-  },
-  {
-	"name": "Furniture & Appliance Efficiency",
-	"target":"Furniture/Appliance",
-	"subject":"Recipe",
-	"data":[
-		"Basic",
-		"Uncommon",
-		"Advanced",
-		"Rare",
-		"Exotic"
-	],
-	"targets":[
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true}
-	]
-  },
-  {
-	"name": "Industry & Infrastructure Efficiency",
-	"target":"InIn",
-	"subject":"Recipe",
-	"data":[
-		"Basic",
-		"Uncommon",
-		"Advanced",
-		"Rare",
-		"Exotic"
-	],
-	"targets":[
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true}
-	]
-  },
-  {
-	"name": "Piloting Element Efficiency",
-	"target":"Piloting",
-	"subject":"Recipe",
-	"data":[
-		"Basic",
-		"Uncommon",
-		"Advanced",
-		"Rare",
-		"Exotic"
-	],
-	"targets":[
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true}
-	]
-  },
-  {
-	"name": "Systems Element Efficiency",
-	"target":"Systems",
-	"subject":"Recipe",
-	"data":[
-		"Basic",
-		"Uncommon",
-		"Advanced",
-		"Rare",
-		"Exotic"
-	],
-	"targets":[
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true},
-		{"type":"Time","amount":0.02,"relative":true}
-	]
-  },
-		{
-    "name": "Basic Scrap",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Scrap",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Refinery",
-			  "Aluminium",
-			  "Carbon",
-			  "Iron",
-			  "Silicon"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Input","amount":1,"relative":false},
-				{"type":"Input","amount":2,"relative":false},
-				{"type":"Input","amount":2,"relative":false},
-				{"type":"Input","amount":2,"relative":false},
-				{"type":"Input","amount":2,"relative":false}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Scrap",
-			"subject":"Recipe",
-			"data": [
-			  "Aluminium",
-			  "Carbon",
-			  "Iron",
-			  "Silicon"
-			],
-			"targets":[
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false}
-			]
-		}
-	]
-  },
-  {
-    "name": "Uncommon Scrap",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Scrap",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Refinery",
-			  "Calcium",
-			  "Chromium",
-			  "Copper",
-			  "Sodium"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Input","amount":1,"relative":false},
-				{"type":"Input","amount":2,"relative":false},
-				{"type":"Input","amount":2,"relative":false},
-				{"type":"Input","amount":2,"relative":false},
-				{"type":"Input","amount":2,"relative":false}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Scrap",
-			"subject":"Recipe",
-			"data": [
-			  "Calcium",
-			  "Chromium",
-			  "Copper",
-			  "Sodium"
-			],
-			"targets":[
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false}
-			]
-		}
-	]
-  },
-  {
-    "name": "Advanced Scrap",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Scrap",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Refinery",
-			  "Lithium",
-			  "Nickel",
-			  "Silver",
-			  "Sulfur"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Input","amount":1,"relative":false},
-				{"type":"Input","amount":2,"relative":false},
-				{"type":"Input","amount":2,"relative":false},
-				{"type":"Input","amount":2,"relative":false},
-				{"type":"Input","amount":2,"relative":false}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Scrap",
-			"subject":"Recipe",
-			"data": [
-			  "Lithium",
-			  "Nickel",
-			  "Silver",
-			  "Sulfur"
-			],
-			"targets":[
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false}
-			]
-		}
-	]
-  },
-  {
-    "name": "Rare Scrap",
-	"data":[
-		{
-			"name":"Refining",
-			"target":"Scrap",
-			"subject":"Recipe",
-			"data": [
-			  "Efficiency",
-			  "Refinery",
-			  "Cobalt",
-			  "Fluorine",
-			  "Gold",
-			  "Scandium"
-			],
-			"targets":[
-				{"type":"Time","amount":0.1,"relative":true},
-				{"type":"Input","amount":1,"relative":false},
-				{"type":"Input","amount":2,"relative":false},
-				{"type":"Input","amount":2,"relative":false},
-				{"type":"Input","amount":2,"relative":false},
-				{"type":"Input","amount":2,"relative":false}
-			]
-		},
-		{
-			"name":"Productivity",
-			"target":"Scrap",
-			"subject":"Recipe",
-			"data": [
-			  "Cobalt",
-			  "Fluorine",
-			  "Gold",
-			  "Scandium"
-			],
-			"targets":[
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false},
-				{"type":"Output","amount":1,"relative":false}
-			]
-		}
-	]
-  }
- 
+	{
+		"name": "Basic Ore/Pure",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Pure",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Aluminium Pure",
+					"Carbon Pure",
+					"Iron Pure",
+					"Silicon Pure"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Pure",
+				"subject": "Recipe",
+				"data": [
+					"Aluminium Pure",
+					"Carbon Pure",
+					"Iron Pure",
+					"Silicon Pure"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Uncommon Ore/Pure",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Pure",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Calcium Pure",
+					"Chromium Pure",
+					"Copper Pure",
+					"Sodium Pure"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Pure",
+				"subject": "Recipe",
+				"data": [
+					"Calcium Pure",
+					"Chromium Pure",
+					"Copper Pure",
+					"Sodium Pure"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Advanced Ore/Pure",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Pure",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Lithium Pure",
+					"Nickel Pure",
+					"Silver Pure",
+					"Sulfur Pure"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Pure",
+				"subject": "Recipe",
+				"data": [
+					"Lithium Pure",
+					"Nickel Pure",
+					"Silver Pure",
+					"Sulfur Pure"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Rare Ore/Pure",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Pure",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Cobalt Pure",
+					"Fluorine Pure",
+					"Gold Pure",
+					"Scandium Pure"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Pure",
+				"subject": "Recipe",
+				"data": [
+					"Cobalt Pure",
+					"Fluorine Pure",
+					"Gold Pure",
+					"Scandium Pure"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Exotic Ore/Pure",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Pure",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Manganese Pure",
+					"Niobium Pure",
+					"Titanium Pure",
+					"Vanadium Pure"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Pure",
+				"subject": "Recipe",
+				"data": [
+					"Manganese Pure",
+					"Niobium Pure",
+					"Titanium Pure",
+					"Vanadium Pure"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Basic Product",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Product",
+				"data": [
+					"Efficiency",
+					"Al-Fe Alloy",
+					"Polycarbonate Plastic",
+					"Silumin",
+					"Steel",
+					"Glass"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"data": [
+					"Al-Fe Alloy",
+					"Polycarbonate Plastic",
+					"Silumin",
+					"Steel",
+					"Glass"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Uncommon Product",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Product",
+				"data": [
+					"Efficiency",
+					"Calcium Reinforced Copper",
+					"Duralumin",
+					"Stainless Steel",
+					"Polycalcite Plastic",
+					"Advanced Glass"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"data": [
+					"Calcium Reinforced Copper",
+					"Duralumin",
+					"Stainless Steel",
+					"Polycalcite Plastic",
+					"Advanced Glass"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Advanced Product",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Product",
+				"data": [
+					"Efficiency",
+					"Cu-Ag Alloy",
+					"Al-Li Alloy",
+					"Inconel",
+					"Polysulfide Plastic",
+					"Ag-Li Reinforced Glass"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"data": [
+					"Cu-Ag Alloy",
+					"Al-Li Alloy",
+					"Inconel",
+					"Polysulfide Plastic",
+					"Ag-Li Reinforced Glass"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Rare Product",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Product",
+				"data": [
+					"Efficiency",
+					"Red Gold",
+					"Fluoropolymer",
+					"Sc-Al Alloy",
+					"Maraging Steel",
+					"Gold Coated Glass"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"data": [
+					"Red Gold",
+					"Fluoropolymer",
+					"Sc-Al Alloy",
+					"Maraging Steel",
+					"Gold Coated Glass"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Exotic Product",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Product",
+				"data": [
+					"Efficiency",
+					"Ti-Nb Supraconductor",
+					"Vanamer",
+					"Grade 5 Titanium Alloy",
+					"Mangalloy",
+					"Manganese Reinforced Glass"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"data": [
+					"Ti-Nb Supraconductor",
+					"Vanamer",
+					"Grade 5 Titanium Alloy",
+					"Mangalloy",
+					"Manganese Reinforced Glass"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Intermediary Part",
+		"data": [
+			{
+				"name": "Productivity",
+				"target": "Intermediary Part",
+				"subject": "Recipe",
+				"data": [
+					"Basic",
+					"Uncommon",
+					"Advanced"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					}
+				]
+			},
+			{
+				"name": "Manufacturer",
+				"target": "Intermediary Part",
+				"subject": "Recipe",
+				"data": [
+					"Basic",
+					"Uncommon",
+					"Advanced"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Complex Part",
+		"data": [
+			{
+				"name": "Manufacturer",
+				"target": "Complex Part",
+				"subject": "Recipe",
+				"data": [
+					"Basic",
+					"Uncommon",
+					"Advanced",
+					"Rare",
+					"Exotic"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Exceptional Part",
+		"data": [
+			{
+				"name": "Manufacturer",
+				"target": "Exceptional Part",
+				"subject": "Recipe",
+				"data": [
+					"Advanced",
+					"Rare",
+					"Exotic"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Functional Part",
+		"data": [
+			{
+				"name": "Manufacturer",
+				"target": "Functional Part",
+				"subject": "Recipe",
+				"data": [
+					"Basic",
+					"Uncommon",
+					"Advanced",
+					"Rare",
+					"Exotic"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Structural Part",
+		"data": [
+			{
+				"name": "Manufacturer",
+				"target": "Structural Part",
+				"subject": "Recipe",
+				"data": [
+					"Basic",
+					"Uncommon",
+					"Advanced",
+					"Rare",
+					"Exotic"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Uncommon Ammo",
+		"data": [
+			{
+				"name": "Productivity",
+				"target": "Uncommon Ammo",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"XS",
+					"S",
+					"M",
+					"L"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Advanced Ammo",
+		"data": [
+			{
+				"name": "Productivity",
+				"target": "Advanced Ammo",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"XS",
+					"S",
+					"M",
+					"L"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Fuel",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Fuel",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Refinery",
+					"Nitron",
+					"Kergon",
+					"Xeron"
+				],
+				"targets": [
+					{
+						"type": "Speed",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.02,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.03,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Fuel",
+				"subject": "Recipe",
+				"data": [
+					"Nitron",
+					"Kergon",
+					"Xeron"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Basic Pure Honeycomb",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Pure Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Aluminium",
+					"Carbon",
+					"Iron",
+					"Silicon"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Pure Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Aluminium",
+					"Carbon",
+					"Iron",
+					"Silicon"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Uncommon Pure Honeycomb",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Pure Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Calcium",
+					"Chromium",
+					"Copper",
+					"Sodium"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Pure Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Calcium",
+					"Chromium",
+					"Copper",
+					"Sodium"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Advanced Pure Honeycomb",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Pure Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Lithium",
+					"Nickel",
+					"Silver",
+					"Sulfur"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Pure Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Lithium",
+					"Nickel",
+					"Silver",
+					"Sulfur"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Rare Pure Honeycomb",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Pure Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Cobalt",
+					"Fluorine",
+					"Gold",
+					"Scandium"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Pure Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Cobalt",
+					"Fluorine",
+					"Gold",
+					"Scandium"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Exotic Pure Honeycomb",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Pure Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Manganese",
+					"Niobium",
+					"Titanium",
+					"Vanadium"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Pure Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Manganese",
+					"Niobium",
+					"Titanium",
+					"Vanadium"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Basic Product Honeycomb",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Product Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Polycarbonate",
+					"Silumin",
+					"Steel"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Product Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Polycarbonate",
+					"Silumin",
+					"Steel"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Uncommon Product Honeycomb",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Product Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Polycalcite",
+					"Duralumin",
+					"Stainless Steel"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Product Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Polycalcite",
+					"Duralumin",
+					"Stainless Steel"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Advanced Product Honeycomb",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Product Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Polysulfide",
+					"Al-Li",
+					"Inconel"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Product Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Polysulfide",
+					"Al-Li",
+					"Inconel"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Rare Product Honeycomb",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Product Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Fluoropolymer",
+					"Sc-Al",
+					"Maraging Steel"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Product Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Fluoropolymer",
+					"Sc-Al",
+					"Maraging Steel"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Exotic Product Honeycomb",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Product Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Vanamer",
+					"Grade 5 Titanium Alloy",
+					"Mangalloy"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Product Honeycomb",
+				"subject": "Recipe",
+				"data": [
+					"Vanamer",
+					"Grade 5 Titanium Alloy",
+					"Mangalloy"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					},
+					{
+						"type": "Output",
+						"amount": 0.05,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Industry",
+		"data": [
+			{
+				"name": "Assembly Line XS",
+				"target": "Assembly Line XS",
+				"subject": "Industry",
+				"data": [
+					"Efficiency",
+					"Handling"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Assembly Line S",
+				"target": "Assembly Line S",
+				"subject": "Industry",
+				"data": [
+					"Efficiency",
+					"Handling"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Assembly Line M",
+				"target": "Assembly Line M",
+				"subject": "Industry",
+				"data": [
+					"Efficiency",
+					"Handling"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Assembly Line L",
+				"target": "Assembly Line L",
+				"subject": "Industry",
+				"data": [
+					"Efficiency",
+					"Handling"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Assembly Line XL",
+				"target": "Assembly Line XL",
+				"subject": "Industry",
+				"data": [
+					"Efficiency",
+					"Handling"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Chemical",
+				"target": "Chemical Industry M",
+				"subject": "Industry",
+				"data": [
+					"Efficiency",
+					"Handling"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "3D Printer",
+				"target": "3D Printer M",
+				"subject": "Industry",
+				"data": [
+					"Efficiency",
+					"Handling"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Glass Furnace",
+				"target": "Glass Furnace M",
+				"subject": "Industry",
+				"data": [
+					"Efficiency",
+					"Handling"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Metalworks",
+				"target": "Metalworks M",
+				"subject": "Industry",
+				"data": [
+					"Efficiency",
+					"Handling"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					}
+				]
+			},
+			{
+				"name": "Electronics",
+				"target": "Electronics Industry M",
+				"subject": "Industry",
+				"data": [
+					"Efficiency",
+					"Handling"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					},
+					{
+						"type": "Time",
+						"amount": 0.02,
+						"relative": true
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Combat Element Efficiency",
+		"target": "Combat",
+		"subject": "Recipe",
+		"data": [
+			"Basic",
+			"Uncommon",
+			"Advanced",
+			"Rare",
+			"Exotic"
+		],
+		"targets": [
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			}
+		]
+	},
+	{
+		"name": "Furniture & Appliance Efficiency",
+		"target": "Furniture/Appliance",
+		"subject": "Recipe",
+		"data": [
+			"Basic",
+			"Uncommon",
+			"Advanced",
+			"Rare",
+			"Exotic"
+		],
+		"targets": [
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			}
+		]
+	},
+	{
+		"name": "Industry & Infrastructure Efficiency",
+		"target": "InIn",
+		"subject": "Recipe",
+		"data": [
+			"Basic",
+			"Uncommon",
+			"Advanced",
+			"Rare",
+			"Exotic"
+		],
+		"targets": [
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			}
+		]
+	},
+	{
+		"name": "Piloting Element Efficiency",
+		"target": "Piloting",
+		"subject": "Recipe",
+		"data": [
+			"Basic",
+			"Uncommon",
+			"Advanced",
+			"Rare",
+			"Exotic"
+		],
+		"targets": [
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			}
+		]
+	},
+	{
+		"name": "Systems Element Efficiency",
+		"target": "Systems",
+		"subject": "Recipe",
+		"data": [
+			"Basic",
+			"Uncommon",
+			"Advanced",
+			"Rare",
+			"Exotic"
+		],
+		"targets": [
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			},
+			{
+				"type": "Time",
+				"amount": 0.02,
+				"relative": true
+			}
+		]
+	},
+	{
+		"name": "Basic Scrap",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Scrap",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Refinery",
+					"Aluminium",
+					"Carbon",
+					"Iron",
+					"Silicon"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Scrap",
+				"subject": "Recipe",
+				"data": [
+					"Aluminium",
+					"Carbon",
+					"Iron",
+					"Silicon"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Uncommon Scrap",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Scrap",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Refinery",
+					"Calcium",
+					"Chromium",
+					"Copper",
+					"Sodium"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Scrap",
+				"subject": "Recipe",
+				"data": [
+					"Calcium",
+					"Chromium",
+					"Copper",
+					"Sodium"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Advanced Scrap",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Scrap",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Refinery",
+					"Lithium",
+					"Nickel",
+					"Silver",
+					"Sulfur"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Scrap",
+				"subject": "Recipe",
+				"data": [
+					"Lithium",
+					"Nickel",
+					"Silver",
+					"Sulfur"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					}
+				]
+			}
+		]
+	},
+	{
+		"name": "Rare Scrap",
+		"data": [
+			{
+				"name": "Refining",
+				"target": "Scrap",
+				"subject": "Recipe",
+				"data": [
+					"Efficiency",
+					"Refinery",
+					"Cobalt",
+					"Fluorine",
+					"Gold",
+					"Scandium"
+				],
+				"targets": [
+					{
+						"type": "Time",
+						"amount": 0.1,
+						"relative": true
+					},
+					{
+						"type": "Input",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					},
+					{
+						"type": "Input",
+						"amount": 2,
+						"relative": false
+					}
+				]
+			},
+			{
+				"name": "Productivity",
+				"target": "Scrap",
+				"subject": "Recipe",
+				"data": [
+					"Cobalt",
+					"Fluorine",
+					"Gold",
+					"Scandium"
+				],
+				"targets": [
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					},
+					{
+						"type": "Output",
+						"amount": 1,
+						"relative": false
+					}
+				]
+			}
+		]
+	}
 ]


### PR DESCRIPTION
- Items and recipes updated to DU 0.25.12
- Using categories as in game (e.g. main categories are Consumables/Elements/Materials/Parts instead of Consumables/Parts)
- Items order as in game (the only exception is sorting by rarity, e.g. Exotic goes after Rare)
- Renamed items so names are consistent with game: e.g. Pure Iron instead of Iron Pure
- Reformatted json files for easier future modifications

To be updated later:
- Skills
- Required industries to craft item (tier of industry unit is not specified)

Change is temporary available at https://craft.astron.one/